### PR TITLE
feat: add ls alias for list command

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -23,8 +23,9 @@ func newListCmd() *cobra.Command {
 	var fuzzy bool
 
 	listCmd := &cobra.Command{
-		Use:   "list",
-		Short: "List all repositories discovered using the paths in the user configuration",
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List all repositories discovered using the paths in the user configuration",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.GetConfig(cmd.Context())
 			if err != nil {


### PR DESCRIPTION
## Summary
- Adds `ls` as an alias for the `list` subcommand, so `scriv ls` works identically to `scriv list`.