### PR TITLE
Add `scriv edit`: find a file, pick it, open it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,21 +1,45 @@
 # Working on scriv
 
 scriv scans the paths you configure for Git repositories, tracks files you
-return to, and switches branches and pull requests — all through one built-in
-fuzzy picker (skim).
+return to, opens files in your editor, and switches branches and pull
+requests — all through one built-in fuzzy picker (skim).
 
 ## Before opening a pull request
 
 - `make` — fmt check, clippy (`-D warnings`), tests, release build. All four
   must pass; CI runs the same set.
-- **If anything changed what a picker shows on screen — row layout, colours,
-  preview contents, the commands or flags in `demo/demo.tape` — re-record the
-  demo with `make demo` and commit the resulting `docs/demo.gif`.** CI only
-  plays the tape (`make demo-check`); it never commits a GIF, so a stale demo
-  is invisible until someone looks at the README. Recording needs `vhs`
-  (`brew install vhs`) and takes about 30 seconds.
 - Keep commits logical and self-contained: each one should build and test
   green on its own.
+
+### The three docs that go stale silently
+
+Nothing in CI compares these against the code, so a change that outdates one
+looks green all the way to merge. Walk the list on every pull request and say
+in the PR body which ones you touched, or why none needed it.
+
+**1. CLI help text — `src/main.rs`.** The `about`, every doc comment on a
+command or flag, and the `EXAMPLES` block are the only documentation most
+users read, and clap ships them straight to the terminal. A new command or
+flag is not done until it has a doc comment; a renamed or re-scoped one is not
+done until the old wording is gone. `EXAMPLES` covers the common entry point
+of each command group — add a line when you add a group, not when you add
+every flag.
+
+**2. README.md.** Check each of these in turn, since a change rarely touches
+just one: the feature table under the demo, the `Commands` section (including
+the abbreviations sentence), the key-binding table when `shell.rs` bindings
+change, and the sample `config.toml` when a config key is added or renamed.
+The README's command table and `scriv --help` describe the same surface and
+must not disagree.
+
+**3. `docs/demo.gif`.** If anything changed what a picker shows on screen —
+row layout, colours, preview contents, the commands or flags in
+`demo/demo.tape` — re-record with `make demo` and commit the GIF. CI only
+plays the tape (`make demo-check`); it never commits a GIF, so a stale demo is
+invisible until someone looks at the README. Recording needs `vhs`
+(`brew install vhs`) and takes about 30 seconds. A change that adds a command
+without altering any existing picker's output does not need a re-record — say
+so in the PR rather than leaving it unmentioned.
 
 ## Layout
 
@@ -27,6 +51,7 @@ is expected to follow it:
 | `config.rs`, `path.rs`, `files.rs` | parsing and path rules, no I/O |
 | `git.rs`, `gh.rs` | ref classification, checkout resolution, JSON parsing — pure functions, plus the process helpers |
 | `repo.rs` | discovery traversal rules |
+| `walk.rs` | the `ignore`-crate file walk shared by `edit` and `file add` |
 | `pick.rs` | the skim wrapper: rows, colours, previews |
 | `cmd/*.rs` | the imperative shell — reads the environment, spawns processes, drives selection |
 | `shell.rs` | the fish integration and completions that `scriv init` emits |
@@ -50,9 +75,19 @@ reference, so command implementations do no environment lookups of their own.
   lock and contend with whatever the user is running in it.
 - **Preview commands are built through `pick::quote`.** A branch name or path
   containing a quote must not be able to alter the command that runs.
-- **`git` and `gh` explain their own failures.** When a spawned child fails,
-  return `Reported(code)` so the process exits with the child's status instead
-  of printing a second, vaguer error line on top of git's.
+- **`git`, `gh` and the editor explain their own failures.** When a spawned
+  child fails, return `Reported(code)` so the process exits with the child's
+  status instead of printing a second, vaguer error line on top of git's.
+- **The top-level commands are registries; `edit` is the exception.**
+  `repo`/`file`/`branch`/`pr` are each a set scriv knows about, with `ls`/`pick`
+  and a verb over that set. `edit` acts on the directory the user is standing
+  in, so it is a verb at the top level rather than a fifth noun — and it has no
+  `ls`. Resist filing ambient-directory work under a noun group.
+- **Only `cd` needs the shell.** A child cannot change its parent's directory,
+  which is why `repo pick` prints a path for a fish function to consume. Running
+  an editor needs no such help: `scriv edit` spawns it directly and skim restores
+  the terminal on its way out. Add a fish wrapper only for what genuinely cannot
+  work from a child process.
 - **Colour is dropped when stdout is not a terminal**, and `NO_COLOR` is
   honoured — `ls` output has to stay pipe-safe. Use `term::stdout_color()`.
 - **Key bindings use `alt-<letter>`.** fish leaves that space entirely unbound,

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ candidates apart without leaving the picker.
 | --- | --- |
 | **repos** | pick one of your repositories and `cd` into it |
 | **files** | keep a list of files you return to, and open one |
