### PR TITLE
Picker: relative paths, per-group colours, and UX polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,6 +1687,7 @@ dependencies = [
  "dirs",
  "ignore",
  "indexmap",
+ "ratatui",
  "serde",
  "serde_json",
  "skim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ clap_complete = "4.6.7"
 dirs = "6"
 ignore = "0.4.31"
 indexmap = { version = "2.14.0", features = ["serde"] }
+# Pinned to skim's ratatui so the `SkimItem::display` types match; core
+# text/style modules only.
+ratatui = { version = "0.30", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Library use only — skip the `cli`, `image`, and `listen` features and the

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ depth = 2
 
 [picker]
 height = "50%"                           # built-in finder height
+display = "relative"                      # repo path rendering: relative | tilde | full
 ```
 
 ### Configuration keys
@@ -149,3 +150,17 @@ Default: `node_modules`, `vendor`, `dist`, `build`, `target`.
 
 Optional (default `"50%"`). Height of the built-in fuzzy finder, e.g. `"50%"`
 or `"20"`. The finder is compiled in (skim); there is no `fzf` dependency.
+
+#### `picker.display`
+
+Optional (default `"relative"`). How `repo pick` renders each repository:
+
+- `relative` — path relative to the search root it was found under, so the
+  shared base (named by the group) is not repeated on every row:
+  `personal  joakimen/scriv`.
+- `tilde` — absolute path with the home directory collapsed to `~`:
+  `personal  ~/dev/github.com/joakimen/scriv`.
+- `full` — the full absolute path.
+
+The selected path is always absolute regardless of this setting; only the
+display changes. `repo ls` is unaffected.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ external tools are required.
 ## Commands
 
 - `scriv repo ls [-A]` — list discovered repositories (`-A` for absolute paths)
-- `scriv repo pick` — fuzzy-select a repository (tagged by group), print its
-  absolute path
+- `scriv repo pick` — fuzzy-select a repository (colour-tagged by group), print
+  its absolute path
 - `scriv file ls [--status] [--missing|--exists]` — list known files
 - `scriv file pick` — fuzzy-select a known file, print its absolute path
 - `scriv file add [path]` — add a file; omit the path to pick one from the
@@ -30,7 +30,9 @@ external tools are required.
 - `scriv config init` — write a starter configuration file
 - `scriv config print` — print the resolved configuration
 - `scriv config path` — print the configuration file path
-- `scriv init fish` — print shell integration to `source`
+- `scriv init <shell>` — print shell integration to `source` (`fish` adds
+  pick-and-`cd`/edit helpers and key bindings; `bash`/`zsh`/`powershell`/`elvish`
+  emit completions)
 
 `pick` always prints a single absolute path, so it composes cleanly with shell
 functions:
@@ -77,6 +79,9 @@ end
 This defines `scriv-repo-cd` (pick a repo and `cd` into it) and
 `scriv-file-edit` (pick a known file and open it in `$EDITOR`).
 
+For other shells, `scriv init bash` / `zsh` / `powershell` / `elvish` emit
+completions you can source or install.
+
 ## Configuration
 
 Configuration lives under `$XDG_CONFIG_HOME/scriv` (default
@@ -118,9 +123,10 @@ display = "relative"                      # repo path rendering: relative | tild
 
 #### `paths.<group>`
 
-A named group of search paths. The group label is shown alongside each repo in
-`repo pick`, so you can tell at a glance which context a repo belongs to (e.g.
-`personal` vs a client name). Groups appear in the order written.
+A named group of search paths. The group label is shown — in a colour assigned
+per group — alongside each repo in `repo pick`, so you can tell at a glance
+which context a repo belongs to (e.g. `personal` vs a client name). Groups
+appear in the order written.
 
 A flat `[[paths]]` list (no group) is also accepted and lands in a `default`
 group.

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -28,9 +28,10 @@ depth = 0
 # path = "~/work/acme"
 # depth = 2
 
-# Built-in fuzzy picker. height is the finder height (e.g. "50%" or "20").
+# Built-in fuzzy picker.
 [picker]
-height = "50%"
+height = "50%"        # finder height, e.g. "50%" or "20"
+# display = "relative" # repo path rendering: relative | tilde | full
 "#;
 
 /// `scriv config init` — write `config.toml` into the config directory,

--- a/src/cmd/file.rs
+++ b/src/cmd/file.rs
@@ -148,7 +148,7 @@ pub fn pick(ctx: &Ctx) -> Result<()> {
     ctx.ensure_files_migrated()?;
     let lines = files::read_lines(&ctx.files_path)?;
     if lines.is_empty() {
-        bail!("no known files");
+        bail!("no known files yet — add one with `scriv file add <path>`");
     }
 
     let items: Vec<PickItem> = lines

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -2,7 +2,8 @@
 
 use anyhow::{Context, Result};
 
-use crate::path::display_path;
+use crate::config::RepoDisplay;
+use crate::path::{display_path, relative_label};
 use crate::pick::PickItem;
 use crate::repo::FoundRepo;
 use crate::{Ctx, pick, repo};
@@ -58,11 +59,16 @@ pub fn pick(ctx: &Ctx) -> Result<()> {
         0
     };
 
+    let mode = ctx.config.picker.display;
     let items: Vec<PickItem> = repos
         .iter()
         .map(|repo| {
             let abs = repo.path.to_string_lossy().into_owned();
-            let shown = display_path(&abs, ctx.home_str(), false);
+            let shown = match mode {
+                RepoDisplay::Relative => relative_label(&repo.path, &repo.root),
+                RepoDisplay::Tilde => display_path(&abs, ctx.home_str(), false),
+                RepoDisplay::Full => abs.clone(),
+            };
             let label = if show_groups {
                 format!("{group:<width$}  {shown}", group = repo.group)
             } else {

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -12,7 +12,7 @@ use crate::{Ctx, pick, repo};
 fn discover(ctx: &Ctx) -> Result<Vec<FoundRepo>> {
     if ctx.config.paths.is_empty() {
         anyhow::bail!(
-            "no repository paths configured in {}",
+            "no repository paths configured in {}; run `scriv config init` to create a starter config",
             ctx.config_path.display()
         );
     }
@@ -26,7 +26,10 @@ fn discover(ctx: &Ctx) -> Result<Vec<FoundRepo>> {
     repos.sort_by(|a, b| a.path.as_os_str().cmp(b.path.as_os_str()));
 
     if repos.is_empty() {
-        anyhow::bail!("no repositories found");
+        anyhow::bail!(
+            "no repositories found under the configured paths (check depths in {})",
+            ctx.config_path.display()
+        );
     }
     Ok(repos)
 }
@@ -44,20 +47,28 @@ pub fn ls(ctx: &Ctx, absolute: bool) -> Result<()> {
     Ok(())
 }
 
+/// ANSI 256-colour indices used to tint groups, in assignment order. Standard
+/// hues (cyan, green, yellow, magenta, blue, red) so they read well and follow
+/// the terminal theme; cycles if there are more groups than colours.
+const GROUP_COLORS: &[u8] = &[6, 2, 3, 5, 4, 1];
+
 /// `scriv repo pick` — fuzzy-select one repository and print its absolute path.
 ///
-/// The picker shows `~`-collapsed paths, and — when more than one group is
-/// configured — an aligned group tag so the repo's group is clear. The printed
-/// path is always absolute so a shell shim can `cd` to it directly.
+/// Each row is prefixed with its group name, coloured per group so groups are
+/// easy to tell apart. Paths render per `picker.display`. The printed path is
+/// always absolute so a shell shim can `cd` to it directly.
 pub fn pick(ctx: &Ctx) -> Result<()> {
     let repos = discover(ctx)?;
 
-    let show_groups = ctx.config.paths.len() > 1;
-    let width = if show_groups {
-        repos.iter().map(|r| r.group.len()).max().unwrap_or(0)
-    } else {
-        0
-    };
+    // Assign each configured group a colour, in config order.
+    let colors: std::collections::HashMap<&str, u8> = ctx
+        .config
+        .paths
+        .keys()
+        .enumerate()
+        .map(|(i, group)| (group.as_str(), GROUP_COLORS[i % GROUP_COLORS.len()]))
+        .collect();
+    let width = repos.iter().map(|r| r.group.len()).max().unwrap_or(0);
 
     let mode = ctx.config.picker.display;
     let items: Vec<PickItem> = repos
@@ -69,12 +80,12 @@ pub fn pick(ctx: &Ctx) -> Result<()> {
                 RepoDisplay::Tilde => display_path(&abs, ctx.home_str(), false),
                 RepoDisplay::Full => abs.clone(),
             };
-            let label = if show_groups {
-                format!("{group:<width$}  {shown}", group = repo.group)
-            } else {
-                shown
-            };
-            PickItem::new(label, abs)
+            let label = format!("{group:<width$}  {shown}", group = repo.group);
+            let mut item = PickItem::new(label, abs);
+            if let Some(&color) = colors.get(repo.group.as_str()) {
+                item = item.color(color);
+            }
+            item
         })
         .collect();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,19 +60,35 @@ pub struct PathEntry {
 
 /// Settings for the built-in fuzzy picker (skim).
 ///
-/// The picker is compiled in — there is no external `fzf` dependency — so the
-/// only knob is the finder height, mirroring the user's `--height` fzf option.
+/// The picker is compiled in — there is no external `fzf` dependency.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(default)]
 pub struct PickerConfig {
     /// Finder height, e.g. `"50%"` or `"20"`. Passed through to skim.
     pub height: String,
+    /// How repository paths are rendered in `repo pick`. See [`RepoDisplay`].
+    pub display: RepoDisplay,
+}
+
+/// How `repo pick` renders each repository's path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RepoDisplay {
+    /// Path relative to the search root it was found under, so the shared base
+    /// (named by the group) is not repeated on every row. The default.
+    #[default]
+    Relative,
+    /// Absolute path with the home directory collapsed to `~`.
+    Tilde,
+    /// The full absolute path.
+    Full,
 }
 
 impl Default for PickerConfig {
     fn default() -> Self {
         Self {
             height: "50%".to_string(),
+            display: RepoDisplay::default(),
         }
     }
 }
@@ -319,6 +335,20 @@ depth = 0
     fn parses_picker_height() {
         let cfg = parse_toml("[picker]\nheight = \"30%\"\n").unwrap();
         assert_eq!(cfg.picker.height, "30%");
+    }
+
+    #[test]
+    fn parses_picker_display_mode() {
+        let cfg = parse_toml("[picker]\ndisplay = \"tilde\"\n").unwrap();
+        assert_eq!(cfg.picker.display, RepoDisplay::Tilde);
+    }
+
+    #[test]
+    fn picker_display_defaults_to_relative() {
+        assert_eq!(
+            parse_toml("").unwrap().picker.display,
+            RepoDisplay::Relative
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,16 +3,25 @@
 //! library crate.
 //!
 //! Top-level commands: `repo` and `file` work with the things scriv tracks;
-//! `config` manages its configuration; `shell` prints shell integration. The
+//! `config` manages its configuration; `init` prints shell integration. The
 //! help layout follows clap's default (description, usage, commands, options).
 
 use std::process::ExitCode;
 
 use clap::builder::styling::{AnsiColor, Effects, Styles};
 use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::Shell;
 
 use scriv::pick::Cancelled;
 use scriv::{Ctx, cmd, shell};
+
+/// Usage examples appended to the top-level help.
+const EXAMPLES: &str = "\x1b[1;92mExamples:\x1b[0m
+  scriv config init            Write a starter configuration
+  scriv repo pick              Fuzzy-pick a repository, print its path
+  cd (scriv repo pick)         Jump to a repository (fish)
+  scriv file add <path>        Track a file you visit often
+  scriv init fish | source     Load shell integration + completions";
 
 /// Help styling matching cargo: bright-green bold headers and usage,
 /// bright-cyan bold literals (command and flag names), cyan placeholders.
@@ -30,6 +39,7 @@ const STYLES: Styles = Styles::styled()
     name = "scriv",
     version,
     about = "Discover Git repositories and track the files you visit often.",
+    after_help = EXAMPLES,
     styles = STYLES,
     disable_help_subcommand = true
 )]
@@ -65,9 +75,12 @@ enum Command {
         command: ConfigCmd,
     },
     /// Print shell integration for `source`-ing
+    ///
+    /// `fish` emits helper functions, key bindings, and completions; other
+    /// shells emit completions only.
     Init {
-        #[command(subcommand)]
-        command: InitCmd,
+        /// Shell to emit integration for
+        shell: Shell,
     },
 }
 
@@ -128,20 +141,12 @@ enum ConfigCmd {
     Path,
 }
 
-#[derive(Subcommand)]
-enum InitCmd {
-    /// Emit fish shell integration
-    Fish,
-}
-
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
     // `init` needs the clap command, not the environment; handle it before Ctx.
-    if let Command::Init { command } = &cli.command {
-        match command {
-            InitCmd::Fish => print!("{}", shell::fish(&mut Cli::command())),
-        }
+    if let Command::Init { shell } = &cli.command {
+        print!("{}", shell::integration(*shell, &mut Cli::command()));
         return ExitCode::SUCCESS;
     }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -32,6 +32,22 @@ pub fn expand_tilde(path: &str, home: &str) -> String {
     format!("{}{}", home, &path[1..])
 }
 
+/// Render a repository path relative to the search `root` it was found under,
+/// so a shared base is not repeated on every row.
+///
+/// When the repository *is* the root (a root that is itself a repo, at depth 0),
+/// the relative part is empty; the basename is used instead so the row is not
+/// blank.
+pub fn relative_label(path: &Path, root: &Path) -> String {
+    match path.strip_prefix(root) {
+        Ok(rest) if !rest.as_os_str().is_empty() => rest.to_string_lossy().into_owned(),
+        _ => path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.to_string_lossy().into_owned()),
+    }
+}
+
 /// Render `path` for display. Paths are returned verbatim when `absolute` is
 /// set; otherwise a `home` prefix is collapsed to `~`.
 ///
@@ -217,6 +233,25 @@ mod tests {
         assert_eq!(
             display_path("/opt/tools/repo", "/home/user", false),
             "/opt/tools/repo"
+        );
+    }
+
+    #[test]
+    fn relative_label_strips_the_root() {
+        assert_eq!(
+            relative_label(
+                Path::new("/Users/kevin/dev/github.com/kkc/scriv"),
+                Path::new("/Users/kevin/dev/github.com")
+            ),
+            "kkc/scriv"
+        );
+    }
+
+    #[test]
+    fn relative_label_falls_back_to_basename_when_repo_is_the_root() {
+        assert_eq!(
+            relative_label(Path::new("/Users/kevin/bin"), Path::new("/Users/kevin/bin")),
+            "bin"
         );
     }
 

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -9,6 +9,8 @@
 //! `~`-collapsed path or a group tag while still returning an absolute path.
 
 use anyhow::{Result, anyhow};
+use ratatui::style::Color;
+use ratatui::text::Line;
 use skim::prelude::*;
 
 use crate::config::PickerConfig;
@@ -27,10 +29,12 @@ impl std::fmt::Display for Cancelled {
 impl std::error::Error for Cancelled {}
 
 /// One choice in the picker: `label` is displayed and matched against, `value`
-/// is returned when it is selected.
+/// is returned when it is selected, and `color` optionally tints the row (an
+/// ANSI 256-colour index, so it respects the terminal theme).
 pub struct PickItem {
     pub label: String,
     pub value: String,
+    pub color: Option<u8>,
 }
 
 impl PickItem {
@@ -40,6 +44,7 @@ impl PickItem {
         Self {
             label: text.clone(),
             value: text,
+            color: None,
         }
     }
 
@@ -48,15 +53,23 @@ impl PickItem {
         Self {
             label: label.into(),
             value: value.into(),
+            color: None,
         }
+    }
+
+    /// Tint the row with an ANSI 256-colour index.
+    pub fn color(mut self, color: u8) -> Self {
+        self.color = Some(color);
+        self
     }
 }
 
 /// Bridges a [`PickItem`] to skim: `text()` drives display and matching,
-/// `output()` is what a selection yields.
+/// `output()` is what a selection yields, and `display()` tints the row.
 struct SkItem {
     label: String,
     value: String,
+    color: Option<u8>,
 }
 
 impl SkimItem for SkItem {
@@ -66,6 +79,15 @@ impl SkimItem for SkItem {
 
     fn output(&self) -> Cow<'_, str> {
         Cow::Borrowed(&self.value)
+    }
+
+    fn display(&self, mut context: DisplayContext) -> Line<'_> {
+        // Tint the whole row in the group's colour; skim still overlays its
+        // match highlighting on top via `to_line`.
+        if let Some(idx) = self.color {
+            context.base_style = context.base_style.fg(Color::Indexed(idx));
+        }
+        context.to_line(self.text())
     }
 }
 
@@ -87,6 +109,15 @@ pub fn pick_many(items: Vec<PickItem>, prompt: &str, cfg: &PickerConfig) -> Resu
 
 /// Drive skim over `items` and return the selected values.
 fn run(items: Vec<PickItem>, prompt: &str, multi: bool, cfg: &PickerConfig) -> Result<Vec<String>> {
+    // skim needs a terminal for its UI. Fail with a clear message rather than
+    // skim's raw "Device not configured" when there is none (e.g. in a pipe
+    // with no controlling tty). Command substitution — `cd (scriv repo pick)` —
+    // still has a tty on stdin/stderr, so it is allowed.
+    use std::io::IsTerminal;
+    if !std::io::stdin().is_terminal() && !std::io::stderr().is_terminal() {
+        anyhow::bail!("interactive selection needs a terminal");
+    }
+
     let options = SkimOptionsBuilder::default()
         .height(cfg.height.clone())
         .prompt(format!("{prompt}> "))
@@ -103,6 +134,7 @@ fn run(items: Vec<PickItem>, prompt: &str, multi: bool, cfg: &PickerConfig) -> R
             Arc::new(SkItem {
                 label: it.label,
                 value: it.value,
+                color: it.color,
             }) as Arc<dyn SkimItem>
         })
         .collect();

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -10,9 +10,11 @@ use crate::config::{Config, PathEntry};
 use crate::logger::Logger;
 use crate::path::expand_home_dir;
 
-/// A discovered repository together with the configuration group it belongs to.
+/// A discovered repository together with its group and the search root it was
+/// found under (used to render the path relative to that root).
 pub struct FoundRepo {
     pub group: String,
+    pub root: PathBuf,
     pub path: PathBuf,
 }
 
@@ -47,6 +49,7 @@ pub fn find_all_repos(cfg: &Config, home: &Path, log: &Logger) -> Result<Vec<Fou
                         .into_iter()
                         .map(|path| FoundRepo {
                             group: group.to_string(),
+                            root: root.clone(),
                             path,
                         })
                         .collect())

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -8,20 +8,21 @@
 use clap::Command;
 use clap_complete::Shell;
 
-/// Render the fish integration: helper functions, a bindings function, and
-/// completions, as one block meant to be `source`d.
-pub fn fish(cmd: &mut Command) -> String {
+/// Render shell integration for `shell`, meant to be `source`d.
+///
+/// For fish this is the helper functions, a key-binding function, and
+/// completions; for every other shell it is completions only (the pick-and-`cd`
+/// helpers are fish-specific).
+pub fn integration(shell: Shell, cmd: &mut Command) -> String {
     let mut out = String::new();
-    out.push_str(FISH_FUNCTIONS);
+
+    if shell == Shell::Fish {
+        out.push_str(FISH_FUNCTIONS);
+        out.push_str("\n# --- completions ---\n");
+    }
 
     let mut completions = Vec::new();
-    clap_complete::generate(
-        Shell::Fish,
-        cmd,
-        cmd.get_name().to_string(),
-        &mut completions,
-    );
-    out.push_str("\n# --- completions ---\n");
+    clap_complete::generate(shell, cmd, cmd.get_name().to_string(), &mut completions);
     out.push_str(&String::from_utf8_lossy(&completions));
 
     out
@@ -74,24 +75,26 @@ mod tests {
     }
 
     #[test]
-    fn emits_helper_functions() {
-        let out = fish(&mut dummy());
+    fn fish_emits_helper_functions() {
+        let out = integration(Shell::Fish, &mut dummy());
         assert!(out.contains("function scriv-repo-cd"));
         assert!(out.contains("function scriv-file-edit"));
         assert!(out.contains("function scriv_key_bindings"));
     }
 
     #[test]
-    fn emits_completions() {
-        let out = fish(&mut dummy());
+    fn fish_emits_completions_and_keys() {
+        let out = integration(Shell::Fish, &mut dummy());
         assert!(out.contains("complete -c scriv"));
-    }
-
-    #[test]
-    fn binds_expected_keys() {
-        let out = fish(&mut dummy());
         assert!(out.contains("bind ctrl-o"));
         assert!(out.contains("bind alt-o"));
         assert!(out.contains("bind f3"));
+    }
+
+    #[test]
+    fn non_fish_emits_completions_only() {
+        let out = integration(Shell::Bash, &mut dummy());
+        assert!(out.contains("scriv")); // bash completion script mentions the command
+        assert!(!out.contains("function scriv-repo-cd"));
     }
 }


### PR DESCRIPTION
Improves `repo pick` rendering and general CLI UX.

## Picker rendering
- **Relative paths** (`picker.display`, default `relative`): repos shown relative to the search root they were found under, so the shared base — named by the group — isn't repeated on every row. `tilde`/`full` restore/expand as alternatives.
- **Per-group colours:** each row is tinted by its group's colour (cyan, green, yellow, magenta, blue, red — cycled in config order, ANSI 256 so it respects the terminal theme), via a custom skim display. The group name is always shown, even with a single group.
- Selected path is always **absolute**; `repo ls` is unchanged.

## UX polish (inspired by cargo/ripgrep/fd)
- **Multi-shell `scriv init <shell>`:** bash/zsh/fish/powershell/elvish. fish keeps the pick-and-`cd`/edit helpers + key bindings; other shells emit completions.
- **Actionable errors:** empty repo config → "run `scriv config init`"; empty known-files → "add one with `scriv file add <path>`"; no tty → "interactive selection needs a terminal" (instead of skim's raw device error).
- **`--help` Examples** section.

## Tests
67 unit tests; fmt, clippy `-D warnings`, test, release build green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)