### PR TITLE
feat: replace JSON config output with human-readable format

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,24 @@ List repositories
 
 ```sh
 $ scriv list
+~/dev/github.com/joakimen/scriv
+~/dev/github.com/joakimen/fzf.clj
+...
+```
+
+List repositories with absolute paths
+
+```sh
+$ scriv list --absolute-paths
 /Users/joakim/dev/github.com/joakimen/scriv
 /Users/joakim/dev/github.com/joakimen/fzf.clj
 ...
+```
+
+Interactively select a repository with fuzzy filtering
+
+```sh
+$ scriv list --fuzzy
 ```
 
 Print resolved configuration
@@ -38,26 +53,25 @@ Print resolved configuration
 ```sh
 $ scriv config
 {
-  "Paths": [
+  "paths": [
     {
-      "Path": "~/dev/github.com",
-      "Depth": 2
+      "path": "~/dev/github.com",
+      "depth": 2
     },
     {
-      "Path": "~/bin",
-      "Depth": 0
+      "path": "~/bin",
+      "depth": 0
     }
   ],
-  "Settings": {
-    "Ignore": [
+  "settings": {
+    "ignore": [
       "node_modules",
       "vendor",
       "dist",
       "build",
       "target"
     ]
-  },
-  "Logger": {}
+  }
 }
 ```
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/joakimen/scriv/internal/config"
 	"github.com/joakimen/scriv/internal/logger"
@@ -25,12 +25,12 @@ var configCmd = &cobra.Command{
 		}
 		log.Info("printing current configuration", "configFile", cfgPath, "verbose", verbose)
 
-		out, err := json.MarshalIndent(cfg, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshalling configuration to json: %w", err)
+		fmt.Println("paths:")
+		for _, p := range cfg.Paths {
+			fmt.Printf("  - %s (depth: %d)\n", p.Path, p.Depth)
 		}
-
-		fmt.Println(string(out))
+		fmt.Println()
+		fmt.Printf("ignore: %s\n", strings.Join(cfg.Settings.Ignore, ", "))
 		return nil
 	},
 }


### PR DESCRIPTION
## Summary
- Replace raw JSON output from `scriv config` with a human-readable format
- Paths are listed with their depth, ignore patterns shown as a comma-separated list