+| **editing** | fuzzy-find a file where you are standing and open it in `$EDITOR` |
 | **branches** | switch to a local branch, or check out a remote one |
 | **pull requests** | check out a GitHub pull request |
 
@@ -67,6 +68,19 @@ Four nouns, the same few verbs:
 `scriv init` handle setup. `branch` abbreviates to `br`, `checkout` to `co`,
 `ls` to `list`. Any command takes `--help` for its flags.
 
+`scriv edit` is the one verb rather than a noun: it searches the directory
+you are in — not a list scriv keeps — and opens what you choose.
+
+```fish
+scriv edit              # pick a file below $PWD, open it in your editor
+scriv edit --tracked    # pick from your tracked files instead
+scriv edit src/main.rs  # skip the picker
+```
+
+Select several with `tab` and they open together. The walk honours
+`.gitignore`, `.ignore` and `.fdignore`. The editor is `$VISUAL`, then
+`$EDITOR`, unless the config sets `editor`. `edit` abbreviates to `e`.
+
 Every `pick` prints one line and nothing else, so it composes:
 
 ```fish
@@ -92,9 +106,15 @@ end
 | Key | Does |
 | --- | --- |
 | `ctrl-o`, `alt-o` | pick a repository and `cd` into it |
+| `alt-e` | pick a file below `$PWD` and open it in `$EDITOR` |
 | `f3` | pick a tracked file and open it in `$EDITOR` |
 | `alt-b`, `alt-g` | pick a branch and check it out |
 | `alt-p` | pick a pull request and check it out |
+
+It also defines `fe` — find, fuzzy-pick, edit — as a short alias for
+`scriv edit`, forwarding its arguments so `fe -t` and `fe src/main.rs` work
+too. That is the only unprefixed name scriv defines; redefine it after sourcing
+if you have your own.
 
 To use your own keys, bind them after `scriv_key_bindings` — the last binding
 for a key wins. For other shells, `scriv init bash`/`zsh`/`powershell`/`elvish`
@@ -107,6 +127,9 @@ emit completions.
 ```toml
 # Directory names to skip while searching.
 ignore = ["node_modules", "target"]
+
+# Editor launched by `scriv edit`. Defaults to $VISUAL, then $EDITOR.
+editor = "nvim"
 
 # Where to look for repositories. Paths are grouped by a label, and repo pick
 # shows the group a repo belongs to in a colour of its own, so work and

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -14,6 +14,9 @@ const TEMPLATE: &str = r#"# scriv configuration.
 # Directory names to skip while searching.
 ignore = ["node_modules", "target"]
 
+# Editor launched by `scriv edit`. Defaults to $VISUAL, then $EDITOR.
+# editor = "nvim"
+
 # Search paths are grouped by a label; `repo pick` shows which group a repo
 # belongs to. Add more groups (e.g. per client) as needed.
 [[paths.personal]]
@@ -91,6 +94,11 @@ pub fn print(ctx: &Ctx) -> Result<()> {
     }
     println!();
     println!("ignore: {}", ctx.config.ignore.join(", "));
