### PR TITLE
Group repositories by label; refine picker rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,6 +904,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1684,6 +1686,7 @@ dependencies = [
  "clap_complete",
  "dirs",
  "ignore",
+ "indexmap",
  "serde",
  "serde_json",
  "skim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,13 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4.6.7"
 dirs = "6"
 ignore = "0.4.31"
+indexmap = { version = "2.14.0", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Library use only — skip the `cli`, `image`, and `listen` features and the
 # heavy deps (image stack, IPC server, duplicate clap) they pull in.
 skim = { version = "5", default-features = false }
-toml = "1.1.3"
+toml = { version = "1.1.3", features = ["preserve_order"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ external tools are required.
 ## Commands
 
 - `scriv repo ls [-A]` — list discovered repositories (`-A` for absolute paths)
-- `scriv repo pick` — fuzzy-select a repository, print its absolute path
+- `scriv repo pick` — fuzzy-select a repository (tagged by group), print its
+  absolute path
 - `scriv file ls [--status] [--missing|--exists]` — list known files
 - `scriv file pick` — fuzzy-select a known file, print its absolute path
 - `scriv file add [path]` — add a file; omit the path to pick one from the
@@ -86,19 +87,27 @@ Configuration lives under `$XDG_CONFIG_HOME/scriv` (default
 - `files` — the known-files list, one path per line, managed by
   `scriv file add`/`remove`
 
+Run `scriv config init` to write a starter `config.toml`.
+
 ### `config.toml`
 
 ```toml
 # Directory names to skip while searching.
 ignore = ["node_modules", "target"]
 
-[[paths]]
+# Search paths are grouped by a label. repo pick shows which group a repo
+# belongs to (once more than one group is configured).
+[[paths.personal]]
 path = "~/dev/github.com"
 depth = 2
 
-[[paths]]
+[[paths.personal]]
 path = "~/bin"
 depth = 0
+
+[[paths.work]]
+path = "~/work/acme"
+depth = 2
 
 [picker]
 height = "50%"                           # built-in finder height
@@ -106,12 +115,21 @@ height = "50%"                           # built-in finder height
 
 ### Configuration keys
 
-#### `paths[].path`
+#### `paths.<group>`
+
+A named group of search paths. The group label is shown alongside each repo in
+`repo pick`, so you can tell at a glance which context a repo belongs to (e.g.
+`personal` vs a client name). Groups appear in the order written.
+
+A flat `[[paths]]` list (no group) is also accepted and lands in a `default`
+group.
+
+#### `paths.<group>[].path`
 
 Required. The root path under which to search for repos. The root path may
 itself be a repo.
 
-#### `paths[].depth`
+#### `paths.<group>[].depth`
 
 Optional (default `0`). The search depth for the associated path. Tune this to
 your project layout — it is the primary factor in discovery performance.

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -7,21 +7,26 @@ use anyhow::{Context, Result, bail};
 
 use crate::Ctx;
 
-/// A commented starter config covering the common layout: a couple of search
-/// roots and the default picker. Users edit it to taste.
+/// A commented starter config covering the common layout: search roots grouped
+/// by label and the default picker. Users edit it to taste.
 const TEMPLATE: &str = r#"# scriv configuration.
 # Repositories are discovered by searching each path below, up to its depth.
-
 # Directory names to skip while searching.
 ignore = ["node_modules", "target"]
 
-[[paths]]
+# Search paths are grouped by a label; `repo pick` shows which group a repo
+# belongs to. Add more groups (e.g. per client) as needed.
+[[paths.personal]]
 path = "~/dev/github.com"
 depth = 2
 
-[[paths]]
+[[paths.personal]]
 path = "~/bin"
 depth = 0
+
+# [[paths.work]]
+# path = "~/work/acme"
+# depth = 2
 
 # Built-in fuzzy picker. height is the finder height (e.g. "50%" or "20").
 [picker]
@@ -75,8 +80,11 @@ pub fn print(ctx: &Ctx) -> Result<()> {
     ));
 
     println!("paths:");
-    for entry in &ctx.config.paths {
-        println!("  - {} (depth: {})", entry.path, entry.depth);
+    for (group, entries) in &ctx.config.paths {
+        println!("  {group}:");
+        for entry in entries {
+            println!("    - {} (depth: {})", entry.path, entry.depth);
+        }
     }
     println!();
     println!("ignore: {}", ctx.config.ignore.join(", "));

--- a/src/cmd/file.rs
+++ b/src/cmd/file.rs
@@ -5,7 +5,8 @@ use std::path::Path;
 use anyhow::{Context, Result, bail};
 use ignore::WalkBuilder;
 
-use crate::path::{expand_tilde, sanitize_file_path};
+use crate::path::{display_path, expand_tilde, sanitize_file_path};
+use crate::pick::PickItem;
 use crate::{Ctx, files, pick};
 
 /// `scriv file ls` — print known files, optionally with existence status.
@@ -112,7 +113,17 @@ fn remove_interactive(ctx: &Ctx) -> Result<()> {
         return Ok(());
     }
 
-    let selected = match pick::pick_many(&lines, "Select files to remove", &ctx.config.picker) {
+    // Show a `~`-collapsed label; the returned value is the stored line so it
+    // matches the list for removal.
+    let items: Vec<PickItem> = lines
+        .iter()
+        .map(|line| {
+            let shown = display_path(&expand_tilde(line, ctx.home_str()), ctx.home_str(), false);
+            PickItem::new(shown, line.clone())
+        })
+        .collect();
+
+    let selected = match pick::pick_many(items, "Select files to remove", &ctx.config.picker) {
         Ok(selected) => selected,
         Err(e) if e.is::<pick::Cancelled>() => return Ok(()),
         Err(e) => return Err(e),
@@ -131,17 +142,25 @@ fn remove_interactive(ctx: &Ctx) -> Result<()> {
 }
 
 /// `scriv file pick` — fuzzy-select a known file and print its absolute path.
+///
+/// The picker shows `~`-collapsed paths; the printed path is absolute.
 pub fn pick(ctx: &Ctx) -> Result<()> {
     ctx.ensure_files_migrated()?;
-    let files: Vec<String> = files::read_lines(&ctx.files_path)?
-        .iter()
-        .map(|line| expand_tilde(line, ctx.home_str()))
-        .collect();
-    if files.is_empty() {
+    let lines = files::read_lines(&ctx.files_path)?;
+    if lines.is_empty() {
         bail!("no known files");
     }
 
-    let choice = pick::pick_one(&files, "Pick a file", &ctx.config.picker)?;
+    let items: Vec<PickItem> = lines
+        .iter()
+        .map(|line| {
+            let abs = expand_tilde(line, ctx.home_str());
+            let shown = display_path(&abs, ctx.home_str(), false);
+            PickItem::new(shown, abs)
+        })
+        .collect();
+
+    let choice = pick::pick_one(items, "Pick a file", &ctx.config.picker)?;
     println!("{choice}");
     Ok(())
 }
@@ -154,7 +173,8 @@ fn pick_from_cwd(ctx: &Ctx) -> Result<Option<String>> {
     if candidates.is_empty() {
         bail!("no files found in the current directory");
     }
-    match pick::pick_one(&candidates, "Add a file", &ctx.config.picker) {
+    let items = candidates.into_iter().map(PickItem::plain).collect();
+    match pick::pick_one(items, "Add a file", &ctx.config.picker) {
         Ok(choice) => Ok(Some(choice)),
         Err(e) if e.is::<pick::Cancelled>() => Ok(None),
         Err(e) => Err(e),

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -3,10 +3,12 @@
 use anyhow::{Context, Result};
 
 use crate::path::display_path;
+use crate::pick::PickItem;
+use crate::repo::FoundRepo;
 use crate::{Ctx, pick, repo};
 
-/// Discover repositories, sorted, home-collapsed unless `absolute`.
-fn discover(ctx: &Ctx) -> Result<Vec<String>> {
+/// Discover repositories, group-tagged and sorted by path.
+fn discover(ctx: &Ctx) -> Result<Vec<FoundRepo>> {
     if ctx.config.paths.is_empty() {
         anyhow::bail!(
             "no repository paths configured in {}",
@@ -20,35 +22,57 @@ fn discover(ctx: &Ctx) -> Result<Vec<String>> {
 
     let mut repos = repo::find_all_repos(&ctx.config, ctx.home(), &ctx.log)
         .with_context(|| format!("using configuration {}", ctx.config_path.display()))?;
-    repos.sort_by(|a, b| a.as_os_str().cmp(b.as_os_str()));
+    repos.sort_by(|a, b| a.path.as_os_str().cmp(b.path.as_os_str()));
 
     if repos.is_empty() {
         anyhow::bail!("no repositories found");
     }
-    Ok(repos
-        .iter()
-        .map(|r| r.to_string_lossy().into_owned())
-        .collect())
+    Ok(repos)
 }
 
-/// `scriv repo ls` — print every discovered repository, one per line.
+/// `scriv repo ls` — print every discovered repository, one per line,
+/// home-collapsed unless `absolute`.
 pub fn ls(ctx: &Ctx, absolute: bool) -> Result<()> {
     let repos = discover(ctx)?;
     ctx.log
         .info(&format!("returning {} repositories", repos.len()));
     for repo in &repos {
-        println!("{}", display_path(repo, ctx.home_str(), absolute));
+        let path = repo.path.to_string_lossy();
+        println!("{}", display_path(&path, ctx.home_str(), absolute));
     }
     Ok(())
 }
 
 /// `scriv repo pick` — fuzzy-select one repository and print its absolute path.
 ///
-/// The printed path is always absolute so a shell shim can `cd` to it without
-/// re-expanding `~`.
+/// The picker shows `~`-collapsed paths, and — when more than one group is
+/// configured — an aligned group tag so the repo's group is clear. The printed
+/// path is always absolute so a shell shim can `cd` to it directly.
 pub fn pick(ctx: &Ctx) -> Result<()> {
     let repos = discover(ctx)?;
-    let choice = pick::pick_one(&repos, "Pick a repository", &ctx.config.picker)?;
+
+    let show_groups = ctx.config.paths.len() > 1;
+    let width = if show_groups {
+        repos.iter().map(|r| r.group.len()).max().unwrap_or(0)
+    } else {
+        0
+    };
+
+    let items: Vec<PickItem> = repos
+        .iter()
+        .map(|repo| {
+            let abs = repo.path.to_string_lossy().into_owned();
+            let shown = display_path(&abs, ctx.home_str(), false);
+            let label = if show_groups {
+                format!("{group:<width$}  {shown}", group = repo.group)
+            } else {
+                shown
+            };
+            PickItem::new(label, abs)
+        })
+        .collect();
+
+    let choice = pick::pick_one(items, "Pick a repository", &ctx.config.picker)?;
     println!("{choice}");
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@
 //!   clobber hand-written settings or comments.
 
 use anyhow::{Context, Result};
+use indexmap::IndexMap;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
@@ -23,10 +24,17 @@ pub const CONFIG_ENV_VAR: &str = "SCRIV_CONFIG";
 pub const XDG_ENV_VAR: &str = "XDG_CONFIG_HOME";
 
 const DEFAULT_IGNORED_DIRS: &[&str] = &["node_modules", "vendor", "dist", "build", "target"];
+/// Group name assigned to paths from an ungrouped (flat or legacy) config.
+pub const DEFAULT_GROUP: &str = "default";
+
+/// Search paths keyed by group name. Insertion order is preserved so groups
+/// display in the order the user wrote them.
+pub type Groups = IndexMap<String, Vec<PathEntry>>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Config {
-    pub paths: Vec<PathEntry>,
+    /// Search paths, keyed by the group label repos under them belong to.
+    pub paths: Groups,
     pub ignore: Vec<String>,
     pub picker: PickerConfig,
 }
@@ -36,7 +44,7 @@ impl Config {
     /// nothing to search, but the known-files commands remain fully usable.
     pub fn empty() -> Self {
         Self {
-            paths: Vec::new(),
+            paths: Groups::new(),
             ignore: default_ignored_dirs(),
             picker: PickerConfig::default(),
         }
@@ -73,13 +81,38 @@ impl Default for PickerConfig {
 #[derive(Deserialize)]
 struct RawToml {
     #[serde(default)]
-    paths: Vec<PathEntry>,
+    paths: RawPaths,
     ignore: Option<Vec<String>>,
     #[serde(default)]
     picker: PickerConfig,
 }
 
-/// The serialized shape of the legacy `config.json`.
+/// `paths` accepts two shapes. The grouped form keys entries by a group label
+/// (`[[paths.work]]`); the flat form is a bare list (`[[paths]]`) whose entries
+/// land in the [`DEFAULT_GROUP`]. Untagged, so serde picks by structure.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawPaths {
+    Grouped(Groups),
+    Flat(Vec<PathEntry>),
+}
+
+impl Default for RawPaths {
+    fn default() -> Self {
+        RawPaths::Grouped(Groups::new())
+    }
+}
+
+impl RawPaths {
+    fn into_groups(self) -> Groups {
+        match self {
+            RawPaths::Grouped(groups) => groups,
+            RawPaths::Flat(entries) => flat_to_groups(entries),
+        }
+    }
+}
+
+/// The serialized shape of the legacy `config.json` (always a flat list).
 ///
 /// `ignore` has been written both at the top level and nested under `settings`;
 /// both are accepted, with the top-level key winning when both are present.
@@ -97,11 +130,20 @@ struct JsonSettings {
     ignore: Option<Vec<String>>,
 }
 
+/// Wrap a flat entry list in the default group, or nothing when empty.
+fn flat_to_groups(entries: Vec<PathEntry>) -> Groups {
+    let mut groups = Groups::new();
+    if !entries.is_empty() {
+        groups.insert(DEFAULT_GROUP.to_string(), entries);
+    }
+    groups
+}
+
 /// Parse `config.toml` contents.
 fn parse_toml(data: &str) -> Result<Config> {
     let raw: RawToml = toml::from_str(data).context("parsing configuration file")?;
     Ok(Config {
-        paths: raw.paths,
+        paths: raw.paths.into_groups(),
         ignore: raw.ignore.unwrap_or_else(default_ignored_dirs),
         picker: raw.picker,
     })
@@ -117,7 +159,7 @@ fn parse_json(data: &str) -> Result<Config> {
         .or_else(|| raw.settings.and_then(|s| s.ignore))
         .unwrap_or_else(default_ignored_dirs);
     Ok(Config {
-        paths: raw.paths,
+        paths: flat_to_groups(raw.paths),
         ignore,
         picker: PickerConfig::default(),
     })
@@ -216,8 +258,15 @@ mod tests {
         false
     }
 
+    fn entry(path: &str, depth: usize) -> PathEntry {
+        PathEntry {
+            path: path.into(),
+            depth,
+        }
+    }
+
     #[test]
-    fn parses_valid_toml() {
+    fn parses_flat_toml_into_default_group() {
         let cfg = parse_toml(
             r#"
 ignore = ["foo", "bar"]
@@ -228,14 +277,42 @@ depth = 2
 "#,
         )
         .unwrap();
-        assert_eq!(
-            cfg.paths,
-            vec![PathEntry {
-                path: "~/dev".into(),
-                depth: 2
-            }]
-        );
+        assert_eq!(cfg.paths[DEFAULT_GROUP], vec![entry("~/dev", 2)]);
         assert_eq!(cfg.ignore, vec!["foo".to_string(), "bar".to_string()]);
+    }
+
+    #[test]
+    fn parses_grouped_toml_preserving_order() {
+        let cfg = parse_toml(
+            r#"
+[[paths.work]]
+path = "~/work"
+depth = 2
+
+[[paths.personal]]
+path = "~/dev"
+depth = 1
+
+[[paths.personal]]
+path = "~/bin"
+depth = 0
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            cfg.paths.keys().collect::<Vec<_>>(),
+            vec!["work", "personal"] // config order, not alphabetical
+        );
+        assert_eq!(cfg.paths["work"], vec![entry("~/work", 2)]);
+        assert_eq!(
+            cfg.paths["personal"],
+            vec![entry("~/dev", 1), entry("~/bin", 0)]
+        );
+    }
+
+    #[test]
+    fn empty_toml_has_no_groups() {
+        assert!(parse_toml("").unwrap().paths.is_empty());
     }
 
     #[test]
@@ -263,7 +340,7 @@ depth = 2
     fn toml_applies_default_ignore_when_absent() {
         let cfg = parse_toml("[[paths]]\npath = \"~/dev\"\n").unwrap();
         assert_eq!(cfg.ignore, default_ignored_dirs());
-        assert_eq!(cfg.paths[0].depth, 0);
+        assert_eq!(cfg.paths[DEFAULT_GROUP][0].depth, 0);
     }
 
     #[test]
@@ -277,10 +354,10 @@ depth = 2
     }
 
     #[test]
-    fn parses_valid_json() {
+    fn parses_legacy_json_into_default_group() {
         let cfg = parse_json(r#"{ "paths": [{"path": "~/dev", "depth": 2}], "ignore": ["foo"] }"#)
             .unwrap();
-        assert_eq!(cfg.paths[0].depth, 2);
+        assert_eq!(cfg.paths[DEFAULT_GROUP], vec![entry("~/dev", 2)]);
         assert_eq!(cfg.ignore, vec!["foo".to_string()]);
     }
 

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -3,8 +3,10 @@
 //! The fuzzy finder is compiled into the binary — there is no `fzf` subprocess
 //! and no external dependency. Every place that asks the user to choose a path
 //! goes through here, so selection looks and behaves the same everywhere.
-
-use std::io::Cursor;
+//!
+//! Items carry a separate [`PickItem::label`] (shown and fuzzy-matched) and
+//! [`PickItem::value`] (returned on selection), so the picker can show a
+//! `~`-collapsed path or a group tag while still returning an absolute path.
 
 use anyhow::{Result, anyhow};
 use skim::prelude::*;
@@ -24,23 +26,67 @@ impl std::fmt::Display for Cancelled {
 
 impl std::error::Error for Cancelled {}
 
-/// Pick exactly one item. Returns [`Cancelled`] as an error on cancel; the
-/// caller decides whether that is a silent exit or a failure.
-pub fn pick_one(items: &[String], prompt: &str, cfg: &PickerConfig) -> Result<String> {
+/// One choice in the picker: `label` is displayed and matched against, `value`
+/// is returned when it is selected.
+pub struct PickItem {
+    pub label: String,
+    pub value: String,
+}
+
+impl PickItem {
+    /// An item whose displayed label is also its returned value.
+    pub fn plain(text: impl Into<String>) -> Self {
+        let text = text.into();
+        Self {
+            label: text.clone(),
+            value: text,
+        }
+    }
+
+    /// An item with a distinct display label and returned value.
+    pub fn new(label: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            value: value.into(),
+        }
+    }
+}
+
+/// Bridges a [`PickItem`] to skim: `text()` drives display and matching,
+/// `output()` is what a selection yields.
+struct SkItem {
+    label: String,
+    value: String,
+}
+
+impl SkimItem for SkItem {
+    fn text(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.label)
+    }
+
+    fn output(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.value)
+    }
+}
+
+/// Pick exactly one item, returning its value. Returns [`Cancelled`] as an
+/// error on cancel; the caller decides whether that is a silent exit or a
+/// failure.
+pub fn pick_one(items: Vec<PickItem>, prompt: &str, cfg: &PickerConfig) -> Result<String> {
     run(items, prompt, false, cfg)?
         .into_iter()
         .next()
         .ok_or_else(|| Cancelled.into())
 }
 
-/// Pick zero or more items. An empty result means the user selected nothing;
-/// cancelling still yields [`Cancelled`].
-pub fn pick_many(items: &[String], prompt: &str, cfg: &PickerConfig) -> Result<Vec<String>> {
+/// Pick zero or more items, returning their values. An empty result means the
+/// user selected nothing; cancelling still yields [`Cancelled`].
+pub fn pick_many(items: Vec<PickItem>, prompt: &str, cfg: &PickerConfig) -> Result<Vec<String>> {
     run(items, prompt, true, cfg)
 }
 
-/// Drive skim over `items` and return the selected lines.
-fn run(items: &[String], prompt: &str, multi: bool, cfg: &PickerConfig) -> Result<Vec<String>> {
+/// Drive skim over `items` and return the selected values.
+fn run(items: Vec<PickItem>, prompt: &str, multi: bool, cfg: &PickerConfig) -> Result<Vec<String>> {
     let options = SkimOptionsBuilder::default()
         .height(cfg.height.clone())
         .prompt(format!("{prompt}> "))
@@ -49,13 +95,21 @@ fn run(items: &[String], prompt: &str, multi: bool, cfg: &PickerConfig) -> Resul
         .build()
         .map_err(|e| anyhow!("configuring picker: {e}"))?;
 
-    // skim reads items from a channel fed by a background reader over this
-    // buffer; no temp files, no subprocess.
-    let input = items.join("\n");
-    let source = SkimItemReader::default().of_bufread(Cursor::new(input));
+    // Feed all items through a channel, then close it so skim stops waiting.
+    let (tx, rx): (SkimItemSender, SkimItemReceiver) = unbounded();
+    let batch: Vec<Arc<dyn SkimItem>> = items
+        .into_iter()
+        .map(|it| {
+            Arc::new(SkItem {
+                label: it.label,
+                value: it.value,
+            }) as Arc<dyn SkimItem>
+        })
+        .collect();
+    tx.send(batch).map_err(|e| anyhow!("feeding picker: {e}"))?;
+    drop(tx);
 
-    let output =
-        Skim::run_with(options, Some(source)).map_err(|e| anyhow!("running picker: {e}"))?;
+    let output = Skim::run_with(options, Some(rx)).map_err(|e| anyhow!("running picker: {e}"))?;
 
     if output.is_abort {
         return Err(Cancelled.into());

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -6,30 +6,50 @@ use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use std::thread;
 
-use crate::config::Config;
+use crate::config::{Config, PathEntry};
 use crate::logger::Logger;
 use crate::path::expand_home_dir;
 
+/// A discovered repository together with the configuration group it belongs to.
+pub struct FoundRepo {
+    pub group: String,
+    pub path: PathBuf,
+}
+
 /// Discover repositories across every configured path, expanding `~` against
-/// `home`. Each path is searched on its own thread. A missing root path is a
-/// hard error; unreadable subdirectories are logged and skipped.
-pub fn find_all_repos(cfg: &Config, home: &Path, log: &Logger) -> Result<Vec<PathBuf>> {
+/// `home` and tagging each result with its group. Each (group, path) pair is
+/// searched on its own thread. A missing root path is a hard error; unreadable
+/// subdirectories are logged and skipped.
+pub fn find_all_repos(cfg: &Config, home: &Path, log: &Logger) -> Result<Vec<FoundRepo>> {
     if cfg.paths.is_empty() {
         anyhow::bail!("no paths found in config file");
     }
 
-    let results: Vec<Result<Vec<PathBuf>>> = thread::scope(|scope| {
-        let handles: Vec<_> = cfg
-            .paths
+    // One search job per (group, path entry).
+    let jobs: Vec<(&str, &PathEntry)> = cfg
+        .paths
+        .iter()
+        .flat_map(|(group, entries)| entries.iter().map(move |entry| (group.as_str(), entry)))
+        .collect();
+
+    let results: Vec<Result<Vec<FoundRepo>>> = thread::scope(|scope| {
+        let handles: Vec<_> = jobs
             .iter()
-            .map(|entry| {
-                scope.spawn(|| {
+            .map(|&(group, entry)| {
+                scope.spawn(move || {
                     let root = expand_home_dir(&entry.path, home);
                     log.info(&format!(
-                        "path entry {} (depth {})",
+                        "group {group}: path {} (depth {})",
                         entry.path, entry.depth
                     ));
-                    find_repos(&root, entry.depth, &cfg.ignore, log)
+                    let repos = find_repos(&root, entry.depth, &cfg.ignore, log)?;
+                    Ok(repos
+                        .into_iter()
+                        .map(|path| FoundRepo {
+                            group: group.to_string(),
+                            path,
+                        })
+                        .collect())
                 })
             })
             .collect();


### PR DESCRIPTION
Builds on the unified CLI (#12).

## Repo groups

`config.paths` becomes a map of group label → search paths (TOML array-of-tables):

```toml
[[paths.personal]]
path = "~/dev/github.com"
depth = 2

[[paths.work]]
path = "~/work/acme"
depth = 2
```

`scriv repo pick` tags each repository with its group — an aligned prefix, shown only when more than one group is configured — so it's clear which context a repo belongs to. Groups display in config-file order (`toml` `preserve_order` + an `IndexMap`), and the group name is fuzzy-searchable.

**Backward compatible:** a flat `[[paths]]` list and the legacy `config.json` are read into a `default` group.

## Picker rendering

The picker now shows `~`-collapsed paths while still returning an **absolute** path, via a custom skim item whose displayed label differs from its output value. Applies to both `repo pick` and `file pick`.

## Tests

63 unit tests (incl. grouped/flat/legacy config parsing and group-order preservation). `cargo fmt --check`, `clippy -D warnings`, `test`, release build all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)