### PR TITLE
Branch and pull request pickers, with previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,56 +4,91 @@
 
 > "We found him wandering around, with a candle."
 
-## Summary
-
 [Scriv](https://kingkiller.fandom.com/wiki/Scriv) is a CLI for finding your way
-around a machine. Each of the things it does comes with a built-in fuzzy picker:
+around a machine. Four things, each with the same built-in fuzzy picker:
 
-- **repos** — discover your Git repositories and jump into one
-- **files** — track the config and notes files you return to, and open one
-- **branches** — switch between local branches and check out remote ones
-- **pull requests** — pick a GitHub PR and check it out
+| | | Jump to |
+| --- | --- | --- |
+| **repos** | discover your Git repositories and jump into one | [Repositories](#repositories) |
+| **files** | track the config and notes files you return to, and open one | [Files](#files) |
+| **branches** | switch between local branches, check out remote ones | [Branches](#branches) |
+| **pull requests** | pick a GitHub PR and check it out | [Pull requests](#pull-requests) |
+
+Every picker previews the highlighted row, and none of them make you leave the
+finder to decide.
 
 It is self-contained: the fuzzy finder ([skim](https://github.com/skim-rs/skim))
 and the file walker (the [`ignore`](https://docs.rs/ignore) crate that powers
 [fd](https://github.com/sharkdp/fd)) are compiled in. No `fzf`, `fd`, or other
-external tools are required. Branch commands shell out to `git`; the pull
-request commands shell out to [`gh`](https://cli.github.com), reusing whatever
-`gh auth login` already set up — scriv stores no tokens of its own.
+external tools are required. Branch commands drive `git`; pull request commands
+drive [`gh`](https://cli.github.com), reusing whatever `gh auth login` already
+set up — scriv stores no tokens of its own.
+
+## Install
+
+With [mise](https://mise.jdx.dev):
+
+```sh
+mise use -g github:joakimen/scriv
+```
+
+From source:
+
+```sh
+cargo install --path .
+```
+
+## Getting started
+
+```sh
+scriv config init          # write ~/.config/scriv/config.toml
+scriv config print         # tune the search paths, then verify
+scriv repo ls              # verify discovery
+scriv init fish | source   # helpers, key bindings, completions
+```
 
 ## Commands
 
-- `scriv repo ls [-A]` — list discovered repositories (`-A` for absolute paths)
-- `scriv repo pick` — fuzzy-select a repository (colour-tagged by group), print
-  its absolute path
-- `scriv file ls [--status] [--missing|--exists]` — list known files
-- `scriv file pick` — fuzzy-select a known file, print its absolute path
-- `scriv file add [path]` — add a file; omit the path to pick one from the
-  current directory
-- `scriv file remove [path]` — remove a file; omit the path to pick interactively
-- `scriv branch ls [--local|--remote] [--status] [--fetch]` — list branches
-- `scriv branch pick` — fuzzy-select a branch, print its name
-- `scriv branch checkout [branch]` — check out a branch; omit the name to pick
-  one (aliases: `co`, `switch`)
-- `scriv pr ls [--state <state>] [--limit <n>] [--status]` — list pull requests
-- `scriv pr pick` — fuzzy-select a pull request, print its number
-- `scriv pr checkout [number]` — check out a pull request; omit the number to
-  pick one
-- `scriv config init` — write a starter configuration file
-- `scriv config print` — print the resolved configuration
-- `scriv config path` — print the configuration file path
-- `scriv init <shell>` — print shell integration to `source` (`fish` adds
-  pick-and-`cd`/edit helpers and key bindings; `bash`/`zsh`/`powershell`/`elvish`
-  emit completions)
+| Command | Does |
+| --- | --- |
+| `scriv repo ls [-A]` | list discovered repositories (`-A` for absolute paths) |
+| `scriv repo pick` | fuzzy-select a repository, print its absolute path |
+| `scriv file ls [--status] [--missing\|--exists]` | list known files |
+| `scriv file pick` | fuzzy-select a known file, print its absolute path |
+| `scriv file add [path]` | add a file; omit the path to pick one from the current directory |
+| `scriv file remove [path]` | remove a file; omit the path to pick interactively |
+| `scriv branch ls [--local\|--remote] [--status] [--fetch]` | list local and remote branches |
+| `scriv branch pick` | fuzzy-select a branch, print its name |
+| `scriv branch checkout [branch]` | check out a branch; omit the name to pick one |
+| `scriv pr ls [--state <state>] [--limit <n>] [--status]` | list pull requests |
+| `scriv pr pick` | fuzzy-select a pull request, print its number |
+| `scriv pr checkout [number]` | check out a pull request; omit the number to pick one |
+| `scriv config init\|print\|path` | write, show, or locate the configuration |
+| `scriv init <shell>` | print shell integration to `source` |
 
-`pick` always prints a single absolute path, so it composes cleanly with shell
-functions:
+`scriv branch` abbreviates to `scriv br`; `checkout` to `co` (and `switch` for
+branches). `ls` is also spelled `list`.
+
+Every `pick` prints one line and nothing else, so it composes:
 
 ```fish
 cd (scriv repo pick)
+gh pr view (scriv pr pick)
 ```
 
-`scriv branch` may be abbreviated to `scriv br`.
+## Repositories
+
+`scriv repo` searches the paths in your config, groups the results by the label
+you gave each path, and colours each group differently — so a work checkout and
+a personal one are distinguishable at a glance. See
+[`paths.<group>`](#pathsgroup) and [`picker.display`](#pickerdisplay).
+
+## Files
+
+`scriv file` keeps a list of the files you keep coming back to — dotfiles,
+notes, that one YAML — so opening one is two keystrokes rather than a path you
+half-remember. `file ls --status` marks which still exist; `file add` with no
+argument picks from the current directory tree, honouring `.gitignore`.
 
 ## Branches
 
@@ -80,6 +115,11 @@ scriv branch checkout main       # skip the picker
 scriv branch ls --status         # marker, tag, last commit
 ```
 
+Naming a branch on the command line always resolves against every branch, so
+`--local`/`--remote` only narrow what the picker offers. Asking for
+`origin/main` when `main` is already checked out locally switches to the local
+branch rather than detaching HEAD.
+
 `branch ls` prints bare names by default so it pipes cleanly; colour is dropped
 when stdout is not a terminal, and `NO_COLOR` is honoured.
 
@@ -99,27 +139,30 @@ gh pr view (scriv pr pick)       # pick prints the number, so it composes
 `pr checkout` hands off to `gh pr checkout`, which handles PRs from forks and
 sets the upstream.
 
-## Install
+## Previews
 
-With [mise](https://mise.jdx.dev):
+Every picker previews the highlighted row, so you can tell candidates apart
+without leaving the finder:
 
-```sh
-mise use -g github:joakimen/scriv
-```
+| Picker | Preview |
+| ------ | ------- |
+| `repo pick` | current branch, working-tree status, recent commits |
+| `branch pick` / `checkout` | recent commits with **author** and relative date |
+| `pr pick` / `checkout` | title, state, author, source branch, description |
+| `file pick` / `add` / `remove` | file contents (via `bat` when installed, else `head`) |
 
-From source:
+A preview is extra information, never a reason for the list to feel slow, so
+each one is either free or nearly so:
 
-```sh
-cargo install --path .
-```
+- Pull request previews are rendered from the listing scriv already fetched —
+  no per-row network call, and no extra request.
+- The rest run a local command only for the highlighted row, bounded so it stays
+  in the tens of milliseconds (30 commits, 200 lines, a `head`-capped status).
+- Repository and branch previews pass `--no-optional-locks`, so scrolling a list
+  never takes a repository's index lock or competes with your own `git`.
 
-## Getting started
-
-```sh
-scriv config init          # write ~/.config/scriv/config.toml
-scriv config print         # tune the search paths, then verify
-scriv repo ls              # verify discovery
-```
+Turn previews off, or move the pane, with [`picker.preview`](#pickerpreview) and
+[`picker.preview_window`](#pickerpreview_window).
 
 ## Shell integration (fish)
 
@@ -130,14 +173,33 @@ completions. Source it from `config.fish`:
 scriv init fish | source
 
 function fish_user_key_bindings
-    scriv_key_bindings     # ctrl-o / alt-o -> repo cd, f3 -> file edit,
-                           # f4 -> branch checkout, f5 -> PR checkout
+    scriv_key_bindings
 end
 ```
 
-This defines `scriv-repo-cd` (pick a repo and `cd` into it), `scriv-file-edit`
-(pick a known file and open it in `$EDITOR`), `scriv-branch-checkout`, and
-`scriv-pr-checkout`.
+That defines four helpers and binds them:
+
+| Key | Helper | Does |
+| --- | --- | --- |
+| `ctrl-o`, `alt-o` | `scriv-repo-cd` | pick a repository and `cd` into it |
+| `f3` | `scriv-file-edit` | pick a known file, open it in `$EDITOR` |
+| `alt-b`, `alt-g` | `scriv-branch-checkout` | pick a branch and check it out |
+| `alt-p` | `scriv-pr-checkout` | pick a pull request and check it out |
+
+The bindings are `alt-<letter>`, which fish leaves entirely unbound by default,
+and each chord falls under one hand: `alt-b`/`alt-g` left, `alt-o`/`alt-p`
+right. Function keys past `f3` are deliberately left alone — they are the ones
+people bind to their own tools.
+
+To use different keys, bind them *after* `scriv_key_bindings`, since the last
+binding for a key wins:
+
+```fish
+function fish_user_key_bindings
+    scriv_key_bindings
+    bind ctrl-g "scriv-branch-checkout; commandline -f execute"
+end
+```
 
 For other shells, `scriv init bash` / `zsh` / `powershell` / `elvish` emit
 completions you can source or install.
@@ -175,8 +237,10 @@ path = "~/work/acme"
 depth = 2
 
 [picker]
-height = "50%"                           # built-in finder height
-display = "relative"                      # repo path rendering: relative | tilde | full
+height = "50%"                # built-in finder height
+display = "relative"          # repo path rendering: relative | tilde | full
+preview = true                # show a preview pane for the highlighted row
+preview_window = "right:50%"  # preview layout
 ```
 
 ### Configuration keys
@@ -230,3 +294,16 @@ Optional (default `"relative"`). How `repo pick` renders each repository:
 
 The selected path is always absolute regardless of this setting; only the
 display changes. `repo ls` is unaffected.
+
+#### `picker.preview`
+
+Optional (default `true`). Whether the picker shows a preview pane for the
+highlighted row — see [Previews](#previews). Set to `false` to give the list the
+full width.
+
+#### `picker.preview_window`
+
+Optional (default `"right:50%"`). Preview pane layout, in skim's syntax:
+`[up|down|left|right][:SIZE][:hidden][:[no]wrap][:[no]pty]`. For example
+`"down:40%"` on narrow terminals, or `"right:50%:hidden"` to keep the pane
+collapsed until toggled.

--- a/README.md
+++ b/README.md
@@ -7,15 +7,19 @@
 ## Summary
 
 [Scriv](https://kingkiller.fandom.com/wiki/Scriv) is a CLI for finding your way
-around a machine. It does two things, each with a built-in fuzzy picker:
+around a machine. Each of the things it does comes with a built-in fuzzy picker:
 
 - **repos** — discover your Git repositories and jump into one
 - **files** — track the config and notes files you return to, and open one
+- **branches** — switch between local branches and check out remote ones
+- **pull requests** — pick a GitHub PR and check it out
 
 It is self-contained: the fuzzy finder ([skim](https://github.com/skim-rs/skim))
 and the file walker (the [`ignore`](https://docs.rs/ignore) crate that powers
 [fd](https://github.com/sharkdp/fd)) are compiled in. No `fzf`, `fd`, or other
-external tools are required.
+external tools are required. Branch commands shell out to `git`; the pull
+request commands shell out to [`gh`](https://cli.github.com), reusing whatever
+`gh auth login` already set up — scriv stores no tokens of its own.
 
 ## Commands
 
@@ -27,6 +31,14 @@ external tools are required.
 - `scriv file add [path]` — add a file; omit the path to pick one from the
   current directory
 - `scriv file remove [path]` — remove a file; omit the path to pick interactively
+- `scriv branch ls [--local|--remote] [--status] [--fetch]` — list branches
+- `scriv branch pick` — fuzzy-select a branch, print its name
+- `scriv branch checkout [branch]` — check out a branch; omit the name to pick
+  one (aliases: `co`, `switch`)
+- `scriv pr ls [--state <state>] [--limit <n>] [--status]` — list pull requests
+- `scriv pr pick` — fuzzy-select a pull request, print its number
+- `scriv pr checkout [number]` — check out a pull request; omit the number to
+  pick one
 - `scriv config init` — write a starter configuration file
 - `scriv config print` — print the resolved configuration
 - `scriv config path` — print the configuration file path
@@ -40,6 +52,52 @@ functions:
 ```fish
 cd (scriv repo pick)
 ```
+
+`scriv branch` may be abbreviated to `scriv br`.
+
+## Branches
+
+`scriv branch` lists local and remote branches together, most recently
+committed to first, and colours each row by where the branch lives:
+
+| Colour | Meaning | `--status` tag |
+| ------ | ------- | -------------- |
+| green  | exists here **and** on a remote | `both` |
+| yellow | exists **only** here — never pushed, or its upstream is gone | `local` |
+| cyan   | exists **only** on a remote | `remote` |
+
+A remote-only branch is shown with its remote (`origin/feature`), so two remotes
+carrying the same branch stay distinguishable. Checking one out creates the
+matching local branch and sets its upstream — the equivalent of
+`git switch --track origin/feature` — so `git push` and `git pull` work right
+away. The current branch is marked with `*`.
+
+```sh
+scriv branch checkout            # pick from every branch and switch to it
+scriv branch checkout --fetch    # refresh remotes (pruning deleted) first
+scriv branch checkout --remote   # pick only branches that exist on a remote
+scriv branch checkout main       # skip the picker
+scriv branch ls --status         # marker, tag, last commit
+```
+
+`branch ls` prints bare names by default so it pipes cleanly; colour is dropped
+when stdout is not a terminal, and `NO_COLOR` is honoured.
+
+## Pull requests
+
+`scriv pr` uses the [`gh`](https://cli.github.com) CLI, so it works wherever
+`gh` is authenticated — including GitHub Enterprise — and needs no configuration
+in scriv. Rows are coloured by state: green open, grey draft, magenta merged,
+red closed.
+
+```sh
+scriv pr checkout                # pick an open PR and check it out
+scriv pr ls --state all --limit 20
+gh pr view (scriv pr pick)       # pick prints the number, so it composes
+```
+
+`pr checkout` hands off to `gh pr checkout`, which handles PRs from forks and
+sets the upstream.
 
 ## Install
 
@@ -72,12 +130,14 @@ completions. Source it from `config.fish`:
 scriv init fish | source
 
 function fish_user_key_bindings
-    scriv_key_bindings     # ctrl-o / alt-o -> repo cd, f3 -> file edit
+    scriv_key_bindings     # ctrl-o / alt-o -> repo cd, f3 -> file edit,
+                           # f4 -> branch checkout, f5 -> PR checkout
 end
 ```
 
-This defines `scriv-repo-cd` (pick a repo and `cd` into it) and
-`scriv-file-edit` (pick a known file and open it in `$EDITOR`).
+This defines `scriv-repo-cd` (pick a repo and `cd` into it), `scriv-file-edit`
+(pick a known file and open it in `$EDITOR`), `scriv-branch-checkout`, and
+`scriv-pr-checkout`.
 
 For other shells, `scriv init bash` / `zsh` / `powershell` / `elvish` emit
 completions you can source or install.

--- a/src/cmd/branch.rs
+++ b/src/cmd/branch.rs
@@ -8,7 +8,7 @@
 use anyhow::{Result, bail};
 
 use crate::git::{self, Branch, Filter};
-use crate::pick::PickItem;
+use crate::pick::{PickItem, Preview};
 use crate::term;
 use crate::{Ctx, pick};
 
@@ -82,6 +82,24 @@ pub fn ls(ctx: &Ctx, filter: Filter, status: bool, fetch: bool) -> Result<()> {
     Ok(())
 }
 
+/// The preview for a branch: its recent commits, with who wrote them and when.
+///
+/// That is the question a branch list actually raises — whose work is this, and
+/// is it still live — and it is answered by the same `git log` invocation for a
+/// local or a remote ref. The trailing `--` keeps a branch named like a file
+/// from being read as a path.
+///
+/// Bounded to 30 commits and run with `--no-optional-locks`, so scrolling the
+/// list never takes the repository's index lock or reads more history than the
+/// pane can show.
+fn preview(branch: &Branch) -> Preview {
+    Preview::Command(format!(
+        "git --no-optional-locks log --color=always --max-count=30 --date=relative \
+         --format='%C(auto)%h%C(reset)  %C(blue)%an%C(reset)  %C(green)%ad%C(reset)  %s' {} --",
+        pick::quote(&branch.name)
+    ))
+}
+
 /// Build picker rows: current-branch marker, name, last commit date, subject,
 /// each row tinted by [`BranchKind`](crate::git::BranchKind) — yellow
 /// local-only, green local+remote, cyan remote-only.
@@ -98,7 +116,9 @@ fn items(branches: &[Branch]) -> Vec<PickItem> {
                 date = branch.date,
                 subject = branch.subject,
             );
-            PickItem::new(label.trim_end(), branch.name.clone()).color(branch.kind.color())
+            PickItem::new(label.trim_end(), branch.name.clone())
+                .color(branch.kind.color())
+                .preview(preview(branch))
         })
         .collect()
 }
@@ -195,5 +215,21 @@ mod tests {
     fn columns_align() {
         let items = items(&branches());
         assert_eq!(items[0].label.find("init"), items[1].label.find("wip"));
+    }
+
+    #[test]
+    fn preview_logs_the_branch_with_authors() {
+        let Preview::Command(cmd) = preview(&branches()[1]) else {
+            panic!("expected a command preview");
+        };
+        assert!(cmd.contains(" log "), "{cmd}");
+        assert!(
+            cmd.contains("%an"),
+            "author is what the preview is for: {cmd}"
+        );
+        assert!(cmd.ends_with("'origin/feature' --"), "{cmd}");
+        // Browsing a branch list must not take the repository's index lock.
+        assert!(cmd.contains("--no-optional-locks"), "{cmd}");
+        assert!(cmd.contains("--max-count=30"), "unbounded log: {cmd}");
     }
 }

--- a/src/cmd/branch.rs
+++ b/src/cmd/branch.rs
@@ -1,0 +1,199 @@
+//! `scriv branch` — list, pick, and check out git branches.
+//!
+//! Local and remote branches are shown in one list, coloured by where they
+//! live, so switching to a branch you have and checking out one you do not are
+//! the same gesture. Picking a remote-only branch creates the local branch and
+//! sets its upstream, which is the step that otherwise has to be typed by hand.
+
+use anyhow::{Result, bail};
+
+use crate::git::{self, Branch, Filter};
+use crate::pick::PickItem;
+use crate::term;
+use crate::{Ctx, pick};
+
+/// Every branch in the current repository, optionally refreshing remotes first.
+fn load(ctx: &Ctx, fetch: bool) -> Result<Vec<Branch>> {
+    git::ensure_repo()?;
+    if fetch {
+        git::fetch()?;
+    }
+    let branches = git::branches()?;
+    ctx.log.info(&format!("found {} branches", branches.len()));
+    Ok(branches)
+}
+
+/// Apply `filter`, failing with a message that names what was looked for.
+fn narrow(branches: Vec<Branch>, filter: Filter) -> Result<Vec<Branch>> {
+    let branches = git::filtered(branches, filter);
+    if branches.is_empty() {
+        bail!(match filter {
+            Filter::Local => "no local branches found",
+            Filter::Remote => "no remote branches found",
+            Filter::All => "no branches found",
+        });
+    }
+    Ok(branches)
+}
+
+/// Load and filter in one step, for the commands that only ever show a list.
+fn collect(ctx: &Ctx, filter: Filter, fetch: bool) -> Result<Vec<Branch>> {
+    narrow(load(ctx, fetch)?, filter)
+}
+
+/// Width of the widest branch name, for column alignment.
+fn name_width(branches: &[Branch]) -> usize {
+    branches.iter().map(|b| b.name.len()).max().unwrap_or(0)
+}
+
+/// `scriv branch ls` — print branch names, one per line.
+///
+/// Bare names by default so the output pipes cleanly; `--status` adds the
+/// current-branch marker, the local/both/remote tag, and the last commit.
+/// Colour follows the same kind mapping as the picker and is dropped when
+/// stdout is not a terminal.
+pub fn ls(ctx: &Ctx, filter: Filter, status: bool, fetch: bool) -> Result<()> {
+    let branches = collect(ctx, filter, fetch)?;
+    let color = term::stdout_color();
+
+    if !status {
+        for branch in &branches {
+            println!("{}", term::paint(&branch.name, branch.kind.color(), color));
+        }
+        return Ok(());
+    }
+
+    let width = name_width(&branches);
+    let date_width = branches.iter().map(|b| b.date.len()).max().unwrap_or(0);
+    for branch in &branches {
+        let marker = if branch.head { "*" } else { " " };
+        let row = format!(
+            "{marker} {name:<width$}  {tag:<6}  {date:<date_width$}  {subject}",
+            name = branch.name,
+            tag = branch.kind.tag(),
+            date = branch.date,
+            subject = branch.subject,
+        );
+        println!(
+            "{}",
+            term::paint(row.trim_end(), branch.kind.color(), color)
+        );
+    }
+    Ok(())
+}
+
+/// Build picker rows: current-branch marker, name, last commit date, subject,
+/// each row tinted by [`BranchKind`](crate::git::BranchKind) — yellow
+/// local-only, green local+remote, cyan remote-only.
+fn items(branches: &[Branch]) -> Vec<PickItem> {
+    let width = name_width(branches);
+    let date_width = branches.iter().map(|b| b.date.len()).max().unwrap_or(0);
+    branches
+        .iter()
+        .map(|branch| {
+            let marker = if branch.head { "*" } else { " " };
+            let label = format!(
+                "{marker} {name:<width$}  {date:<date_width$}  {subject}",
+                name = branch.name,
+                date = branch.date,
+                subject = branch.subject,
+            );
+            PickItem::new(label.trim_end(), branch.name.clone()).color(branch.kind.color())
+        })
+        .collect()
+}
+
+/// Fuzzy-select one branch and return its name (`main`, or `origin/main` for a
+/// branch that only exists on a remote).
+fn select(ctx: &Ctx, branches: &[Branch], prompt: &str) -> Result<String> {
+    pick::pick_one(items(branches), prompt, &ctx.config.picker)
+}
+
+/// `scriv branch pick` — fuzzy-select a branch and print its name.
+pub fn pick(ctx: &Ctx, filter: Filter, fetch: bool) -> Result<()> {
+    let branches = collect(ctx, filter, fetch)?;
+    let choice = select(ctx, &branches, "Pick a branch")?;
+    println!("{choice}");
+    Ok(())
+}
+
+/// `scriv branch checkout [name]` — switch to a branch, picking one when no
+/// name is given.
+///
+/// A remote-only branch is checked out as a new local branch tracking it, so
+/// `git push`/`git pull` work immediately afterwards. git's own output is left
+/// alone, so the familiar "Switched to branch …" line still appears.
+///
+/// `filter` narrows what the picker offers, but a name given on the command
+/// line always resolves against every branch — `--local` is about choosing, not
+/// about what `origin/feature` is allowed to mean.
+pub fn checkout(ctx: &Ctx, name: Option<&str>, filter: Filter, fetch: bool) -> Result<()> {
+    let branches = load(ctx, fetch)?;
+    let name = match name {
+        Some(name) => name.to_string(),
+        None => {
+            let offered = narrow(branches.clone(), filter)?;
+            select(ctx, &offered, "Check out a branch")?
+        }
+    };
+
+    let action = git::resolve(&branches, &name);
+    ctx.log.info(&format!("checkout action: {action:?}"));
+    git::checkout(&action)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::git::{BranchKind, RefLine, classify};
+
+    fn branches() -> Vec<Branch> {
+        classify(&[
+            RefLine {
+                refname: "refs/heads/main".into(),
+                head: true,
+                upstream: "origin/main".into(),
+                date: "2 hours ago".into(),
+                subject: "init".into(),
+            },
+            RefLine {
+                refname: "refs/remotes/origin/main".into(),
+                head: false,
+                upstream: String::new(),
+                date: "2 hours ago".into(),
+                subject: "init".into(),
+            },
+            RefLine {
+                refname: "refs/remotes/origin/feature".into(),
+                head: false,
+                upstream: String::new(),
+                date: "3 days ago".into(),
+                subject: "wip".into(),
+            },
+        ])
+    }
+
+    #[test]
+    fn rows_mark_head_and_return_the_branch_name() {
+        let items = items(&branches());
+        assert!(items[0].label.starts_with("* main"));
+        assert_eq!(items[0].value, "main");
+        assert!(items[1].label.starts_with("  origin/feature"));
+        assert_eq!(items[1].value, "origin/feature");
+    }
+
+    #[test]
+    fn rows_are_coloured_by_kind() {
+        let items = items(&branches());
+        assert_eq!(items[0].color, Some(BranchKind::Tracked.color()));
+        assert_eq!(items[1].color, Some(BranchKind::Remote.color()));
+    }
+
+    /// Names and dates are padded to a common width so the subject column
+    /// lines up across rows.
+    #[test]
+    fn columns_align() {
+        let items = items(&branches());
+        assert_eq!(items[0].label.find("init"), items[1].label.find("wip"));
+    }
+}

--- a/src/cmd/branch.rs
+++ b/src/cmd/branch.rs
@@ -42,8 +42,25 @@ fn collect(ctx: &Ctx, filter: Filter, fetch: bool) -> Result<Vec<Branch>> {
 }
 
 /// Width of the widest branch name, for column alignment.
+///
+/// Counted in characters, not bytes: `{:<width$}` pads by character count, so a
+/// byte length would over-pad any row containing non-ASCII and leave the
+/// columns ragged.
 fn name_width(branches: &[Branch]) -> usize {
-    branches.iter().map(|b| b.name.len()).max().unwrap_or(0)
+    branches
+        .iter()
+        .map(|b| b.name.chars().count())
+        .max()
+        .unwrap_or(0)
+}
+
+/// Width of the widest relative date, counted in characters as above.
+fn date_width(branches: &[Branch]) -> usize {
+    branches
+        .iter()
+        .map(|b| b.date.chars().count())
+        .max()
+        .unwrap_or(0)
 }
 
 /// `scriv branch ls` — print branch names, one per line.
@@ -64,7 +81,7 @@ pub fn ls(ctx: &Ctx, filter: Filter, status: bool, fetch: bool) -> Result<()> {
     }
 
     let width = name_width(&branches);
-    let date_width = branches.iter().map(|b| b.date.len()).max().unwrap_or(0);
+    let date_width = date_width(&branches);
     for branch in &branches {
         let marker = if branch.head { "*" } else { " " };
         let row = format!(
@@ -105,7 +122,7 @@ fn preview(branch: &Branch) -> Preview {
 /// local-only, green local+remote, cyan remote-only.
 fn items(branches: &[Branch]) -> Vec<PickItem> {
     let width = name_width(branches);
-    let date_width = branches.iter().map(|b| b.date.len()).max().unwrap_or(0);
+    let date_width = date_width(branches);
     branches
         .iter()
         .map(|branch| {
@@ -215,6 +232,25 @@ mod tests {
     fn columns_align() {
         let items = items(&branches());
         assert_eq!(items[0].label.find("init"), items[1].label.find("wip"));
+    }
+
+    /// `{:<width$}` pads by character count, so a width measured in bytes makes
+    /// the column wider than the longest name whenever one is non-ASCII —
+    /// `café` is four characters but five bytes.
+    #[test]
+    fn column_width_counts_characters_not_bytes() {
+        let rows = classify(&[RefLine {
+            refname: "refs/heads/café".into(),
+            head: false,
+            upstream: String::new(),
+            date: "now".into(),
+            subject: "one".into(),
+        }]);
+        let label = &items(&rows)[0].label;
+        assert!(
+            label.starts_with("  café  now"),
+            "column padded past the longest name: {label:?}"
+        );
     }
 
     #[test]

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -32,6 +32,8 @@ depth = 0
 [picker]
 height = "50%"        # finder height, e.g. "50%" or "20"
 # display = "relative" # repo path rendering: relative | tilde | full
+# preview = true       # show a preview pane for the highlighted row
+# preview_window = "right:50%" # preview layout: [up|down|left|right][:SIZE][:hidden]
 "#;
 
 /// `scriv config init` — write `config.toml` into the config directory,

--- a/src/cmd/file.rs
+++ b/src/cmd/file.rs
@@ -6,9 +6,22 @@ use anyhow::{Context, Result, bail};
 use ignore::WalkBuilder;
 
 use crate::path::{display_path, expand_tilde, sanitize_file_path};
-use crate::pick::PickItem;
+use crate::pick::{PickItem, Preview};
 use crate::term;
 use crate::{Ctx, files, pick};
+
+/// The preview for a file: its contents.
+///
+/// `bat` renders them with syntax highlighting when it is installed; `head`
+/// covers everyone else, and its error text is the preview when the path is
+/// gone — which the known-files list expects to happen.
+fn preview(path: &str) -> Preview {
+    let path = pick::quote(path);
+    Preview::Command(format!(
+        "bat --color=always --style=plain --line-range=:200 -- {path} 2>/dev/null \
+         || head -n 200 -- {path}"
+    ))
+}
 
 /// `scriv file ls` — print known files, optionally with existence status.
 pub fn ls(ctx: &Ctx, status: bool, missing: bool, exists: bool) -> Result<()> {
@@ -119,8 +132,9 @@ fn remove_interactive(ctx: &Ctx) -> Result<()> {
     let items: Vec<PickItem> = lines
         .iter()
         .map(|line| {
-            let shown = display_path(&expand_tilde(line, ctx.home_str()), ctx.home_str(), false);
-            PickItem::new(shown, line.clone())
+            let expanded = expand_tilde(line, ctx.home_str());
+            let shown = display_path(&expanded, ctx.home_str(), false);
+            PickItem::new(shown, line.clone()).preview(preview(&expanded))
         })
         .collect();
 
@@ -157,7 +171,7 @@ pub fn pick(ctx: &Ctx) -> Result<()> {
         .map(|line| {
             let abs = expand_tilde(line, ctx.home_str());
             let shown = display_path(&abs, ctx.home_str(), false);
-            PickItem::new(shown, abs)
+            PickItem::new(shown, abs.clone()).preview(preview(&abs))
         })
         .collect();
 
@@ -174,7 +188,13 @@ fn pick_from_cwd(ctx: &Ctx) -> Result<Option<String>> {
     if candidates.is_empty() {
         bail!("no files found in the current directory");
     }
-    let items = candidates.into_iter().map(PickItem::plain).collect();
+    let items = candidates
+        .into_iter()
+        .map(|file| {
+            let preview = preview(&file);
+            PickItem::plain(file).preview(preview)
+        })
+        .collect();
     match pick::pick_one(items, "Add a file", &ctx.config.picker) {
         Ok(choice) => Ok(Some(choice)),
         Err(e) if e.is::<pick::Cancelled>() => Ok(None),

--- a/src/cmd/file.rs
+++ b/src/cmd/file.rs
@@ -7,6 +7,7 @@ use ignore::WalkBuilder;
 
 use crate::path::{display_path, expand_tilde, sanitize_file_path};
 use crate::pick::PickItem;
+use crate::term;
 use crate::{Ctx, files, pick};
 
 /// `scriv file ls` — print known files, optionally with existence status.
@@ -22,7 +23,7 @@ pub fn ls(ctx: &Ctx, status: bool, missing: bool, exists: bool) -> Result<()> {
         return Ok(());
     }
 
-    let use_color = status && stdout_is_tty() && !no_color();
+    let use_color = status && term::stdout_color();
 
     for line in &lines {
         let expanded = expand_tilde(line, ctx.home_str());
@@ -220,17 +221,6 @@ fn list_files(root: &Path) -> Result<Vec<String>> {
     }
     files.sort();
     Ok(files)
-}
-
-fn stdout_is_tty() -> bool {
-    use std::io::IsTerminal;
-    std::io::stdout().is_terminal()
-}
-
-/// Honour the `NO_COLOR` convention: colour is disabled when the variable is
-/// present and non-empty.
-fn no_color() -> bool {
-    std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty())
 }
 
 #[cfg(test)]

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -4,6 +4,8 @@
 //! [`crate::Ctx`] and perform the filesystem and interactive I/O; all decision
 //! logic they rely on lives in the pure core modules.
 
+pub mod branch;
 pub mod config;
 pub mod file;
+pub mod pr;
 pub mod repo;

--- a/src/cmd/pr.rs
+++ b/src/cmd/pr.rs
@@ -16,7 +16,13 @@ fn collect(ctx: &Ctx, state: &str, limit: usize) -> Result<Vec<PullRequest>> {
     let prs = gh::list(state, limit)?;
     ctx.log.info(&format!("found {} pull requests", prs.len()));
     if prs.is_empty() {
-        bail!("no {state} pull requests found for this repository");
+        // `--state all` would otherwise read "no all pull requests found".
+        let scope = if state == "all" {
+            String::new()
+        } else {
+            format!("{state} ")
+        };
+        bail!("no {scope}pull requests found for this repository");
     }
     Ok(prs)
 }

--- a/src/cmd/pr.rs
+++ b/src/cmd/pr.rs
@@ -6,10 +6,10 @@
 
 use anyhow::{Result, bail};
 
+use crate::Ctx;
 use crate::gh::{self, PullRequest};
-use crate::pick::PickItem;
+use crate::pick::{self, PickItem, Preview};
 use crate::term;
-use crate::{Ctx, pick};
 
 /// Fetch pull requests, failing with a useful message when there are none.
 fn collect(ctx: &Ctx, state: &str, limit: usize) -> Result<Vec<PullRequest>> {
@@ -63,6 +63,40 @@ pub fn ls(ctx: &Ctx, state: &str, limit: usize, status: bool) -> Result<()> {
     Ok(())
 }
 
+/// The preview for a pull request: its heading and description, rendered from
+/// data already in memory.
+///
+/// Deliberately *not* `gh pr view`. That would be prettier — it renders
+/// markdown and shows check results — but it is a network round trip (~2s here)
+/// per highlighted row, spawned again on every move through the list. skim runs
+/// preview commands on a background thread and does not kill non-PTY children,
+/// so scrolling would leave a queue of `gh` processes racing to finish. The
+/// description is worth showing; it is not worth making the list feel slow.
+fn preview(pr: &PullRequest) -> Preview {
+    let mut out = term::paint(
+        &format!("#{number}  {title}", number = pr.number, title = pr.title),
+        pr.color(),
+        true,
+    );
+    out.push('\n');
+    out.push_str(&format!(
+        "{tag}  @{author}  [{head}]  updated {updated}\n\n",
+        tag = pr.tag(),
+        author = pr.author_login(),
+        head = pr.head_ref_name,
+        updated = pr.updated_date(),
+    ));
+
+    let body = pr.body.trim();
+    if body.is_empty() {
+        out.push_str("(no description)");
+    } else {
+        // GitHub stores CRLF; the pane renders the stray CRs as artefacts.
+        out.push_str(&body.replace("\r\n", "\n"));
+    }
+    Preview::Text(out)
+}
+
 /// Build picker rows, tinted by state — green ready, grey draft, magenta
 /// merged, red closed. The source branch is part of the label so it is
 /// fuzzy-matchable, not just the title.
@@ -77,7 +111,9 @@ fn items(prs: &[PullRequest]) -> Vec<PickItem> {
                 author = pr.author_login(),
                 head = pr.head_ref_name,
             );
-            PickItem::new(label, pr.number.to_string()).color(pr.color())
+            PickItem::new(label, pr.number.to_string())
+                .color(pr.color())
+                .preview(preview(pr))
         })
         .collect()
 }
@@ -122,10 +158,11 @@ mod tests {
             r#"[
             {"number":7,"title":"Add branch picker","author":{"login":"joakimen"},
              "headRefName":"feat/branches","isDraft":false,"state":"OPEN",
-             "updatedAt":"2026-07-27T09:12:33Z"},
+             "updatedAt":"2026-07-27T09:12:33Z",
+             "body":"Adds a picker.\r\n\r\nSecond paragraph."},
             {"number":123,"title":"WIP","author":{"login":"someone"},
              "headRefName":"wip","isDraft":true,"state":"OPEN",
-             "updatedAt":"2026-07-20T11:00:00Z"}
+             "updatedAt":"2026-07-20T11:00:00Z","body":""}
         ]"#,
         )
         .unwrap()
@@ -151,6 +188,39 @@ mod tests {
     fn drafts_are_tinted_differently() {
         let items = items(&prs());
         assert_ne!(items[0].color, items[1].color);
+    }
+
+    /// The preview must be ready-made text: a command here would mean a `gh`
+    /// network call for every row the user scrolls past.
+    #[test]
+    fn preview_is_rendered_in_memory() {
+        let Preview::Text(text) = preview(&prs()[0]) else {
+            panic!("a PR preview must not spawn a command");
+        };
+        assert!(text.contains("#7"), "{text}");
+        assert!(text.contains("Add branch picker"), "{text}");
+        assert!(text.contains("@joakimen"), "{text}");
+        assert!(text.contains("[feat/branches]"), "{text}");
+        assert!(text.contains("Adds a picker"), "the body is the preview");
+    }
+
+    #[test]
+    fn preview_handles_a_missing_description() {
+        let Preview::Text(text) = preview(&prs()[1]) else {
+            panic!("expected text");
+        };
+        assert!(text.contains("(no description)"), "{text}");
+    }
+
+    /// GitHub stores CRLF; leaving it in litters the pane with stray carriage
+    /// returns.
+    #[test]
+    fn preview_normalises_line_endings() {
+        let text = match preview(&prs()[0]) {
+            Preview::Text(text) => text,
+            Preview::Command(_) => panic!("expected text"),
+        };
+        assert!(!text.contains('\r'), "CRLF leaked into the preview");
     }
 
     /// Numbers are padded to a common width so titles start in one column.

--- a/src/cmd/pr.rs
+++ b/src/cmd/pr.rs
@@ -1,0 +1,165 @@
+//! `scriv pr` — list, pick, and check out GitHub pull requests.
+//!
+//! Everything here goes through the `gh` CLI (see [`crate::gh`]), so scriv
+//! inherits whatever authentication `gh auth login` set up — including SSO and
+//! GitHub Enterprise hosts — and stores no credentials of its own.
+
+use anyhow::{Result, bail};
+
+use crate::gh::{self, PullRequest};
+use crate::pick::PickItem;
+use crate::term;
+use crate::{Ctx, pick};
+
+/// Fetch pull requests, failing with a useful message when there are none.
+fn collect(ctx: &Ctx, state: &str, limit: usize) -> Result<Vec<PullRequest>> {
+    let prs = gh::list(state, limit)?;
+    ctx.log.info(&format!("found {} pull requests", prs.len()));
+    if prs.is_empty() {
+        bail!("no {state} pull requests found for this repository");
+    }
+    Ok(prs)
+}
+
+/// Width of the widest PR number, so the `#123` column aligns.
+fn number_width(prs: &[PullRequest]) -> usize {
+    prs.iter()
+        .map(|pr| pr.number.to_string().len())
+        .max()
+        .unwrap_or(0)
+}
+
+/// `scriv pr ls` — print one pull request per line.
+///
+/// `--status` adds the open/draft/merged/closed tag, the source branch, and the
+/// last-updated date. Rows are coloured by state, and colour is dropped when
+/// stdout is not a terminal.
+pub fn ls(ctx: &Ctx, state: &str, limit: usize, status: bool) -> Result<()> {
+    let prs = collect(ctx, state, limit)?;
+    let color = term::stdout_color();
+    let width = number_width(&prs);
+
+    for pr in &prs {
+        let row = if status {
+            format!(
+                "#{number:<width$}  {tag:<6}  {title}  @{author}  [{head}]  {updated}",
+                number = pr.number,
+                tag = pr.tag(),
+                title = pr.title,
+                author = pr.author_login(),
+                head = pr.head_ref_name,
+                updated = pr.updated_date(),
+            )
+        } else {
+            format!(
+                "#{number:<width$}  {title}  @{author}",
+                number = pr.number,
+                title = pr.title,
+                author = pr.author_login(),
+            )
+        };
+        println!("{}", term::paint(&row, pr.color(), color));
+    }
+    Ok(())
+}
+
+/// Build picker rows, tinted by state — green ready, grey draft, magenta
+/// merged, red closed. The source branch is part of the label so it is
+/// fuzzy-matchable, not just the title.
+fn items(prs: &[PullRequest]) -> Vec<PickItem> {
+    let width = number_width(prs);
+    prs.iter()
+        .map(|pr| {
+            let label = format!(
+                "#{number:<width$}  {title}  @{author}  [{head}]",
+                number = pr.number,
+                title = pr.title,
+                author = pr.author_login(),
+                head = pr.head_ref_name,
+            );
+            PickItem::new(label, pr.number.to_string()).color(pr.color())
+        })
+        .collect()
+}
+
+/// Fuzzy-select one pull request and return its number.
+fn select(ctx: &Ctx, prs: &[PullRequest], prompt: &str) -> Result<u64> {
+    let choice = pick::pick_one(items(prs), prompt, &ctx.config.picker)?;
+    choice
+        .parse()
+        .map_err(|_| anyhow::anyhow!("unexpected picker result: {choice}"))
+}
+
+/// `scriv pr pick` — fuzzy-select a pull request and print its number, so it
+/// composes with `gh`: `gh pr view (scriv pr pick)`.
+pub fn pick(ctx: &Ctx, state: &str, limit: usize) -> Result<()> {
+    let prs = collect(ctx, state, limit)?;
+    let number = select(ctx, &prs, "Pick a pull request")?;
+    println!("{number}");
+    Ok(())
+}
+
+/// `scriv pr checkout [number]` — check out a pull request's branch, picking
+/// one when no number is given. The checkout itself is `gh pr checkout`, which
+/// handles fork PRs and sets the upstream.
+pub fn checkout(ctx: &Ctx, number: Option<u64>, state: &str, limit: usize) -> Result<()> {
+    let number = match number {
+        Some(number) => number,
+        None => {
+            let prs = collect(ctx, state, limit)?;
+            select(ctx, &prs, "Check out a pull request")?
+        }
+    };
+    gh::checkout(number)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn prs() -> Vec<PullRequest> {
+        gh::parse_prs(
+            r#"[
+            {"number":7,"title":"Add branch picker","author":{"login":"joakimen"},
+             "headRefName":"feat/branches","isDraft":false,"state":"OPEN",
+             "updatedAt":"2026-07-27T09:12:33Z"},
+            {"number":123,"title":"WIP","author":{"login":"someone"},
+             "headRefName":"wip","isDraft":true,"state":"OPEN",
+             "updatedAt":"2026-07-20T11:00:00Z"}
+        ]"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn rows_return_the_pr_number() {
+        let items = items(&prs());
+        assert_eq!(items[0].value, "7");
+        assert_eq!(items[1].value, "123");
+    }
+
+    #[test]
+    fn rows_show_title_author_and_branch() {
+        let label = &items(&prs())[0].label;
+        assert!(label.contains("#7"));
+        assert!(label.contains("Add branch picker"));
+        assert!(label.contains("@joakimen"));
+        assert!(label.contains("[feat/branches]"), "{label}");
+    }
+
+    #[test]
+    fn drafts_are_tinted_differently() {
+        let items = items(&prs());
+        assert_ne!(items[0].color, items[1].color);
+    }
+
+    /// Numbers are padded to a common width so titles start in one column.
+    #[test]
+    fn number_column_aligns() {
+        let items = items(&prs());
+        assert_eq!(
+            items[0].label.find("Add branch picker"),
+            items[1].label.find("WIP"),
+        );
+    }
+}

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 
 use crate::config::RepoDisplay;
 use crate::path::{display_path, relative_label};
-use crate::pick::PickItem;
+use crate::pick::{PickItem, Preview};
 use crate::repo::FoundRepo;
 use crate::{Ctx, pick, repo};
 
@@ -52,6 +52,27 @@ pub fn ls(ctx: &Ctx, absolute: bool) -> Result<()> {
 /// the terminal theme; cycles if there are more groups than colours.
 const GROUP_COLORS: &[u8] = &[6, 2, 3, 5, 4, 1];
 
+/// The preview for a repository: its current branch and working-tree state,
+/// then recent commits.
+///
+/// That is what distinguishes two similarly named checkouts — which branch is
+/// out, whether it is dirty, and what was last done there. Both commands are
+/// local and take tens of milliseconds, which is the bar for running anything
+/// per highlighted row.
+///
+/// `--no-optional-locks` matters here: a plain `git status` refreshes and
+/// rewrites the index, so merely scrolling past a repository would take its
+/// index lock and contend with whatever the user is running in it.
+fn preview(path: &str) -> Preview {
+    let repo = pick::quote(path);
+    Preview::Command(format!(
+        "git --no-optional-locks -C {repo} -c color.status=always status --short --branch \
+         | head -n 10; \
+         git --no-optional-locks -C {repo} log --color=always --max-count=20 --date=relative \
+         --format='%C(auto)%h%C(reset)  %C(blue)%an%C(reset)  %C(green)%ad%C(reset)  %s'"
+    ))
+}
+
 /// `scriv repo pick` — fuzzy-select one repository and print its absolute path.
 ///
 /// Each row is prefixed with its group name, coloured per group so groups are
@@ -81,7 +102,7 @@ pub fn pick(ctx: &Ctx) -> Result<()> {
                 RepoDisplay::Full => abs.clone(),
             };
             let label = format!("{group:<width$}  {shown}", group = repo.group);
-            let mut item = PickItem::new(label, abs);
+            let mut item = PickItem::new(label, abs.clone()).preview(preview(&abs));
             if let Some(&color) = colors.get(repo.group.as_str()) {
                 item = item.color(color);
             }

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -89,7 +89,13 @@ pub fn pick(ctx: &Ctx) -> Result<()> {
         .enumerate()
         .map(|(i, group)| (group.as_str(), GROUP_COLORS[i % GROUP_COLORS.len()]))
         .collect();
-    let width = repos.iter().map(|r| r.group.len()).max().unwrap_or(0);
+    // Character count, not bytes: `{:<width$}` pads by characters, so a byte
+    // length would over-pad a group label containing non-ASCII.
+    let width = repos
+        .iter()
+        .map(|r| r.group.chars().count())
+        .max()
+        .unwrap_or(0);
 
     let mode = ctx.config.picker.display;
     let items: Vec<PickItem> = repos

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,6 +68,11 @@ pub struct PickerConfig {
     pub height: String,
     /// How repository paths are rendered in `repo pick`. See [`RepoDisplay`].
     pub display: RepoDisplay,
+    /// Whether the picker shows a preview pane for the highlighted row.
+    pub preview: bool,
+    /// Preview pane layout in skim's syntax, e.g. `"right:50%"`, `"down:40%"`,
+    /// or `"right:50%:hidden"` to start collapsed.
+    pub preview_window: String,
 }
 
 /// How `repo pick` renders each repository's path.
@@ -89,6 +94,8 @@ impl Default for PickerConfig {
         Self {
             height: "50%".to_string(),
             display: RepoDisplay::default(),
+            preview: true,
+            preview_window: "right:50%".to_string(),
         }
     }
 }
@@ -349,6 +356,20 @@ depth = 0
             parse_toml("").unwrap().picker.display,
             RepoDisplay::Relative
         );
+    }
+
+    #[test]
+    fn parses_preview_settings() {
+        let cfg = parse_toml("[picker]\npreview = false\npreview_window = \"down:40%\"\n").unwrap();
+        assert!(!cfg.picker.preview);
+        assert_eq!(cfg.picker.preview_window, "down:40%");
+    }
+
+    #[test]
+    fn preview_defaults_to_on_at_the_right() {
+        let cfg = parse_toml("").unwrap();
+        assert!(cfg.picker.preview);
+        assert_eq!(cfg.picker.preview_window, "right:50%");
     }
 
     #[test]

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -1,0 +1,215 @@
+//! GitHub pull requests, via the `gh` CLI.
+//!
+//! scriv does no GitHub authentication of its own: it shells out to `gh`, which
+//! already holds the user's token (`gh auth login`) and knows which repository
+//! the working directory belongs to. That keeps tokens out of scriv's config
+//! and makes enterprise hosts, SSO, and keyring storage work for free.
+//!
+//! As in [`crate::git`], the decisions — parsing `gh`'s JSON, colouring a PR by
+//! its state — are pure functions with tests; only [`list`] and [`checkout`]
+//! touch the outside world.
+
+use std::io::ErrorKind;
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde::Deserialize;
+
+use crate::Reported;
+
+/// JSON fields requested from `gh pr list`.
+const FIELDS: &str = "number,title,author,headRefName,isDraft,state,updatedAt";
+
+/// A pull request, as much of it as the picker needs.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PullRequest {
+    pub number: u64,
+    pub title: String,
+    /// Absent when the author's account is gone.
+    #[serde(default)]
+    pub author: Option<Author>,
+    /// The PR's source branch.
+    pub head_ref_name: String,
+    #[serde(default)]
+    pub is_draft: bool,
+    /// `OPEN`, `CLOSED`, or `MERGED`.
+    #[serde(default)]
+    pub state: String,
+    /// ISO-8601 timestamp, e.g. `2026-07-27T09:12:33Z`.
+    #[serde(default)]
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct Author {
+    #[serde(default)]
+    pub login: String,
+}
+
+impl PullRequest {
+    pub fn author_login(&self) -> &str {
+        self.author.as_ref().map_or("unknown", |a| a.login.as_str())
+    }
+
+    /// Just the date part of [`Self::updated_at`]; `gh` reports no relative
+    /// time and a date needs no clock of our own to render.
+    pub fn updated_date(&self) -> &str {
+        self.updated_at.split('T').next().unwrap_or_default()
+    }
+
+    /// ANSI 256-colour index for this PR, used in both the picker and `ls`.
+    pub fn color(&self) -> u8 {
+        color_for(self.is_draft, &self.state)
+    }
+
+    pub fn tag(&self) -> &'static str {
+        tag_for(self.is_draft, &self.state)
+    }
+}
+
+/// Colour a PR by what can be done with it: a draft is not ready to review, a
+/// merged or closed one is history.
+fn color_for(is_draft: bool, state: &str) -> u8 {
+    match state.to_ascii_uppercase().as_str() {
+        "MERGED" => 5,      // magenta
+        "CLOSED" => 1,      // red
+        _ if is_draft => 8, // bright black — open but draft
+        _ => 2,             // green — open and ready
+    }
+}
+
+fn tag_for(is_draft: bool, state: &str) -> &'static str {
+    match state.to_ascii_uppercase().as_str() {
+        "MERGED" => "merged",
+        "CLOSED" => "closed",
+        _ if is_draft => "draft",
+        _ => "open",
+    }
+}
+
+/// Parse the array `gh pr list --json …` prints.
+pub fn parse_prs(data: &str) -> Result<Vec<PullRequest>> {
+    // `gh` prints nothing at all in some error paths; treat that as empty.
+    if data.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    serde_json::from_str(data).context("parsing `gh pr list` output")
+}
+
+/// Pull requests for the repository the working directory belongs to.
+///
+/// `state` is passed through to `gh` (`open`, `closed`, `merged`, `all`).
+pub fn list(state: &str, limit: usize) -> Result<Vec<PullRequest>> {
+    let limit = limit.to_string();
+    let out = capture(&[
+        "pr", "list", "--json", FIELDS, "--state", state, "--limit", &limit,
+    ])?;
+    parse_prs(&out)
+}
+
+/// Check out a pull request's branch. `gh` creates the local branch and sets
+/// its upstream, including for PRs from forks.
+///
+/// `gh` writes its own diagnostics, so a failure is [`Reported`] rather than
+/// restated.
+pub fn checkout(number: u64) -> Result<()> {
+    let number = number.to_string();
+    let status = Command::new("gh")
+        .args(["pr", "checkout", &number])
+        .status()
+        .map_err(spawn_error)?;
+    if !status.success() {
+        return Err(Reported(status.code().unwrap_or(1)).into());
+    }
+    Ok(())
+}
+
+fn capture(args: &[&str]) -> Result<String> {
+    let output = Command::new("gh")
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+        .map_err(spawn_error)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = stderr.trim();
+        bail!(if stderr.is_empty() {
+            format!("gh {} failed", args.join(" "))
+        } else {
+            stderr.to_string()
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// A missing `gh` is the one failure worth explaining, since PR support is the
+/// only thing that depends on it.
+fn spawn_error(err: std::io::Error) -> anyhow::Error {
+    match err.kind() {
+        ErrorKind::NotFound => anyhow!(
+            "`gh` was not found on PATH — pull request commands need the GitHub CLI (https://cli.github.com), authenticated with `gh auth login`"
+        ),
+        _ => anyhow!(err).context("running gh"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"[
+        {"number":12,"title":"Add branch picker","author":{"login":"joakimen"},
+         "headRefName":"feat/branches","isDraft":false,"state":"OPEN",
+         "updatedAt":"2026-07-27T09:12:33Z"},
+        {"number":9,"title":"WIP","author":null,"headRefName":"wip",
+         "isDraft":true,"state":"OPEN","updatedAt":"2026-07-20T11:00:00Z"}
+    ]"#;
+
+    #[test]
+    fn parses_gh_output() {
+        let prs = parse_prs(SAMPLE).unwrap();
+        assert_eq!(prs.len(), 2);
+        assert_eq!(prs[0].number, 12);
+        assert_eq!(prs[0].head_ref_name, "feat/branches");
+        assert_eq!(prs[0].author_login(), "joakimen");
+        assert_eq!(prs[0].updated_date(), "2026-07-27");
+        assert!(prs[1].is_draft);
+    }
+
+    /// A deleted account leaves `author: null`; the listing must still render.
+    #[test]
+    fn missing_author_falls_back() {
+        let prs = parse_prs(SAMPLE).unwrap();
+        assert_eq!(prs[1].author_login(), "unknown");
+    }
+
+    #[test]
+    fn empty_output_is_no_prs() {
+        assert!(parse_prs("").unwrap().is_empty());
+        assert!(parse_prs("[]").unwrap().is_empty());
+    }
+
+    #[test]
+    fn rejects_invalid_json() {
+        assert!(parse_prs("{oops").is_err());
+    }
+
+    #[test]
+    fn colours_by_state() {
+        assert_eq!(color_for(false, "OPEN"), 2);
+        assert_eq!(color_for(true, "OPEN"), 8);
+        assert_eq!(color_for(false, "MERGED"), 5);
+        assert_eq!(color_for(false, "CLOSED"), 1);
+        // A draft that was merged or closed is history first.
+        assert_eq!(color_for(true, "MERGED"), 5);
+    }
+
+    #[test]
+    fn tags_match_colours() {
+        assert_eq!(tag_for(false, "OPEN"), "open");
+        assert_eq!(tag_for(true, "OPEN"), "draft");
+        assert_eq!(tag_for(false, "MERGED"), "merged");
+        assert_eq!(tag_for(false, "CLOSED"), "closed");
+    }
+}

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -18,7 +18,11 @@ use serde::Deserialize;
 use crate::Reported;
 
 /// JSON fields requested from `gh pr list`.
-const FIELDS: &str = "number,title,author,headRefName,isDraft,state,updatedAt";
+///
+/// `body` is fetched here, with everything else, so the preview pane can be
+/// rendered from memory. It costs no extra request — only a larger response —
+/// and saves a `gh pr view` round trip per highlighted row.
+const FIELDS: &str = "number,title,author,headRefName,isDraft,state,updatedAt,body";
 
 /// A pull request, as much of it as the picker needs.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -39,6 +43,9 @@ pub struct PullRequest {
     /// ISO-8601 timestamp, e.g. `2026-07-27T09:12:33Z`.
     #[serde(default)]
     pub updated_at: String,
+    /// The description, as markdown. Empty when none was written.
+    #[serde(default)]
+    pub body: String,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,0 +1,573 @@
+//! Git branch enumeration and checkout.
+//!
+//! Talking to git is a subprocess concern, but the interesting part — deciding
+//! which refs are local, which are remote-only, and what a checkout of a given
+//! name should actually do — is pure and lives here as functions over plain
+//! data ([`parse_ref_lines`], [`classify`], [`resolve`]), covered by tests.
+//!
+//! Branches are enumerated with a single `for-each-ref` over `refs/heads` and
+//! `refs/remotes`, so local and remote branches arrive in one pass, already
+//! ordered by commit recency.
+
+use std::collections::HashSet;
+use std::io::ErrorKind;
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result, anyhow, bail};
+
+use crate::Reported;
+
+/// Field separator in the `for-each-ref` format. ASCII unit separator, so
+/// commit subjects containing tabs or pipes cannot split a row.
+const SEP: char = '\x1f';
+
+/// Where a branch exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BranchKind {
+    /// Only in this clone — never pushed, or its upstream is gone.
+    Local,
+    /// Both here and on a remote.
+    Tracked,
+    /// Only on a remote; checking it out creates the local branch.
+    Remote,
+}
+
+impl BranchKind {
+    /// ANSI 256-colour index used for this kind, in both the picker and `ls`.
+    /// Standard hues so they follow the terminal theme.
+    pub fn color(self) -> u8 {
+        match self {
+            BranchKind::Local => 3,   // yellow — here only
+            BranchKind::Tracked => 2, // green  — in sync with a remote
+            BranchKind::Remote => 6,  // cyan   — not here yet
+        }
+    }
+
+    /// Short tag shown in `branch ls --status`, for when colour is unavailable.
+    pub fn tag(self) -> &'static str {
+        match self {
+            BranchKind::Local => "local",
+            BranchKind::Tracked => "both",
+            BranchKind::Remote => "remote",
+        }
+    }
+}
+
+/// Which branches a listing includes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Filter {
+    /// Local and remote-only branches. The default.
+    #[default]
+    All,
+    /// Branches that exist in this clone ([`BranchKind::Local`] and
+    /// [`BranchKind::Tracked`]).
+    Local,
+    /// Branches that exist on a remote ([`BranchKind::Tracked`] and
+    /// [`BranchKind::Remote`]).
+    Remote,
+}
+
+impl Filter {
+    /// Resolve the mutually exclusive `--local` / `--remote` flags.
+    pub fn from_flags(local: bool, remote: bool) -> Self {
+        match (local, remote) {
+            (true, false) => Filter::Local,
+            (false, true) => Filter::Remote,
+            _ => Filter::All,
+        }
+    }
+
+    fn accepts(self, kind: BranchKind) -> bool {
+        match self {
+            Filter::All => true,
+            Filter::Local => kind != BranchKind::Remote,
+            Filter::Remote => kind != BranchKind::Local,
+        }
+    }
+}
+
+/// A branch as offered to the user.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Branch {
+    /// Displayed and returned name: `main` for a local branch, `origin/main`
+    /// for a remote-only one, so the remote is never ambiguous.
+    pub name: String,
+    pub kind: BranchKind,
+    /// Whether this is the currently checked-out branch.
+    pub head: bool,
+    /// Relative commit date, e.g. `2 days ago`.
+    pub date: String,
+    /// Commit subject line.
+    pub subject: String,
+}
+
+/// One row of `for-each-ref` output, before classification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RefLine {
+    pub refname: String,
+    pub head: bool,
+    /// Configured upstream in short form (`origin/main`), empty when unset.
+    pub upstream: String,
+    pub date: String,
+    pub subject: String,
+}
+
+/// What checking out a given name should do.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Checkout {
+    /// Switch to an existing local branch.
+    Switch(String),
+    /// Create a local branch tracking `remote_ref` (`origin/main`).
+    Track { remote_ref: String },
+}
+
+/// Parse `for-each-ref` output written with the [`SEP`]-joined format.
+///
+/// Rows with too few fields are skipped rather than failing the listing — a
+/// malformed ref should not make the whole command unusable.
+pub fn parse_ref_lines(output: &str) -> Vec<RefLine> {
+    output
+        .lines()
+        .filter(|line| !line.is_empty())
+        .filter_map(|line| {
+            let mut fields = line.splitn(5, SEP);
+            let refname = fields.next()?;
+            let head = fields.next()?;
+            let upstream = fields.next()?;
+            let date = fields.next()?;
+            // The subject is last and unsplit, so separators inside it survive.
+            let subject = fields.next().unwrap_or_default();
+            if refname.is_empty() {
+                return None;
+            }
+            Some(RefLine {
+                refname: refname.to_string(),
+                head: head.trim() == "*",
+                upstream: upstream.to_string(),
+                date: date.to_string(),
+                subject: subject.to_string(),
+            })
+        })
+        .collect()
+}
+
+/// Split a remote ref short name (`origin/feat/x`) into remote and branch.
+/// Branch names may contain `/`; remote names may not, so the first component
+/// is the remote.
+fn split_remote(short: &str) -> Option<(&str, &str)> {
+    short
+        .split_once('/')
+        .filter(|(r, b)| !r.is_empty() && !b.is_empty())
+}
+
+/// Fold ref rows into the branch list shown to the user.
+///
+/// A local branch whose name also exists on a remote is [`BranchKind::Tracked`]
+/// rather than two rows; a remote ref with no local counterpart becomes a
+/// [`BranchKind::Remote`] row. `origin/HEAD` and friends are dropped — they are
+/// pointers to a default branch, not branches of their own. Input order (git's
+/// `--sort`) is preserved.
+pub fn classify(lines: &[RefLine]) -> Vec<Branch> {
+    let locals: HashSet<&str> = lines
+        .iter()
+        .filter_map(|line| line.refname.strip_prefix("refs/heads/"))
+        .collect();
+
+    // Remote refs already spoken for as some local branch's upstream, so a
+    // branch tracked under a different name is not also listed on its own.
+    let upstreams: HashSet<&str> = lines
+        .iter()
+        .filter(|line| line.refname.starts_with("refs/heads/"))
+        .map(|line| line.upstream.as_str())
+        .filter(|upstream| !upstream.is_empty())
+        .collect();
+
+    // Branch parts of every remote ref, across all remotes: `origin/main` and
+    // `fork/main` both contribute `main`.
+    let on_remote: HashSet<&str> = lines
+        .iter()
+        .filter_map(|line| line.refname.strip_prefix("refs/remotes/"))
+        .filter(|short| !short.ends_with("/HEAD"))
+        .filter_map(|short| split_remote(short).map(|(_, branch)| branch))
+        .collect();
+
+    let mut branches = Vec::new();
+    for line in lines {
+        if let Some(name) = line.refname.strip_prefix("refs/heads/") {
+            // Prefer the configured upstream when it points somewhere else, so
+            // `git branch -u origin/other` still reads as tracked.
+            let counterpart = match split_remote(&line.upstream) {
+                Some((_, branch)) => branch,
+                None => name,
+            };
+            let kind = if on_remote.contains(counterpart) {
+                BranchKind::Tracked
+            } else {
+                BranchKind::Local
+            };
+            branches.push(Branch {
+                name: name.to_string(),
+                kind,
+                head: line.head,
+                date: line.date.clone(),
+                subject: line.subject.clone(),
+            });
+        } else if let Some(short) = line.refname.strip_prefix("refs/remotes/") {
+            if short.ends_with("/HEAD") {
+                continue;
+            }
+            let Some((_, branch)) = split_remote(short) else {
+                continue;
+            };
+            // Already represented by its local counterpart.
+            if locals.contains(branch) || upstreams.contains(short) {
+                continue;
+            }
+            branches.push(Branch {
+                name: short.to_string(),
+                kind: BranchKind::Remote,
+                head: false,
+                date: line.date.clone(),
+                subject: line.subject.clone(),
+            });
+        }
+    }
+    branches
+}
+
+/// Apply a [`Filter`] to a branch list.
+pub fn filtered(branches: Vec<Branch>, filter: Filter) -> Vec<Branch> {
+    branches
+        .into_iter()
+        .filter(|branch| filter.accepts(branch.kind))
+        .collect()
+}
+
+/// Decide what checking out `input` means, given the known branches.
+///
+/// Rules, in order:
+/// - A name matching a listed branch uses that branch's kind: local branches
+///   are switched to, remote-only ones get a tracking branch created.
+/// - `origin/foo` where a local `foo` already exists switches to the local
+///   branch, rather than detaching HEAD at the remote ref.
+/// - Anything else is handed to git verbatim, so its own resolution (and its
+///   error message) still applies.
+pub fn resolve(branches: &[Branch], input: &str) -> Checkout {
+    if let Some(branch) = branches.iter().find(|b| b.name == input) {
+        return match branch.kind {
+            BranchKind::Remote => Checkout::Track {
+                remote_ref: branch.name.clone(),
+            },
+            _ => Checkout::Switch(branch.name.clone()),
+        };
+    }
+
+    // `origin/foo` when `foo` is checked out locally: the user means `foo`.
+    if let Some((_, tail)) = split_remote(input)
+        && branches
+            .iter()
+            .any(|b| b.kind != BranchKind::Remote && b.name == tail)
+    {
+        return Checkout::Switch(tail.to_string());
+    }
+
+    Checkout::Switch(input.to_string())
+}
+
+/// Run git with `args`, capturing stdout.
+fn capture(args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+        .map_err(|e| match e.kind() {
+            ErrorKind::NotFound => anyhow!("`git` was not found on PATH"),
+            _ => anyhow!(e).context("running git"),
+        })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = stderr.trim();
+        bail!(if stderr.is_empty() {
+            format!("git {} failed", args.join(" "))
+        } else {
+            stderr.to_string()
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Run git with `args`, letting it write straight to the terminal so its
+/// progress and "Switched to branch …" messages reach the user unchanged.
+///
+/// A failure is [`Reported`]: git has already said why on stderr, in wording
+/// the user knows, so scriv exits with its status and stays quiet.
+fn passthrough(args: &[&str]) -> Result<()> {
+    let status = Command::new("git")
+        .args(args)
+        .status()
+        .map_err(|e| match e.kind() {
+            ErrorKind::NotFound => anyhow!("`git` was not found on PATH"),
+            _ => anyhow!(e).context("running git"),
+        })?;
+    if !status.success() {
+        return Err(Reported(status.code().unwrap_or(1)).into());
+    }
+    Ok(())
+}
+
+/// Fail early, and with a better message than git's, when the working
+/// directory is not inside a repository.
+pub fn ensure_repo() -> Result<()> {
+    let inside = Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|e| match e.kind() {
+            ErrorKind::NotFound => anyhow!("`git` was not found on PATH"),
+            _ => anyhow!(e).context("running git"),
+        })?;
+    if !inside.success() {
+        bail!("not inside a git repository");
+    }
+    Ok(())
+}
+
+/// Every branch in the repository, most recently committed to first.
+pub fn branches() -> Result<Vec<Branch>> {
+    let format = format!(
+        "--format=%(refname){SEP}%(HEAD){SEP}%(upstream:short){SEP}%(committerdate:relative){SEP}%(subject)"
+    );
+    let out = capture(&[
+        "for-each-ref",
+        "--sort=-committerdate",
+        &format,
+        "refs/heads",
+        "refs/remotes",
+    ])
+    .context("listing branches")?;
+    Ok(classify(&parse_ref_lines(&out)))
+}
+
+/// Refresh remote-tracking refs, dropping ones deleted upstream.
+pub fn fetch() -> Result<()> {
+    passthrough(&["fetch", "--all", "--prune"]).context("fetching from remotes")
+}
+
+/// Perform a resolved checkout.
+///
+/// `switch --track origin/foo` creates local `foo` with its upstream already
+/// set, which is exactly the two-step the user would otherwise do by hand.
+pub fn checkout(action: &Checkout) -> Result<()> {
+    match action {
+        Checkout::Switch(name) => passthrough(&["switch", "--", name]),
+        Checkout::Track { remote_ref } => passthrough(&["switch", "--track", remote_ref]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn line(refname: &str, head: bool, upstream: &str) -> RefLine {
+        RefLine {
+            refname: refname.to_string(),
+            head,
+            upstream: upstream.to_string(),
+            date: "2 days ago".to_string(),
+            subject: "some commit".to_string(),
+        }
+    }
+
+    fn render(rows: &[(&str, &str, &str, &str, &str)]) -> String {
+        rows.iter()
+            .map(|(r, h, u, d, s)| format!("{r}{SEP}{h}{SEP}{u}{SEP}{d}{SEP}{s}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn parses_ref_rows() {
+        let out = render(&[
+            ("refs/heads/main", "*", "origin/main", "2 hours ago", "init"),
+            ("refs/remotes/origin/main", " ", "", "2 hours ago", "init"),
+        ]);
+        let got = parse_ref_lines(&out);
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].refname, "refs/heads/main");
+        assert!(got[0].head);
+        assert_eq!(got[0].upstream, "origin/main");
+        assert_eq!(got[0].date, "2 hours ago");
+        assert_eq!(got[1].refname, "refs/remotes/origin/main");
+        assert!(!got[1].head);
+    }
+
+    /// The subject is the final field, so separators inside it must not split
+    /// the row or truncate the message.
+    #[test]
+    fn subject_keeps_trailing_separators() {
+        let out = format!("refs/heads/main{SEP} {SEP}{SEP}now{SEP}fix: a{SEP}b");
+        let got = parse_ref_lines(&out);
+        assert_eq!(got[0].subject, format!("fix: a{SEP}b"));
+    }
+
+    #[test]
+    fn skips_malformed_rows() {
+        let out = format!("refs/heads/main{SEP}*\n\nrefs/heads/ok{SEP} {SEP}{SEP}now{SEP}s");
+        let got = parse_ref_lines(&out);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].refname, "refs/heads/ok");
+    }
+
+    #[test]
+    fn local_with_remote_counterpart_is_tracked() {
+        let got = classify(&[
+            line("refs/heads/main", true, "origin/main"),
+            line("refs/remotes/origin/main", false, ""),
+        ]);
+        assert_eq!(got.len(), 1, "the remote ref must not add a second row");
+        assert_eq!(got[0].kind, BranchKind::Tracked);
+        assert!(got[0].head);
+    }
+
+    #[test]
+    fn local_without_remote_is_local_only() {
+        let got = classify(&[line("refs/heads/scratch", false, "")]);
+        assert_eq!(got[0].kind, BranchKind::Local);
+    }
+
+    /// An upstream that has been deleted from the remote leaves the branch
+    /// local-only, not "both".
+    #[test]
+    fn stale_upstream_is_local_only() {
+        let got = classify(&[line("refs/heads/gone", false, "origin/gone")]);
+        assert_eq!(got[0].kind, BranchKind::Local);
+    }
+
+    #[test]
+    fn upstream_under_another_name_still_counts() {
+        let got = classify(&[
+            line("refs/heads/local-name", false, "origin/remote-name"),
+            line("refs/remotes/origin/remote-name", false, ""),
+        ]);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].kind, BranchKind::Tracked);
+    }
+
+    /// The remote prefix is kept, so a slash-heavy branch name stays
+    /// unambiguous and `switch --track` gets a ref it can resolve.
+    #[test]
+    fn remote_only_keeps_its_remote_prefix() {
+        let got = classify(&[line("refs/remotes/origin/feat/x", false, "")]);
+        assert_eq!(got[0].kind, BranchKind::Remote);
+        assert_eq!(got[0].name, "origin/feat/x");
+        assert_eq!(
+            resolve(&got, "origin/feat/x"),
+            Checkout::Track {
+                remote_ref: "origin/feat/x".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn drops_remote_head_pointer() {
+        let got = classify(&[
+            line("refs/remotes/origin/HEAD", false, ""),
+            line("refs/remotes/origin/main", false, ""),
+        ]);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].name, "origin/main");
+    }
+
+    /// The same branch on two remotes, with no local copy, stays two rows —
+    /// the user has to say which remote to track.
+    #[test]
+    fn same_branch_on_two_remotes_lists_both() {
+        let got = classify(&[
+            line("refs/remotes/origin/shared", false, ""),
+            line("refs/remotes/fork/shared", false, ""),
+        ]);
+        assert_eq!(
+            got.iter().map(|b| b.name.as_str()).collect::<Vec<_>>(),
+            vec!["origin/shared", "fork/shared"]
+        );
+    }
+
+    #[test]
+    fn preserves_input_order() {
+        let got = classify(&[
+            line("refs/heads/b", false, ""),
+            line("refs/heads/a", false, ""),
+        ]);
+        assert_eq!(
+            got.iter().map(|b| b.name.as_str()).collect::<Vec<_>>(),
+            vec!["b", "a"]
+        );
+    }
+
+    fn sample() -> Vec<Branch> {
+        classify(&[
+            line("refs/heads/main", true, "origin/main"),
+            line("refs/remotes/origin/main", false, ""),
+            line("refs/heads/scratch", false, ""),
+            line("refs/remotes/origin/feature", false, ""),
+        ])
+    }
+
+    #[test]
+    fn filters_by_side() {
+        let names = |f| {
+            filtered(sample(), f)
+                .into_iter()
+                .map(|b| b.name)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(names(Filter::All), ["main", "scratch", "origin/feature"]);
+        assert_eq!(names(Filter::Local), ["main", "scratch"]);
+        assert_eq!(names(Filter::Remote), ["main", "origin/feature"]);
+    }
+
+    #[test]
+    fn filter_flags_default_to_all() {
+        assert_eq!(Filter::from_flags(false, false), Filter::All);
+        assert_eq!(Filter::from_flags(true, false), Filter::Local);
+        assert_eq!(Filter::from_flags(false, true), Filter::Remote);
+    }
+
+    #[test]
+    fn local_branch_is_switched_to() {
+        assert_eq!(
+            resolve(&sample(), "main"),
+            Checkout::Switch("main".to_string())
+        );
+    }
+
+    #[test]
+    fn remote_only_branch_creates_a_tracking_branch() {
+        assert_eq!(
+            resolve(&sample(), "origin/feature"),
+            Checkout::Track {
+                remote_ref: "origin/feature".to_string()
+            }
+        );
+    }
+
+    /// Typing the remote form of a branch that is already local must switch to
+    /// the local branch, not detach HEAD at the remote ref.
+    #[test]
+    fn remote_form_of_a_local_branch_switches_locally() {
+        assert_eq!(
+            resolve(&sample(), "origin/main"),
+            Checkout::Switch("main".to_string())
+        );
+    }
+
+    #[test]
+    fn unknown_name_is_left_to_git() {
+        assert_eq!(
+            resolve(&sample(), "nope"),
+            Checkout::Switch("nope".to_string())
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,23 @@
 //! `scriv` — discover Git repositories and track the files you visit often.
 //!
 //! The crate is split into an I/O-free core ([`config`], [`path`], [`files`]'s
-//! pure helpers, [`repo`]'s traversal rules) and an imperative shell: the
-//! [`cmd`] modules that read the environment, touch the filesystem, and drive
+//! pure helpers, [`repo`]'s traversal rules, [`git`] and [`gh`]'s parsing and
+//! classification) and an imperative shell: the [`cmd`] modules that read the
+//! environment, touch the filesystem, shell out to `git`/`gh`, and drive
 //! interactive selection. [`Ctx`] resolves the environment once and hands it to
 //! every command.
 
 pub mod cmd;
 pub mod config;
 pub mod files;
+pub mod gh;
+pub mod git;
 pub mod logger;
 pub mod path;
 pub mod pick;
 pub mod repo;
 pub mod shell;
+pub mod term;
 
 use std::path::{Path, PathBuf};
 
@@ -21,6 +25,22 @@ use anyhow::{Context, Result};
 
 use config::Config;
 use logger::Logger;
+
+/// A subprocess that already explained its own failure on stderr — `git` and
+/// `gh` both do, in their own well-known wording.
+///
+/// Propagated instead of a message so the command exits with the child's status
+/// without scriv restating what the user just read.
+#[derive(Debug)]
+pub struct Reported(pub i32);
+
+impl std::fmt::Display for Reported {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "subprocess exited with status {}", self.0)
+    }
+}
+
+impl std::error::Error for Reported {}
 
 /// Resolved runtime environment shared by every command.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,10 @@
 //! dispatch to the [`cmd`] implementations. All decision logic lives in the
 //! library crate.
 //!
-//! Top-level commands: `repo` and `file` work with the things scriv tracks;
-//! `config` manages its configuration; `init` prints shell integration. The
-//! help layout follows clap's default (description, usage, commands, options).
+//! Top-level commands: `repo`, `file`, `branch`, and `pr` work with the things
+//! scriv finds; `config` manages its configuration; `init` prints shell
+//! integration. The help layout follows clap's default (description, usage,
+//! commands, options).
 
 use std::process::ExitCode;
 
@@ -12,8 +13,9 @@ use clap::builder::styling::{AnsiColor, Effects, Styles};
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
 
+use scriv::git::Filter;
 use scriv::pick::Cancelled;
-use scriv::{Ctx, cmd, shell};
+use scriv::{Ctx, Reported, cmd, shell};
 
 /// Usage examples appended to the top-level help.
 const EXAMPLES: &str = "\x1b[1;92mExamples:\x1b[0m
@@ -21,6 +23,8 @@ const EXAMPLES: &str = "\x1b[1;92mExamples:\x1b[0m
   scriv repo pick              Fuzzy-pick a repository, print its path
   cd (scriv repo pick)         Jump to a repository (fish)
   scriv file add <path>        Track a file you visit often
+  scriv branch checkout        Pick a local or remote branch and switch to it
+  scriv pr checkout            Pick a GitHub pull request and check it out
   scriv init fish | source     Load shell integration + completions";
 
 /// Help styling matching cargo: bright-green bold headers and usage,
@@ -68,6 +72,17 @@ enum Command {
     File {
         #[command(subcommand)]
         command: FileCmd,
+    },
+    /// Switch between local and remote git branches
+    #[command(alias = "br")]
+    Branch {
+        #[command(subcommand)]
+        command: BranchCmd,
+    },
+    /// Work with GitHub pull requests (via the `gh` CLI)
+    Pr {
+        #[command(subcommand)]
+        command: PrCmd,
     },
     /// Manage the configuration
     Config {
@@ -127,6 +142,92 @@ enum FileCmd {
     },
 }
 
+/// Which branches a `branch` subcommand considers, shared by all three.
+#[derive(clap::Args)]
+struct BranchScope {
+    /// Only branches that exist in this clone
+    #[arg(short = 'l', long, conflicts_with = "remote")]
+    local: bool,
+    /// Only branches that exist on a remote
+    #[arg(short = 'r', long)]
+    remote: bool,
+    /// Fetch from all remotes (pruning deleted branches) first
+    #[arg(short = 'f', long)]
+    fetch: bool,
+}
+
+impl BranchScope {
+    fn filter(&self) -> Filter {
+        Filter::from_flags(self.local, self.remote)
+    }
+}
+
+#[derive(Subcommand)]
+enum BranchCmd {
+    /// List local and remote branches
+    #[command(alias = "list")]
+    Ls {
+        /// Show the current-branch marker, local/both/remote tag, and last commit
+        #[arg(long)]
+        status: bool,
+        #[command(flatten)]
+        scope: BranchScope,
+    },
+    /// Fuzzy-select a branch and print its name
+    Pick {
+        #[command(flatten)]
+        scope: BranchScope,
+    },
+    /// Check out a branch; omit the name to pick one
+    ///
+    /// Checking out a remote-only branch creates the matching local branch and
+    /// sets its upstream.
+    #[command(aliases = ["co", "switch"])]
+    Checkout {
+        /// Branch to check out, e.g. `main` or `origin/feature`
+        branch: Option<String>,
+        #[command(flatten)]
+        scope: BranchScope,
+    },
+}
+
+/// Which pull requests a `pr` subcommand fetches, shared by all three.
+#[derive(clap::Args)]
+struct PrScope {
+    /// Pull request state to include
+    #[arg(short, long, default_value = "open", value_parser = ["open", "closed", "merged", "all"])]
+    state: String,
+    /// Maximum number of pull requests to fetch
+    #[arg(short = 'L', long, default_value_t = 50)]
+    limit: usize,
+}
+
+#[derive(Subcommand)]
+enum PrCmd {
+    /// List pull requests
+    #[command(alias = "list")]
+    Ls {
+        /// Show the state tag, source branch, and last-updated date
+        #[arg(long)]
+        status: bool,
+        #[command(flatten)]
+        scope: PrScope,
+    },
+    /// Fuzzy-select a pull request and print its number
+    Pick {
+        #[command(flatten)]
+        scope: PrScope,
+    },
+    /// Check out a pull request's branch; omit the number to pick one
+    #[command(alias = "co")]
+    Checkout {
+        /// Pull request number
+        number: Option<u64>,
+        #[command(flatten)]
+        scope: PrScope,
+    },
+}
+
 #[derive(Subcommand)]
 enum ConfigCmd {
     /// Generate a starter configuration file
@@ -154,6 +255,12 @@ fn main() -> ExitCode {
         Ok(()) => ExitCode::SUCCESS,
         // A cancelled picker is a silent, conventional exit, not an error.
         Err(err) if err.is::<Cancelled>() => ExitCode::from(130),
+        // git and gh explain their own failures; pass their status through
+        // rather than printing a second, vaguer line on top.
+        Err(err) if err.is::<Reported>() => match err.downcast_ref::<Reported>() {
+            Some(Reported(code)) if *code > 0 => ExitCode::from(*code as u8),
+            _ => ExitCode::FAILURE,
+        },
         Err(err) => {
             eprintln!("error: {err:#}");
             ExitCode::FAILURE
@@ -178,6 +285,22 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             FileCmd::Pick => cmd::file::pick(&ctx),
             FileCmd::Add { file } => cmd::file::add(&ctx, file.as_deref()),
             FileCmd::Remove { file } => cmd::file::remove(&ctx, file.as_deref()),
+        },
+        Command::Branch { command } => match command {
+            BranchCmd::Ls { status, scope } => {
+                cmd::branch::ls(&ctx, scope.filter(), status, scope.fetch)
+            }
+            BranchCmd::Pick { scope } => cmd::branch::pick(&ctx, scope.filter(), scope.fetch),
+            BranchCmd::Checkout { branch, scope } => {
+                cmd::branch::checkout(&ctx, branch.as_deref(), scope.filter(), scope.fetch)
+            }
+        },
+        Command::Pr { command } => match command {
+            PrCmd::Ls { status, scope } => cmd::pr::ls(&ctx, &scope.state, scope.limit, status),
+            PrCmd::Pick { scope } => cmd::pr::pick(&ctx, &scope.state, scope.limit),
+            PrCmd::Checkout { number, scope } => {
+                cmd::pr::checkout(&ctx, number, &scope.state, scope.limit)
+            }
         },
         Command::Config { command } => match command {
             ConfigCmd::Init { force } => cmd::config::init(&ctx, force),

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -28,13 +28,37 @@ impl std::fmt::Display for Cancelled {
 
 impl std::error::Error for Cancelled {}
 
+/// What the preview pane shows for the highlighted row.
+///
+/// Prefer [`Preview::Text`] whenever the data is already in hand: it renders
+/// instantly, with nothing to spawn or wait for. A [`Preview::Command`] is only
+/// appropriate for work that is local and fast (tens of milliseconds), because
+/// skim spawns it again on every move through the list and does not kill the
+/// previous child.
+pub enum Preview {
+    /// Ready-made text; ANSI escapes are honoured.
+    Text(String),
+    /// A shell command, run only when the row is highlighted — so the cost is
+    /// paid per look, not per item. skim exports `COLUMNS` and `ROWS` to it,
+    /// for tools that wrap their own output.
+    Command(String),
+}
+
+/// Quote `arg` for the shell that runs a [`Preview::Command`], so a branch name
+/// or path containing spaces or quotes cannot alter the command.
+pub fn quote(arg: &str) -> String {
+    format!("'{}'", arg.replace('\'', r"'\''"))
+}
+
 /// One choice in the picker: `label` is displayed and matched against, `value`
-/// is returned when it is selected, and `color` optionally tints the row (an
-/// ANSI 256-colour index, so it respects the terminal theme).
+/// is returned when it is selected, `color` optionally tints the row (an ANSI
+/// 256-colour index, so it respects the terminal theme), and `preview` fills
+/// the preview pane while the row is highlighted.
 pub struct PickItem {
     pub label: String,
     pub value: String,
     pub color: Option<u8>,
+    pub preview: Option<Preview>,
 }
 
 impl PickItem {
@@ -45,6 +69,7 @@ impl PickItem {
             label: text.clone(),
             value: text,
             color: None,
+            preview: None,
         }
     }
 
@@ -54,6 +79,7 @@ impl PickItem {
             label: label.into(),
             value: value.into(),
             color: None,
+            preview: None,
         }
     }
 
@@ -62,14 +88,22 @@ impl PickItem {
         self.color = Some(color);
         self
     }
+
+    /// Show `preview` in the preview pane while this row is highlighted.
+    pub fn preview(mut self, preview: Preview) -> Self {
+        self.preview = Some(preview);
+        self
+    }
 }
 
 /// Bridges a [`PickItem`] to skim: `text()` drives display and matching,
-/// `output()` is what a selection yields, and `display()` tints the row.
+/// `output()` is what a selection yields, `display()` tints the row, and
+/// `preview()` fills the preview pane.
 struct SkItem {
     label: String,
     value: String,
     color: Option<u8>,
+    preview: Option<Preview>,
 }
 
 impl SkimItem for SkItem {
@@ -88,6 +122,16 @@ impl SkimItem for SkItem {
             context.base_style = context.base_style.fg(Color::Indexed(idx));
         }
         context.to_line(self.text())
+    }
+
+    fn preview(&self, _context: PreviewContext) -> ItemPreview {
+        match &self.preview {
+            Some(Preview::Text(text)) => ItemPreview::AnsiText(text.clone()),
+            Some(Preview::Command(cmd)) => ItemPreview::Command(cmd.clone()),
+            // Blank rather than `Global`, which would run the (empty) global
+            // preview command for rows that have nothing to show.
+            None => ItemPreview::Text(String::new()),
+        }
     }
 }
 
@@ -118,11 +162,24 @@ fn run(items: Vec<PickItem>, prompt: &str, multi: bool, cfg: &PickerConfig) -> R
         anyhow::bail!("interactive selection needs a terminal");
     }
 
-    let options = SkimOptionsBuilder::default()
+    let mut builder = SkimOptionsBuilder::default();
+    builder
         .height(cfg.height.clone())
         .prompt(format!("{prompt}> "))
         .reverse(true)
-        .multi(multi)
+        .multi(multi);
+
+    // The pane only exists when skim has a preview command; the per-item
+    // `preview()` above supplies the actual content, so an empty string is
+    // enough to turn it on. Skipped entirely when no item has a preview, so
+    // pickers without one keep the full width.
+    if cfg.preview && items.iter().any(|item| item.preview.is_some()) {
+        builder
+            .preview("")
+            .preview_window(cfg.preview_window.as_str());
+    }
+
+    let options = builder
         .build()
         .map_err(|e| anyhow!("configuring picker: {e}"))?;
 
@@ -135,6 +192,7 @@ fn run(items: Vec<PickItem>, prompt: &str, multi: bool, cfg: &PickerConfig) -> R
                 label: it.label,
                 value: it.value,
                 color: it.color,
+                preview: it.preview,
             }) as Arc<dyn SkimItem>
         })
         .collect();
@@ -151,4 +209,23 @@ fn run(items: Vec<PickItem>, prompt: &str, multi: bool, cfg: &PickerConfig) -> R
         .iter()
         .map(|item| item.output().to_string())
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quotes_plain_values() {
+        assert_eq!(quote("main"), "'main'");
+        assert_eq!(quote("/home/u/my repo"), "'/home/u/my repo'");
+    }
+
+    /// A single quote in a branch name or path must not end the quoted string
+    /// and let the rest be read as shell syntax.
+    #[test]
+    fn quotes_escape_embedded_single_quotes() {
+        assert_eq!(quote("it's"), r"'it'\''s'");
+        assert_eq!(quote("'; rm -rf /; '"), r"''\''; rm -rf /; '\'''");
+    }
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -58,10 +58,25 @@ function scriv-file-edit --description "Pick a known file and open it in \$EDITO
     end
 end
 
+function scriv-branch-checkout --description "Pick a git branch and check it out"
+    command scriv branch checkout
+end
+
+function scriv-pr-checkout --description "Pick a GitHub pull request and check it out"
+    command scriv pr checkout
+end
+
+# Bindings use alt-<letter>, which fish leaves entirely unbound by default, and
+# are chosen so the chord falls under one hand: alt-b (branch) and alt-g (git)
+# are both left-hand, alt-o and alt-p right-hand. Rebind any of them by calling
+# `bind` yourself after `scriv_key_bindings`.
 function scriv_key_bindings --description "Bind scriv pickers to keys"
     bind ctrl-o "scriv-repo-cd; commandline -f execute"
     bind alt-o  "scriv-repo-cd; commandline -f execute"
     bind f3     "scriv-file-edit; commandline -f execute"
+    bind alt-b  "scriv-branch-checkout; commandline -f execute"
+    bind alt-g  "scriv-branch-checkout; commandline -f execute"
+    bind alt-p  "scriv-pr-checkout; commandline -f execute"
 end
 "#;
 
@@ -79,6 +94,8 @@ mod tests {
         let out = integration(Shell::Fish, &mut dummy());
         assert!(out.contains("function scriv-repo-cd"));
         assert!(out.contains("function scriv-file-edit"));
+        assert!(out.contains("function scriv-branch-checkout"));
+        assert!(out.contains("function scriv-pr-checkout"));
         assert!(out.contains("function scriv_key_bindings"));
     }
 
@@ -89,6 +106,18 @@ mod tests {
         assert!(out.contains("bind ctrl-o"));
         assert!(out.contains("bind alt-o"));
         assert!(out.contains("bind f3"));
+        assert!(out.contains("bind alt-b"));
+        assert!(out.contains("bind alt-g"));
+        assert!(out.contains("bind alt-p"));
+    }
+
+    /// f4 and f5 are common in user configs (awsvault, editors); fish leaves
+    /// the whole alt-<letter> space free, so scriv stays out of the way.
+    #[test]
+    fn fish_avoids_function_keys_beyond_f3() {
+        let out = integration(Shell::Fish, &mut dummy());
+        assert!(!out.contains("bind f4"));
+        assert!(!out.contains("bind f5"));
     }
 
     #[test]

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,0 +1,42 @@
+//! Terminal capability checks shared by the printing commands.
+//!
+//! Colour is opt-out per the `NO_COLOR` convention and is never emitted when
+//! stdout is redirected, so `scriv … ls` stays pipe-safe by default.
+
+use std::io::IsTerminal;
+
+/// Whether stdout should carry ANSI colour: a terminal, and `NO_COLOR` unset.
+pub fn stdout_color() -> bool {
+    std::io::stdout().is_terminal() && !no_color()
+}
+
+/// Honour the `NO_COLOR` convention: colour is disabled when the variable is
+/// present and non-empty.
+pub fn no_color() -> bool {
+    std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty())
+}
+
+/// Wrap `text` in an ANSI 256-colour sequence when `on`, so the same colour
+/// indices the picker uses also drive plain listings.
+pub fn paint(text: &str, color: u8, on: bool) -> String {
+    if on {
+        format!("\x1b[38;5;{color}m{text}\x1b[0m")
+    } else {
+        text.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn paint_is_identity_when_off() {
+        assert_eq!(paint("main", 2, false), "main");
+    }
+
+    #[test]
+    fn paint_wraps_when_on() {
+        assert_eq!(paint("main", 2, true), "\x1b[38;5;2mmain\x1b[0m");
+    }
+}


### PR DESCRIPTION
Adds two command groups — `scriv branch` and `scriv pr` — and gives every picker a preview pane.

## Branches

`scriv branch ls|pick|checkout` (alias `br`) lists local and remote branches in one list, ordered by commit recency and coloured by where each branch lives:

| Colour | Meaning | `--status` tag |
| ------ | ------- | -------------- |
| green  | exists here **and** on a remote | `both` |
| yellow | exists **only** here — never pushed, or upstream gone | `local` |
| cyan   | exists **only** on a remote | `remote` |

Remote-only branches keep their remote prefix (`origin/feature`), so two remotes carrying the same branch stay distinguishable. Checking one out creates the matching local branch and sets its upstream — the equivalent of `git switch --track origin/feature` — so `git push`/`git pull` work immediately.

Details worth calling out:

- Typing `origin/main` when `main` is already local switches to the local branch instead of detaching HEAD.
- A branch whose upstream was deleted reads as `local`, not `both`.
- `--local`/`--remote` narrow what the picker offers; a name given on the command line still resolves against every branch.
- `--fetch` refreshes remotes (with `--prune`) first.

## Pull requests

`scriv pr ls|pick|checkout` shells out to `gh`, so it inherits `gh auth login` — including Enterprise hosts — and scriv stores no tokens. Rows are coloured by state (green open, grey draft, magenta merged, red closed). `pr checkout` hands off to `gh pr checkout`, which handles fork PRs. `pr pick` prints the number, so it composes: `gh pr view (scriv pr pick)`.

## Previews

Every picker previews the highlighted row:

| Picker | Preview |
| ------ | ------- |
| `repo pick` | current branch, working-tree status, recent commits |
| `branch pick`/`checkout` | recent commits with author and relative date |
| `pr pick`/`checkout` | title, state, author, source branch, description |
| `file pick`/`add`/`remove` | contents, via `bat` when installed, else `head` |

**A preview is eye candy and must never make the list feel slow**, which shaped the design. skim runs preview commands on a background thread with a 50 ms debounce, but does *not* kill non-PTY children — it only discards their output — so anything slow piles up while scrolling. Therefore:

- PR previews are rendered from memory rather than by `gh pr view`, which measured ~2.0–2.4 s of network **per highlighted row**. `body` is instead one more field on the `gh pr list` call already being made — no extra request (measured: same latency, response 3 KB → 14 KB for 50 PRs).
- The commands that remain are local and bounded: git log 29 ms, status+log 42 ms, bat/head 31 ms (23 ms on a 134 MB file, since `--line-range` stops early).
- Both git previews pass `--no-optional-locks`. A plain `git status` rewrites the index, so scrolling past a repo would take its index lock and contend with your own `git`.

Preview commands are built through a shell-quoting helper, so a branch name or path containing quotes cannot alter what runs.

## Key bindings

Fish integration gains `scriv-branch-checkout` (`alt-b`, `alt-g`) and `scriv-pr-checkout` (`alt-p`). fish leaves the whole `alt-<letter>` space unbound and each chord falls under one hand; function keys past `f3` are deliberately avoided, since those are commonly bound to users' own tools.

## Structure and testing

Parsing and classification are pure functions over plain data (`git::parse_ref_lines`/`classify`/`resolve`, `gh::parse_prs`), matching the existing core/shell split; only the `cmd` modules and process helpers touch the outside world. git and gh already explain their own failures, so those exits now pass the child's status through instead of adding a second, vaguer error line.

109 tests pass, covering ref classification, checkout resolution, filters, PR parsing, row rendering, column widths, and shell quoting. Verified by hand against a fixture repo with all three branch kinds: remote-only checkout creates the local branch with upstream set, and `origin/main` does not detach HEAD.

The picker UI itself is exercised end to end by the demo recording, which follows in a separate PR.