+    println!(
+        "editor: {}",
+        ctx.editor_setting()
+            .unwrap_or("(unset — set $EDITOR or $VISUAL)")
+    );
     Ok(())
 }
 

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -1,0 +1,129 @@
+//! `scriv edit` — fuzzy-find a file and open it in your editor.
+//!
+//! Unlike the other commands, this one is a verb rather than a registry: it
+//! searches whatever directory you are in rather than a list scriv maintains.
+//! `--tracked` points the same picker at the known-files list instead.
+//!
+//! Nothing here needs shell integration — a child process cannot change its
+//! parent's directory, which is why `repo pick` is wrapped in a fish function,
+//! but it can perfectly well inherit the terminal and run an editor in it.
+
+use std::io::ErrorKind;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Result, anyhow, bail};
+
+use crate::path::{display_path, expand_tilde};
+use crate::pick::{PickItem, file_preview};
+use crate::{Ctx, Reported, files, pick, walk};
+
+/// `scriv edit [FILE]...` — open `paths`, or pick interactively when empty.
+///
+/// With `tracked`, selection comes from the known-files list; otherwise from
+/// the current directory tree. Multiple selections open together, which is what
+/// an editor's buffer list is for.
+pub fn run(ctx: &Ctx, paths: &[String], tracked: bool) -> Result<()> {
+    let targets = if !paths.is_empty() {
+        paths.to_vec()
+    } else {
+        let picked = if tracked {
+            pick_tracked(ctx)?
+        } else {
+            pick_from_cwd(ctx)?
+        };
+        match picked {
+            Some(targets) => targets,
+            // Cancelled: a conventional silent exit, nothing to open.
+            None => return Ok(()),
+        }
+    };
+
+    // Selecting nothing is not an error either — the picker was simply left
+    // with no rows marked.
+    if targets.is_empty() {
+        return Ok(());
+    }
+
+    open(ctx, &targets)
+}
+
+/// Choose files from the current directory tree.
+fn pick_from_cwd(ctx: &Ctx) -> Result<Option<Vec<String>>> {
+    let candidates = walk::list_files(Path::new("."))?;
+    if candidates.is_empty() {
+        bail!("no files found in the current directory");
+    }
+
+    // Paths stay relative to the working directory: the editor is launched from
+    // it, and relative paths are what shows up in its buffer list.
+    let items = candidates
+        .into_iter()
+        .map(|file| {
+            let preview = file_preview(&file);
+            PickItem::plain(file).preview(preview)
+        })
+        .collect();
+
+    cancellable(pick::pick_many(items, "Edit", &ctx.config.picker))
+}
+
+/// Choose files from the known-files list.
+fn pick_tracked(ctx: &Ctx) -> Result<Option<Vec<String>>> {
+    ctx.ensure_files_migrated()?;
+    let lines = files::read_lines(&ctx.files_path)?;
+    if lines.is_empty() {
+        bail!("no known files yet — add one with `scriv file add <path>`");
+    }
+
+    // Show a `~`-collapsed label; hand the editor the absolute path, since the
+    // list is global and rarely relative to where the user is standing.
+    let items = lines
+        .iter()
+        .map(|line| {
+            let abs = expand_tilde(line, ctx.home_str());
+            let shown = display_path(&abs, ctx.home_str(), false);
+            PickItem::new(shown, abs.clone()).preview(file_preview(&abs))
+        })
+        .collect();
+
+    cancellable(pick::pick_many(items, "Edit", &ctx.config.picker))
+}
+
+/// Map a cancelled picker to `None`, leaving real errors alone.
+fn cancellable(result: Result<Vec<String>>) -> Result<Option<Vec<String>>> {
+    match result {
+        Ok(selected) => Ok(Some(selected)),
+        Err(e) if e.is::<pick::Cancelled>() => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Launch the editor on `targets`, inheriting the terminal.
+///
+/// A non-zero exit is [`Reported`]: the editor has already had the terminal and
+/// said whatever it wanted to say, so scriv passes the status through without
+/// adding a line of its own.
+fn open(ctx: &Ctx, targets: &[String]) -> Result<()> {
+    let editor = ctx.editor()?;
+    let (program, args) = editor
+        .split_first()
+        .expect("Ctx::editor rejects an empty command");
+
+    ctx.log
+        .info(&format!("opening {} file(s) with {program}", targets.len()));
+
+    let status = Command::new(program)
+        .args(args)
+        .args(targets)
+        .status()
+        .map_err(|e| match e.kind() {
+            ErrorKind::NotFound => anyhow!("`{program}` was not found on PATH"),
+            _ => anyhow!(e).context(format!("running {program}")),
+        })?;
+
+    if !status.success() {
+        return Err(Reported(status.code().unwrap_or(1)).into());
+    }
+    Ok(())
+}

--- a/src/cmd/file.rs
+++ b/src/cmd/file.rs
@@ -2,26 +2,12 @@
 
 use std::path::Path;
 
-use anyhow::{Context, Result, bail};
-use ignore::WalkBuilder;
+use anyhow::{Result, bail};
 
 use crate::path::{display_path, expand_tilde, sanitize_file_path};
-use crate::pick::{PickItem, Preview};
+use crate::pick::{PickItem, file_preview};
 use crate::term;
-use crate::{Ctx, files, pick};
-
-/// The preview for a file: its contents.
-///
-/// `bat` renders them with syntax highlighting when it is installed; `head`
-/// covers everyone else, and its error text is the preview when the path is
-/// gone — which the known-files list expects to happen.
-fn preview(path: &str) -> Preview {
-    let path = pick::quote(path);
-    Preview::Command(format!(
-        "bat --color=always --style=plain --line-range=:200 -- {path} 2>/dev/null \
-         || head -n 200 -- {path}"
-    ))
-}
+use crate::{Ctx, files, pick, walk};
 
 /// `scriv file ls` — print known files, optionally with existence status.
 pub fn ls(ctx: &Ctx, status: bool, missing: bool, exists: bool) -> Result<()> {
@@ -134,7 +120,7 @@ fn remove_interactive(ctx: &Ctx) -> Result<()> {
         .map(|line| {
             let expanded = expand_tilde(line, ctx.home_str());
             let shown = display_path(&expanded, ctx.home_str(), false);
-            PickItem::new(shown, line.clone()).preview(preview(&expanded))
+            PickItem::new(shown, line.clone()).preview(file_preview(&expanded))
         })
         .collect();
 
@@ -171,7 +157,7 @@ pub fn pick(ctx: &Ctx) -> Result<()> {
         .map(|line| {
             let abs = expand_tilde(line, ctx.home_str());
             let shown = display_path(&abs, ctx.home_str(), false);
-            PickItem::new(shown, abs.clone()).preview(preview(&abs))
+            PickItem::new(shown, abs.clone()).preview(file_preview(&abs))
         })
         .collect();
 
@@ -184,14 +170,14 @@ pub fn pick(ctx: &Ctx) -> Result<()> {
 ///
 /// Returns `Ok(None)` when the user cancels the picker.
 fn pick_from_cwd(ctx: &Ctx) -> Result<Option<String>> {
-    let candidates = list_files(Path::new("."))?;
+    let candidates = walk::list_files(Path::new("."))?;
     if candidates.is_empty() {
         bail!("no files found in the current directory");
     }
     let items = candidates
         .into_iter()
         .map(|file| {
-            let preview = preview(&file);
+            let preview = file_preview(&file);
             PickItem::plain(file).preview(preview)
         })
         .collect();
@@ -199,81 +185,5 @@ fn pick_from_cwd(ctx: &Ctx) -> Result<Option<String>> {
         Ok(choice) => Ok(Some(choice)),
         Err(e) if e.is::<pick::Cancelled>() => Ok(None),
         Err(e) => Err(e),
-    }
-}
-
-/// Directory names never worth walking into when picking a file to add,
-/// matching the user's fzf `--walker-skip` list.
-const WALKER_SKIP: &[&str] = &[
-    ".git",
-    "node_modules",
-    ".clj-kondo",
-    ".cpcache",
-    ".venv",
-    "lib",
-];
-
-/// List files under `root`, as paths relative to `root`.
-///
-/// Uses the `ignore` crate — the same directory walker fd is built on — so it
-/// honours `.gitignore` and skips [`WALKER_SKIP`] directories, all in-process
-/// with no `fd` subprocess.
-fn list_files(root: &Path) -> Result<Vec<String>> {
-    let walker = WalkBuilder::new(root)
-        .hidden(false) // include dotfiles; config files are common targets
-        .require_git(false) // honour .gitignore/.ignore even outside a git repo
-        .filter_entry(|entry| {
-            entry
-                .file_name()
-                .to_str()
-                .is_none_or(|name| !WALKER_SKIP.contains(&name))
-        })
-        .build();
-
-    let mut files = Vec::new();
-    for entry in walker {
-        let entry = entry.context("walking the directory")?;
-        if entry.file_type().is_some_and(|ft| ft.is_file()) {
-            let path = entry.path();
-            let rel = path.strip_prefix(root).unwrap_or(path);
-            files.push(rel.to_string_lossy().into_owned());
-        }
-    }
-    files.sort();
-    Ok(files)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs;
-    use tempfile::TempDir;
-
-    #[test]
-    fn list_files_walks_and_skips() {
-        let dir = TempDir::new().unwrap();
-        let root = dir.path();
-        fs::write(root.join("a.txt"), "").unwrap();
-        fs::create_dir_all(root.join("src")).unwrap();
-        fs::write(root.join("src/main.rs"), "").unwrap();
-        // A skipped directory and a gitignored file must not appear.
-        fs::create_dir_all(root.join("node_modules/pkg")).unwrap();
-        fs::write(root.join("node_modules/pkg/index.js"), "").unwrap();
-        fs::write(root.join(".gitignore"), "ignored.txt\n").unwrap();
-        fs::write(root.join("ignored.txt"), "").unwrap();
-
-        let got = list_files(root).unwrap();
-
-        assert!(got.contains(&"a.txt".to_string()));
-        assert!(got.contains(&"src/main.rs".to_string()));
-        assert!(got.contains(&".gitignore".to_string())); // dotfiles included
-        assert!(
-            !got.iter().any(|f| f.contains("node_modules")),
-            "WALKER_SKIP dir leaked: {got:?}"
-        );
-        assert!(
-            !got.contains(&"ignored.txt".to_string()),
-            ".gitignore not honoured: {got:?}"
-        );
     }
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,11 +1,12 @@
 //! Command implementations — the imperative shell.
 //!
-//! Each submodule mirrors a top-level noun in the CLI. Functions take a
+//! Each submodule mirrors a top-level command in the CLI. Functions take a
 //! [`crate::Ctx`] and perform the filesystem and interactive I/O; all decision
 //! logic they rely on lives in the pure core modules.
 
 pub mod branch;
 pub mod config;
+pub mod edit;
 pub mod file;
 pub mod pr;
 pub mod repo;

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,8 @@ pub struct Config {
     pub paths: Groups,
     pub ignore: Vec<String>,
     pub picker: PickerConfig,
+    /// Editor launched by `scriv edit`, overriding `$VISUAL` and `$EDITOR`.
+    pub editor: Option<String>,
 }
 
 impl Config {
@@ -47,8 +49,39 @@ impl Config {
             paths: Groups::new(),
             ignore: default_ignored_dirs(),
             picker: PickerConfig::default(),
+            editor: None,
         }
     }
+}
+
+/// Pick the editor `scriv edit` launches: the `editor` config key first, then
+/// `$VISUAL`, then `$EDITOR` — the order every other terminal tool uses, with
+/// the config key on top so scriv can differ from the rest of the shell.
+///
+/// Blank and whitespace-only values count as unset: `EDITOR=""` is a common way
+/// to say "no editor", and honouring it literally would try to spawn `""`.
+pub fn resolve_editor(
+    configured: Option<&str>,
+    visual: Option<&str>,
+    editor: Option<&str>,
+) -> Option<String> {
+    [configured, visual, editor]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|candidate| !candidate.is_empty())
+        .map(str::to_string)
+}
+
+/// Split an editor command into program and arguments on whitespace, so
+/// `EDITOR="code -w"` spawns `code` with `-w` rather than looking for a program
+/// with a space in its name.
+///
+/// Whitespace is the whole of the syntax — no quoting, no escapes — which is
+/// what git's own `core.editor` fallback does for the simple cases and covers
+/// every editor invocation short of an embedded shell command.
+pub fn split_editor(command: &str) -> Vec<String> {
+    command.split_whitespace().map(str::to_string).collect()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -108,6 +141,7 @@ struct RawToml {
     ignore: Option<Vec<String>>,
     #[serde(default)]
     picker: PickerConfig,
+    editor: Option<String>,
 }
 
 /// `paths` accepts two shapes. The grouped form keys entries by a group label
@@ -169,6 +203,7 @@ fn parse_toml(data: &str) -> Result<Config> {
         paths: raw.paths.into_groups(),
         ignore: raw.ignore.unwrap_or_else(default_ignored_dirs),
         picker: raw.picker,
+        editor: raw.editor,
     })
 }
 
@@ -185,6 +220,7 @@ fn parse_json(data: &str) -> Result<Config> {
         paths: flat_to_groups(raw.paths),
         ignore,
         picker: PickerConfig::default(),
+        editor: None,
     })
 }
 
@@ -535,5 +571,53 @@ depth = 0
             legacy_kf_path(Some("/xdg"), home),
             PathBuf::from("/xdg/kf/config")
         );
+    }
+
+    #[test]
+    fn parses_editor() {
+        assert_eq!(
+            parse_toml("editor = \"hx\"\n").unwrap().editor.as_deref(),
+            Some("hx")
+        );
+        assert_eq!(parse_toml("").unwrap().editor, None);
+    }
+
+    #[test]
+    fn editor_precedence_prefers_config_then_visual() {
+        assert_eq!(
+            resolve_editor(Some("hx"), Some("code"), Some("vi")).as_deref(),
+            Some("hx")
+        );
+        assert_eq!(
+            resolve_editor(None, Some("code"), Some("vi")).as_deref(),
+            Some("code")
+        );
+        assert_eq!(
+            resolve_editor(None, None, Some("vi")).as_deref(),
+            Some("vi")
+        );
+        assert_eq!(resolve_editor(None, None, None), None);
+    }
+
+    /// `EDITOR=""` means "no editor", not a program named "".
+    #[test]
+    fn editor_ignores_blank_values() {
+        assert_eq!(
+            resolve_editor(None, Some("  "), Some("vi")).as_deref(),
+            Some("vi")
+        );
+        assert_eq!(resolve_editor(Some(""), None, None), None);
+        // A value that is only padded still resolves, trimmed.
+        assert_eq!(
+            resolve_editor(Some(" hx "), None, None).as_deref(),
+            Some("hx")
+        );
+    }
+
+    #[test]
+    fn splits_editor_into_program_and_args() {
+        assert_eq!(split_editor("nvim"), vec!["nvim"]);
+        assert_eq!(split_editor("code -w"), vec!["code", "-w"]);
+        assert_eq!(split_editor("  nvim   -p  "), vec!["nvim", "-p"]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod pick;
 pub mod repo;
 pub mod shell;
 pub mod term;
+pub mod walk;
 
 use std::path::{Path, PathBuf};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ pub struct Ctx {
     pub files_path: PathBuf,
     /// The standalone `kf` tool's config, read once to migrate its list.
     pub legacy_kf_path: PathBuf,
+    /// The editor `scriv edit` launches, from config or the environment.
+    editor: Option<String>,
     pub config: Config,
     pub log: Logger,
 }
@@ -85,6 +87,12 @@ impl Ctx {
         let legacy_kf_path = config::legacy_kf_path(xdg_env.as_deref(), &home);
         let config = config::load_config(&config_path)?;
 
+        let editor = config::resolve_editor(
+            config.editor.as_deref(),
+            std::env::var("VISUAL").ok().as_deref(),
+            std::env::var("EDITOR").ok().as_deref(),
+        );
+
         Ok(Self {
             home_s: home.to_string_lossy().into_owned(),
             pwd_s: pwd.to_string_lossy().into_owned(),
@@ -92,9 +100,32 @@ impl Ctx {
             config_path,
             files_path,
             legacy_kf_path,
+            editor,
             config,
             log: Logger::new(verbose),
         })
+    }
+
+    /// The resolved editor command, or `None` when nothing is set. For
+    /// reporting; [`Ctx::editor`] is what launching goes through.
+    pub fn editor_setting(&self) -> Option<&str> {
+        self.editor.as_deref()
+    }
+
+    /// The editor command to launch, split into program and arguments.
+    ///
+    /// Errors when nothing is configured, naming every place the user can set
+    /// one rather than failing on an empty program name deeper in.
+    pub fn editor(&self) -> Result<Vec<String>> {
+        let command = self.editor.as_deref().context(
+            "no editor set — set $EDITOR or $VISUAL, \
+             or add `editor = \"nvim\"` to the config file",
+        )?;
+        let parts = config::split_editor(command);
+        if parts.is_empty() {
+            anyhow::bail!("the configured editor is empty");
+        }
+        Ok(parts)
     }
 
     pub fn home(&self) -> &Path {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,9 @@
 //! library crate.
 //!
 //! Top-level commands: `repo`, `file`, `branch`, and `pr` work with the things
-//! scriv finds; `config` manages its configuration; `init` prints shell
-//! integration. The help layout follows clap's default (description, usage,
-//! commands, options).
+//! scriv finds; `edit` opens a file from the directory you are in; `config`
+//! manages its configuration; `init` prints shell integration. The help layout
+//! follows clap's default (description, usage, commands, options).
 
 use std::process::ExitCode;
 
@@ -23,6 +23,8 @@ const EXAMPLES: &str = "\x1b[1;92mExamples:\x1b[0m
   scriv repo pick              Fuzzy-pick a repository, print its path
   cd (scriv repo pick)         Jump to a repository (fish)
   scriv file add <path>        Track a file you visit often
+  scriv edit                   Pick a file under the current directory, edit it
+  scriv edit --tracked         Pick one of your tracked files and edit it
   scriv branch checkout        Pick a local or remote branch and switch to it
   scriv pr checkout            Pick a GitHub pull request and check it out
   scriv init fish | source     Load shell integration + completions";
@@ -72,6 +74,21 @@ enum Command {
     File {
         #[command(subcommand)]
         command: FileCmd,
+    },
+    /// Fuzzy-find a file and open it in your editor
+    ///
+    /// Selection comes from the current directory tree, honouring `.gitignore`,
+    /// or from your tracked files with `--tracked`. Selecting several opens them
+    /// all. The editor is `$VISUAL`, then `$EDITOR`, unless the config file sets
+    /// `editor`.
+    #[command(alias = "e")]
+    Edit {
+        /// Files to open; omit to pick interactively
+        #[arg(value_name = "FILE")]
+        files: Vec<String>,
+        /// Pick from your tracked files instead of the current directory
+        #[arg(short, long, conflicts_with = "files")]
+        tracked: bool,
     },
     /// Switch between local and remote git branches
     #[command(alias = "br")]
@@ -286,6 +303,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             FileCmd::Add { file } => cmd::file::add(&ctx, file.as_deref()),
             FileCmd::Remove { file } => cmd::file::remove(&ctx, file.as_deref()),
         },
+        Command::Edit { files, tracked } => cmd::edit::run(&ctx, &files, tracked),
         Command::Branch { command } => match command {
             BranchCmd::Ls { status, scope } => {
                 cmd::branch::ls(&ctx, scope.filter(), status, scope.fetch)

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -50,6 +50,20 @@ pub fn quote(arg: &str) -> String {
     format!("'{}'", arg.replace('\'', r"'\''"))
 }
 
+/// The preview for a file: its contents.
+///
+/// `bat` renders them with syntax highlighting when it is installed; `head`
+/// covers everyone else, and its error text is the preview when the path is
+/// gone — which the known-files list expects to happen. Both are bounded to
+/// 200 lines, so scrolling a list never reads a large file in full.
+pub fn file_preview(path: &str) -> Preview {
+    let path = quote(path);
+    Preview::Command(format!(
+        "bat --color=always --style=plain --line-range=:200 -- {path} 2>/dev/null \
+         || head -n 200 -- {path}"
+    ))
+}
+
 /// One choice in the picker: `label` is displayed and matched against, `value`
 /// is returned when it is selected, `color` optionally tints the row (an ANSI
 /// 256-colour index, so it respects the terminal theme), and `preview` fills

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -44,18 +44,22 @@ function scriv-repo-cd --description "Pick a repository and cd into it"
     test -n "$dir"; and builtin cd $dir
 end
 
-function scriv-file-edit --description "Pick a known file and open it in \$EDITOR"
-    set -l file (command scriv file pick)
-    or return
-    if test -z "$file"
-        return
-    end
-    if set -q EDITOR
-        $EDITOR $file
-    else
-        echo "scriv: \$EDITOR is not set" >&2
-        return 1
-    end
+# `scriv edit` spawns the editor itself — unlike cd, that needs no shell help —
+# so these are thin wrappers kept only to hang key bindings off.
+function scriv-edit --description "Pick a file under \$PWD and open it in \$EDITOR"
+    command scriv edit
+end
+
+function scriv-file-edit --description "Pick a tracked file and open it in \$EDITOR"
+    command scriv edit --tracked
+end
+
+# The find -> fuzzy-pick -> edit pipeline under the name it is usually aliased
+# to. Arguments pass straight through, so `fe -t` and `fe path/to/file` work.
+# This is the one unprefixed name scriv defines: redefine `fe` after sourcing
+# if you already have one.
+function fe --description "Find a file, fuzzy-pick it, open it in \$EDITOR"
+    command scriv edit $argv
 end
 
 function scriv-branch-checkout --description "Pick a git branch and check it out"
@@ -67,12 +71,13 @@ function scriv-pr-checkout --description "Pick a GitHub pull request and check i
 end
 
 # Bindings use alt-<letter>, which fish leaves entirely unbound by default, and
-# are chosen so the chord falls under one hand: alt-b (branch) and alt-g (git)
-# are both left-hand, alt-o and alt-p right-hand. Rebind any of them by calling
-# `bind` yourself after `scriv_key_bindings`.
+# are chosen so the chord falls under one hand: alt-b (branch), alt-g (git) and
+# alt-e (edit) are left-hand, alt-o and alt-p right-hand. Rebind any of them by
+# calling `bind` yourself after `scriv_key_bindings`.
 function scriv_key_bindings --description "Bind scriv pickers to keys"
     bind ctrl-o "scriv-repo-cd; commandline -f execute"
     bind alt-o  "scriv-repo-cd; commandline -f execute"
+    bind alt-e  "scriv-edit; commandline -f execute"
     bind f3     "scriv-file-edit; commandline -f execute"
     bind alt-b  "scriv-branch-checkout; commandline -f execute"
     bind alt-g  "scriv-branch-checkout; commandline -f execute"
@@ -93,7 +98,9 @@ mod tests {
     fn fish_emits_helper_functions() {
         let out = integration(Shell::Fish, &mut dummy());
         assert!(out.contains("function scriv-repo-cd"));
+        assert!(out.contains("function scriv-edit"));
         assert!(out.contains("function scriv-file-edit"));
+        assert!(out.contains("function fe"));
         assert!(out.contains("function scriv-branch-checkout"));
         assert!(out.contains("function scriv-pr-checkout"));
         assert!(out.contains("function scriv_key_bindings"));
@@ -105,10 +112,34 @@ mod tests {
         assert!(out.contains("complete -c scriv"));
         assert!(out.contains("bind ctrl-o"));
         assert!(out.contains("bind alt-o"));
+        assert!(out.contains("bind alt-e"));
         assert!(out.contains("bind f3"));
         assert!(out.contains("bind alt-b"));
         assert!(out.contains("bind alt-g"));
         assert!(out.contains("bind alt-p"));
+    }
+
+    /// `fe` takes arguments, so it stands in for `scriv edit` completely rather
+    /// than only its no-argument form.
+    #[test]
+    fn fe_forwards_arguments() {
+        let out = integration(Shell::Fish, &mut dummy());
+        assert!(out.contains("command scriv edit $argv"));
+    }
+
+    /// `fe` is deliberately the *only* unprefixed function scriv defines: every
+    /// other helper is namespaced, so sourcing the integration cannot quietly
+    /// shadow commands the user already has.
+    #[test]
+    fn fish_defines_one_unprefixed_function() {
+        let out = integration(Shell::Fish, &mut dummy());
+        let unprefixed: Vec<&str> = out
+            .lines()
+            .filter_map(|line| line.strip_prefix("function "))
+            .filter_map(|rest| rest.split_whitespace().next())
+            .filter(|name| !name.starts_with("scriv"))
+            .collect();
+        assert_eq!(unprefixed, vec!["fe"]);
     }
 
     /// f4 and f5 are common in user configs (awsvault, editors); fish leaves

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -1,0 +1,108 @@
+//! Walking a directory tree for files to offer in a picker.
+//!
+//! Built on the [`ignore`] crate — the same walker [fd] is — so `.gitignore`,
+//! `.ignore` and `.fdignore` are honoured in-process, with no `fd` subprocess
+//! to find on `PATH`.
+//!
+//! [fd]: https://github.com/sharkdp/fd
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use ignore::WalkBuilder;
+
+/// Directory names never worth walking into, matching the `--walker-skip` list
+/// this replaced. `.gitignore` covers most build output; these are the
+/// directories that are commonly *not* ignored yet never worth offering.
+const WALKER_SKIP: &[&str] = &[
+    ".git",
+    "node_modules",
+    ".clj-kondo",
+    ".cpcache",
+    ".venv",
+    "lib",
+];
+
+/// List files under `root`, as paths relative to `root`, sorted.
+///
+/// Dotfiles are included — config files are common targets — while ignore
+/// files and [`WALKER_SKIP`] are respected.
+pub fn list_files(root: &Path) -> Result<Vec<String>> {
+    let walker = WalkBuilder::new(root)
+        .hidden(false) // include dotfiles; config files are common targets
+        .require_git(false) // honour .gitignore/.ignore even outside a git repo
+        .add_custom_ignore_filename(".fdignore") // shared with fd, if the user has one
+        .filter_entry(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_none_or(|name| !WALKER_SKIP.contains(&name))
+        })
+        .build();
+
+    let mut files = Vec::new();
+    for entry in walker {
+        let entry = entry.context("walking the directory")?;
+        if entry.file_type().is_some_and(|ft| ft.is_file()) {
+            let path = entry.path();
+            let rel = path.strip_prefix(root).unwrap_or(path);
+            files.push(rel.to_string_lossy().into_owned());
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn list_files_walks_and_skips() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        fs::write(root.join("a.txt"), "").unwrap();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(root.join("src/main.rs"), "").unwrap();
+        // A skipped directory and a gitignored file must not appear.
+        fs::create_dir_all(root.join("node_modules/pkg")).unwrap();
+        fs::write(root.join("node_modules/pkg/index.js"), "").unwrap();
+        fs::write(root.join(".gitignore"), "ignored.txt\n").unwrap();
+        fs::write(root.join("ignored.txt"), "").unwrap();
+
+        let got = list_files(root).unwrap();
+
+        assert!(got.contains(&"a.txt".to_string()));
+        assert!(got.contains(&"src/main.rs".to_string()));
+        assert!(got.contains(&".gitignore".to_string())); // dotfiles included
+        assert!(
+            !got.iter().any(|f| f.contains("node_modules")),
+            "WALKER_SKIP dir leaked: {got:?}"
+        );
+        assert!(
+            !got.contains(&"ignored.txt".to_string()),
+            ".gitignore not honoured: {got:?}"
+        );
+    }
+
+    /// fd reads `.fdignore` in addition to `.gitignore`; a user who keeps one
+    /// expects the same paths to stay out of scriv's pickers.
+    #[test]
+    fn list_files_honours_fdignore() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        fs::write(root.join("keep.txt"), "").unwrap();
+        fs::write(root.join(".fdignore"), "drop.txt\n").unwrap();
+        fs::write(root.join("drop.txt"), "").unwrap();
+
+        let got = list_files(root).unwrap();
+
+        assert!(got.contains(&"keep.txt".to_string()));
+        assert!(
+            !got.contains(&"drop.txt".to_string()),
+            ".fdignore not honoured: {got:?}"
+        );
+    }
+}


### PR DESCRIPTION
Replaces a hand-rolled `fzf | xargs $EDITOR` pipeline with a built-in command.

```fish
scriv edit              # pick a file below $PWD, open it in your editor
scriv edit --tracked    # pick from the tracked list instead
scriv edit src/main.rs  # skip the picker
fe                      # the same thing, under the name it gets aliased to
```

`tab` marks several and they open together. The walk honours `.gitignore`,
`.ignore` and now `.fdignore`.

## Why a top-level verb, and not a `file` subcommand

`repo`/`file`/`branch`/`pr` are each a *registry* — a set scriv knows about,
with `ls`/`pick` and a verb over that set. Searching the directory you happen to
be standing in is not one of those, and it has no `ls` or `add`.

Two alternatives were weighed and dropped:

- **`scriv file edit`.** More defensible than it looks, since `file add` already
  picks from the cwd — the group is already mixed-scope. But it reads as "edit a
  tracked file", which is the wrong default.
- **Renaming `file` to `tracked` and giving the new thing that name.** Costs a
  breaking rename across the CLI, fish functions, completions, README and demo
  tape, and "tracked" collides with git's own sense of the word — arguably a
  worse ambiguity than the one it fixes. A distinct verb disambiguates for free.

## Notes

- **No shell wrapper needed.** Only changing the parent's directory requires help
  from the shell, which is why `repo pick` prints a path for fish to consume.
  `edit` spawns the editor directly. Verified under a pty that skim fully
  restores the terminal — exits alt-screen, restores the cursor, drops mouse
  modes — before the editor takes it over.
- **Editor resolution** is the `editor` config key, then `$VISUAL`, then
  `$EDITOR`, resolved once in `Ctx` like every other environment lookup and
  shown by `config print`. Blank values count as unset, since `EDITOR=""` is a
  common way to say "no editor".
- **Key bindings:** `alt-e` for the new picker; `f3` keeps the tracked list.
  `fe` is the one unprefixed name scriv defines — there is a test pinning that,
  so the integration cannot quietly grow more.
- The first commit extracts the `ignore`-crate walk out of `file add` into
  `walk.rs` so both callers share it; it builds and tests green on its own.

## Docs

Per the checklist this PR also adds to CLAUDE.md:

- **CLI help text** — `edit` and `--tracked` have doc comments; `EXAMPLES` gained
  two lines.
- **README** — feature table, a `Commands` subsection, the key-binding table, the
  `fe` alias, and the sample `config.toml`.
- **`docs/demo.gif`** — **no re-record.** Nothing changed what an existing picker
  shows on screen. `make demo-check` passes, so the tape still renders.

`make` is green: fmt, clippy `-D warnings`, 116 tests, release build.