### PR TITLE
Align help text and crate metadata with the README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,8 @@
 # Working on scriv
 
-scriv discovers Git repositories, tracks files you return to, and switches
-branches and pull requests — all through one built-in fuzzy picker (skim).
+scriv scans the paths you configure for Git repositories, tracks files you
+return to, and switches branches and pull requests — all through one built-in
+fuzzy picker (skim).
 
 ## Before opening a pull request
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "scriv"
 version = "0.1.0"
 edition = "2024"
-description = "scriv discovers Git repositories and tracks the files you visit often."
+description = "Pick your repositories, files, git branches and GitHub pull requests from one fuzzy finder."
 license = "MIT"
 repository = "https://github.com/joakimen/scriv"
 # Artwork, the demo recording and CI config belong to the repository, not the

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -10,7 +10,7 @@ use crate::Ctx;
 /// A commented starter config covering the common layout: search roots grouped
 /// by label and the default picker. Users edit it to taste.
 const TEMPLATE: &str = r#"# scriv configuration.
-# Repositories are discovered by searching each path below, up to its depth.
+# scriv looks for repositories under each path below, up to its depth.
 # Directory names to skip while searching.
 ignore = ["node_modules", "target"]
 

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -1,4 +1,5 @@
-//! `scriv repo` — list and pick discovered Git repositories.
+//! `scriv repo` — list and pick the Git repositories found under the
+//! configured search paths.
 
 use anyhow::{Context, Result};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-//! `scriv` — discover Git repositories and track the files you visit often.
+//! `scriv` — pick repositories, files, git branches and GitHub pull requests
+//! from one fuzzy finder.
 //!
 //! The crate is split into an I/O-free core ([`config`], [`path`], [`files`]'s
 //! pure helpers, [`repo`]'s traversal rules, [`git`] and [`gh`]'s parsing and

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ const STYLES: Styles = Styles::styled()
 #[command(
     name = "scriv",
     version,
-    about = "Discover Git repositories and track the files you visit often.",
+    about = "Pick your repositories, files, git branches and GitHub pull requests from one fuzzy finder.",
     after_help = EXAMPLES,
     styles = STYLES,
     disable_help_subcommand = true
@@ -63,7 +63,7 @@ struct Cli {
 #[derive(Subcommand)]
 #[command(disable_help_subcommand = true)]
 enum Command {
-    /// Discover and open Git repositories
+    /// List and pick the Git repositories under your search paths
     Repo {
         #[command(subcommand)]
         command: RepoCmd,
@@ -101,7 +101,7 @@ enum Command {
 
 #[derive(Subcommand)]
 enum RepoCmd {
-    /// List all discovered repositories
+    /// List every repository found under your search paths
     #[command(alias = "list")]
     Ls {
         /// Return absolute file paths


### PR DESCRIPTION
Follow-up to #17. That PR reworded the README to stop claiming scriv
*discovers* your repositories — the search paths and their depth come from
config, so it scans what it is pointed at. The binary still said otherwise.

## What said the old thing

| Where | Surfaced in |
| --- | --- |
| `Cargo.toml` `description` | the crates.io listing |
| clap `about` in `src/main.rs` | `scriv --help` |
| `Repo` and `RepoCmd::Ls` doc comments | `scriv repo --help`, and shell completions |
| `TEMPLATE` header in `src/cmd/config.rs` | the `config.toml` written for every new user |
| crate-level doc in `src/lib.rs` | rustdoc |

All now describe picking from a list, matching the README.

## Deliberately unchanged

`repo.rs`, `path.rs`, `config.rs` and the private `discover()` in
`cmd/repo.rs` still say "discovery" for the filesystem walk. That traversal
genuinely does discover repositories; the objection was to the user-facing
claim, not the internal vocabulary. Say the word if you want it swept too.

## Checks

`make` passes — fmt, clippy, 109 tests, release build. Verified the rendered
output rather than trusting the source:

```
$ scriv --help
Pick your repositories, files, git branches and GitHub pull requests from one fuzzy finder.
...
  repo    List and pick the Git repositories under your search paths

$ scriv config init && head -2 config.toml
# scriv configuration.
# scriv looks for repositories under each path below, up to its depth.
```

No picker output changed, so the demo did not need re-recording.