### PR TITLE
Stream the file walk into the picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,11 @@ scriv edit src/main.rs  # skip the picker
 ```
 
 Select several with `tab` and they open together. The walk honours
-`.gitignore`, `.ignore` and `.fdignore`. The editor is `$VISUAL`, then
-`$EDITOR`, unless the config sets `editor`. `edit` abbreviates to `e`.
+`.gitignore`, `.ignore` and `.fdignore`, streams into the picker as it goes —
+so a directory of a million files is typeable in milliseconds, not once the
+last one is found — and quietly skips paths it is not allowed to read. The
+editor is `$VISUAL`, then `$EDITOR`, unless the config sets `editor`. `edit`
+abbreviates to `e`.
 
 Every `pick` prints one line and nothing else, so it composes:
 

--- a/src/cmd/branch.rs
+++ b/src/cmd/branch.rs
@@ -214,9 +214,9 @@ mod tests {
     fn rows_mark_head_and_return_the_branch_name() {
         let items = items(&branches());
         assert!(items[0].label.starts_with("* main"));
-        assert_eq!(items[0].value, "main");
+        assert_eq!(items[0].value(), "main");
         assert!(items[1].label.starts_with("  origin/feature"));
-        assert_eq!(items[1].value, "origin/feature");
+        assert_eq!(items[1].value(), "origin/feature");
     }
 
     #[test]

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -15,7 +15,7 @@ use std::process::Command;
 use anyhow::{Result, anyhow, bail};
 
 use crate::path::{display_path, expand_tilde};
-use crate::pick::{PickItem, file_preview};
+use crate::pick::{PickItem, Preview, file_preview};
 use crate::{Ctx, Reported, files, pick, walk};
 
 /// `scriv edit [FILE]...` — open `paths`, or pick interactively when empty.
@@ -49,23 +49,24 @@ pub fn run(ctx: &Ctx, paths: &[String], tracked: bool) -> Result<()> {
 }
 
 /// Choose files from the current directory tree.
+///
+/// The walk is streamed into the picker rather than collected first: a home
+/// directory can hold a million files, and waiting out the last one before
+/// showing the first is the difference between a picker that opens instantly
+/// and one that appears to hang. An empty tree simply gives an empty picker,
+/// as it would in `fzf`.
 fn pick_from_cwd(ctx: &Ctx) -> Result<Option<Vec<String>>> {
-    let candidates = walk::list_files(Path::new("."))?;
-    if candidates.is_empty() {
-        bail!("no files found in the current directory");
-    }
-
     // Paths stay relative to the working directory: the editor is launched from
     // it, and relative paths are what shows up in its buffer list.
-    let items = candidates
-        .into_iter()
-        .map(|file| {
-            let preview = file_preview(&file);
-            PickItem::plain(file).preview(preview)
-        })
-        .collect();
+    let items =
+        walk::files(Path::new(".")).map(|file| PickItem::plain(file).preview(Preview::File));
 
-    cancellable(pick::pick_many(items, "Edit", &ctx.config.picker))
+    cancellable(pick::pick_many_streamed(
+        items,
+        "Edit",
+        true,
+        &ctx.config.picker,
+    ))
 }
 
 /// Choose files from the known-files list.

--- a/src/cmd/file.rs
+++ b/src/cmd/file.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use anyhow::{Result, bail};
 
 use crate::path::{display_path, expand_tilde, sanitize_file_path};
-use crate::pick::{PickItem, file_preview};
+use crate::pick::{PickItem, Preview, file_preview};
 use crate::term;
 use crate::{Ctx, files, pick, walk};
 
@@ -168,20 +168,13 @@ pub fn pick(ctx: &Ctx) -> Result<()> {
 
 /// Interactively choose a file from the current directory tree to add.
 ///
-/// Returns `Ok(None)` when the user cancels the picker.
+/// The walk is streamed into the picker, so it opens on the first filename
+/// rather than the last — see [`crate::cmd::edit`]. Returns `Ok(None)` when the
+/// user cancels the picker.
 fn pick_from_cwd(ctx: &Ctx) -> Result<Option<String>> {
-    let candidates = walk::list_files(Path::new("."))?;
-    if candidates.is_empty() {
-        bail!("no files found in the current directory");
-    }
-    let items = candidates
-        .into_iter()
-        .map(|file| {
-            let preview = file_preview(&file);
-            PickItem::plain(file).preview(preview)
-        })
-        .collect();
-    match pick::pick_one(items, "Add a file", &ctx.config.picker) {
+    let items =
+        walk::files(Path::new(".")).map(|file| PickItem::plain(file).preview(Preview::File));
+    match pick::pick_one_streamed(items, "Add a file", true, &ctx.config.picker) {
         Ok(choice) => Ok(Some(choice)),
         Err(e) if e.is::<pick::Cancelled>() => Ok(None),
         Err(e) => Err(e),

--- a/src/cmd/pr.rs
+++ b/src/cmd/pr.rs
@@ -177,8 +177,8 @@ mod tests {
     #[test]
     fn rows_return_the_pr_number() {
         let items = items(&prs());
-        assert_eq!(items[0].value, "7");
-        assert_eq!(items[1].value, "123");
+        assert_eq!(items[0].value(), "7");
+        assert_eq!(items[1].value(), "123");
     }
 
     #[test]
@@ -222,9 +222,8 @@ mod tests {
     /// returns.
     #[test]
     fn preview_normalises_line_endings() {
-        let text = match preview(&prs()[0]) {
-            Preview::Text(text) => text,
-            Preview::Command(_) => panic!("expected text"),
+        let Preview::Text(text) = preview(&prs()[0]) else {
+            panic!("expected text");
         };
         assert!(!text.contains('\r'), "CRLF leaked into the preview");
     }

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -5,8 +5,15 @@
 //! goes through here, so selection looks and behaves the same everywhere.
 //!
 //! Items carry a separate [`PickItem::label`] (shown and fuzzy-matched) and
-//! [`PickItem::value`] (returned on selection), so the picker can show a
-//! `~`-collapsed path or a group tag while still returning an absolute path.
+//! value (returned on selection), so the picker can show a `~`-collapsed path
+//! or a group tag while still returning an absolute path.
+//!
+//! Rows can arrive either all at once ([`pick_one`], [`pick_many`]) or as they
+//! are discovered ([`pick_one_streamed`], [`pick_many_streamed`]) — the latter
+//! is what makes a walk of a large tree usable, since the picker opens on the
+//! first rows instead of the last.
+
+use std::time::{Duration, Instant};
 
 use anyhow::{Result, anyhow};
 use ratatui::style::Color;
@@ -42,6 +49,11 @@ pub enum Preview {
     /// paid per look, not per item. skim exports `COLUMNS` and `ROWS` to it,
     /// for tools that wrap their own output.
     Command(String),
+    /// The row's own value, previewed as a file — [`file_preview`] built when
+    /// the row is highlighted rather than when the row is created. A streamed
+    /// walk can produce a million rows, and a formatted command string on each
+    /// of them is a hundred megabytes of panes nobody looks at.
+    File,
 }
 
 /// Quote `arg` for the shell that runs a [`Preview::Command`], so a branch name
@@ -57,20 +69,28 @@ pub fn quote(arg: &str) -> String {
 /// gone — which the known-files list expects to happen. Both are bounded to
 /// 200 lines, so scrolling a list never reads a large file in full.
 pub fn file_preview(path: &str) -> Preview {
-    let path = quote(path);
-    Preview::Command(format!(
-        "bat --color=always --style=plain --line-range=:200 -- {path} 2>/dev/null \
-         || head -n 200 -- {path}"
-    ))
+    Preview::Command(file_preview_cmd(path))
 }
 
-/// One choice in the picker: `label` is displayed and matched against, `value`
-/// is returned when it is selected, `color` optionally tints the row (an ANSI
-/// 256-colour index, so it respects the terminal theme), and `preview` fills
-/// the preview pane while the row is highlighted.
+/// The command behind [`Preview::File`] and [`file_preview`].
+fn file_preview_cmd(path: &str) -> String {
+    let path = quote(path);
+    format!(
+        "bat --color=always --style=plain --line-range=:200 -- {path} 2>/dev/null \
+         || head -n 200 -- {path}"
+    )
+}
+
+/// One choice in the picker: `label` is displayed and matched against,
+/// [`PickItem::value`] is returned when it is selected, `color` optionally
+/// tints the row (an ANSI 256-colour index, so it respects the terminal
+/// theme), and `preview` fills the preview pane while the row is highlighted.
 pub struct PickItem {
     pub label: String,
-    pub value: String,
+    /// `None` when the value is the label itself, which is the common case for
+    /// path rows — worth not storing twice when a walk streams in a million of
+    /// them. Read it through [`PickItem::value`].
+    value: Option<String>,
     pub color: Option<u8>,
     pub preview: Option<Preview>,
 }
@@ -78,10 +98,9 @@ pub struct PickItem {
 impl PickItem {
     /// An item whose displayed label is also its returned value.
     pub fn plain(text: impl Into<String>) -> Self {
-        let text = text.into();
         Self {
-            label: text.clone(),
-            value: text,
+            label: text.into(),
+            value: None,
             color: None,
             preview: None,
         }
@@ -91,10 +110,15 @@ impl PickItem {
     pub fn new(label: impl Into<String>, value: impl Into<String>) -> Self {
         Self {
             label: label.into(),
-            value: value.into(),
+            value: Some(value.into()),
             color: None,
             preview: None,
         }
+    }
+
+    /// What selecting this row yields — the label unless one was set apart.
+    pub fn value(&self) -> &str {
+        self.value.as_deref().unwrap_or(&self.label)
     }
 
     /// Tint the row with an ANSI 256-colour index.
@@ -114,34 +138,32 @@ impl PickItem {
 /// `output()` is what a selection yields, `display()` tints the row, and
 /// `preview()` fills the preview pane.
 struct SkItem {
-    label: String,
-    value: String,
-    color: Option<u8>,
-    preview: Option<Preview>,
+    item: PickItem,
 }
 
 impl SkimItem for SkItem {
     fn text(&self) -> Cow<'_, str> {
-        Cow::Borrowed(&self.label)
+        Cow::Borrowed(&self.item.label)
     }
 
     fn output(&self) -> Cow<'_, str> {
-        Cow::Borrowed(&self.value)
+        Cow::Borrowed(self.item.value())
     }
 
     fn display(&self, mut context: DisplayContext) -> Line<'_> {
         // Tint the whole row in the group's colour; skim still overlays its
         // match highlighting on top via `to_line`.
-        if let Some(idx) = self.color {
+        if let Some(idx) = self.item.color {
             context.base_style = context.base_style.fg(Color::Indexed(idx));
         }
         context.to_line(self.text())
     }
 
     fn preview(&self, _context: PreviewContext) -> ItemPreview {
-        match &self.preview {
+        match &self.item.preview {
             Some(Preview::Text(text)) => ItemPreview::AnsiText(text.clone()),
             Some(Preview::Command(cmd)) => ItemPreview::Command(cmd.clone()),
+            Some(Preview::File) => ItemPreview::Command(file_preview_cmd(self.item.value())),
             // Blank rather than `Global`, which would run the (empty) global
             // preview command for rows that have nothing to show.
             None => ItemPreview::Text(String::new()),
@@ -153,20 +175,132 @@ impl SkimItem for SkItem {
 /// error on cancel; the caller decides whether that is a silent exit or a
 /// failure.
 pub fn pick_one(items: Vec<PickItem>, prompt: &str, cfg: &PickerConfig) -> Result<String> {
-    run(items, prompt, false, cfg)?
-        .into_iter()
-        .next()
-        .ok_or_else(|| Cancelled.into())
+    one(Feed::batch(items), prompt, cfg)
 }
 
 /// Pick zero or more items, returning their values. An empty result means the
 /// user selected nothing; cancelling still yields [`Cancelled`].
 pub fn pick_many(items: Vec<PickItem>, prompt: &str, cfg: &PickerConfig) -> Result<Vec<String>> {
-    run(items, prompt, true, cfg)
+    run(Feed::batch(items), prompt, true, cfg)
 }
 
-/// Drive skim over `items` and return the selected values.
-fn run(items: Vec<PickItem>, prompt: &str, multi: bool, cfg: &PickerConfig) -> Result<Vec<String>> {
+/// [`pick_one`] over rows that arrive as they are found.
+///
+/// The picker opens immediately and fills in as `items` yields, so the user can
+/// type against the first rows while the rest are still being discovered.
+/// Because no row exists yet when the pane is configured, whether previews are
+/// offered has to be stated up front in `preview`.
+pub fn pick_one_streamed(
+    items: impl IntoIterator<Item = PickItem, IntoIter: Send + 'static>,
+    prompt: &str,
+    preview: bool,
+    cfg: &PickerConfig,
+) -> Result<String> {
+    one(Feed::stream(items, preview), prompt, cfg)
+}
+
+/// [`pick_many`] over rows that arrive as they are found. See
+/// [`pick_one_streamed`].
+pub fn pick_many_streamed(
+    items: impl IntoIterator<Item = PickItem, IntoIter: Send + 'static>,
+    prompt: &str,
+    preview: bool,
+    cfg: &PickerConfig,
+) -> Result<Vec<String>> {
+    run(Feed::stream(items, preview), prompt, true, cfg)
+}
+
+fn one(feed: Feed, prompt: &str, cfg: &PickerConfig) -> Result<String> {
+    run(feed, prompt, false, cfg)?
+        .into_iter()
+        .next()
+        .ok_or_else(|| Cancelled.into())
+}
+
+/// Rows to feed skim, and whether any of them can fill the preview pane.
+struct Feed {
+    rows: Rows,
+    preview: bool,
+}
+
+enum Rows {
+    /// Every row known before the picker opens.
+    Batch(Vec<PickItem>),
+    /// Rows produced over time, drained on a background thread.
+    Stream(Box<dyn Iterator<Item = PickItem> + Send>),
+}
+
+/// How many rows to accumulate before handing a batch to skim, and how long to
+/// let one sit unsent. Sending each row on its own would put a million channel
+/// round-trips in front of a walk; 15ms is under a frame, so the picker still
+/// fills in as fast as the eye reads it.
+const FEED_BATCH: usize = 512;
+const FEED_INTERVAL: Duration = Duration::from_millis(15);
+
+impl Feed {
+    fn batch(items: Vec<PickItem>) -> Self {
+        let preview = items.iter().any(|item| item.preview.is_some());
+        Self {
+            rows: Rows::Batch(items),
+            preview,
+        }
+    }
+
+    fn stream(
+        items: impl IntoIterator<Item = PickItem, IntoIter: Send + 'static>,
+        preview: bool,
+    ) -> Self {
+        Self {
+            rows: Rows::Stream(Box::new(items.into_iter())),
+            preview,
+        }
+    }
+
+    /// Hand the rows to `tx`, closing it when they run out — that is how skim
+    /// learns the source is exhausted and stops showing itself as still
+    /// reading.
+    fn send(self, tx: SkimItemSender) -> Result<()> {
+        match self.rows {
+            Rows::Batch(items) => {
+                let batch: Vec<Arc<dyn SkimItem>> = items.into_iter().map(into_skim).collect();
+                tx.send(batch).map_err(|e| anyhow!("feeding picker: {e}"))?;
+            }
+            Rows::Stream(items) => {
+                // Detached: `Skim::run_with` has returned by the time the walk
+                // notices the picker is gone, and there is nothing to join for.
+                std::thread::spawn(move || {
+                    let mut batch: Vec<Arc<dyn SkimItem>> = Vec::with_capacity(FEED_BATCH);
+                    let mut flushed = Instant::now();
+                    for item in items {
+                        batch.push(into_skim(item));
+                        if batch.len() < FEED_BATCH && flushed.elapsed() < FEED_INTERVAL {
+                            continue;
+                        }
+                        let full = std::mem::replace(&mut batch, Vec::with_capacity(FEED_BATCH));
+                        // A closed channel means the user has selected or
+                        // cancelled: stop walking rather than spend the rest of
+                        // the tree on a picker that is no longer there.
+                        if tx.send(full).is_err() {
+                            return;
+                        }
+                        flushed = Instant::now();
+                    }
+                    if !batch.is_empty() {
+                        let _ = tx.send(batch);
+                    }
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+fn into_skim(item: PickItem) -> Arc<dyn SkimItem> {
+    Arc::new(SkItem { item }) as Arc<dyn SkimItem>
+}
+
+/// Drive skim over `feed` and return the selected values.
+fn run(feed: Feed, prompt: &str, multi: bool, cfg: &PickerConfig) -> Result<Vec<String>> {
     // skim needs a terminal for its UI. Fail with a clear message rather than
     // skim's raw "Device not configured" when there is none (e.g. in a pipe
     // with no controlling tty). Command substitution — `cd (scriv repo pick)` —
@@ -187,7 +321,7 @@ fn run(items: Vec<PickItem>, prompt: &str, multi: bool, cfg: &PickerConfig) -> R
     // `preview()` above supplies the actual content, so an empty string is
     // enough to turn it on. Skipped entirely when no item has a preview, so
     // pickers without one keep the full width.
-    if cfg.preview && items.iter().any(|item| item.preview.is_some()) {
+    if cfg.preview && feed.preview {
         builder
             .preview("")
             .preview_window(cfg.preview_window.as_str());
@@ -197,21 +331,10 @@ fn run(items: Vec<PickItem>, prompt: &str, multi: bool, cfg: &PickerConfig) -> R
         .build()
         .map_err(|e| anyhow!("configuring picker: {e}"))?;
 
-    // Feed all items through a channel, then close it so skim stops waiting.
+    // Feed the items through a channel; the sender is dropped when they run
+    // out, which is how skim stops waiting for more.
     let (tx, rx): (SkimItemSender, SkimItemReceiver) = unbounded();
-    let batch: Vec<Arc<dyn SkimItem>> = items
-        .into_iter()
-        .map(|it| {
-            Arc::new(SkItem {
-                label: it.label,
-                value: it.value,
-                color: it.color,
-                preview: it.preview,
-            }) as Arc<dyn SkimItem>
-        })
-        .collect();
-    tx.send(batch).map_err(|e| anyhow!("feeding picker: {e}"))?;
-    drop(tx);
+    feed.send(tx)?;
 
     let output = Skim::run_with(options, Some(rx)).map_err(|e| anyhow!("running picker: {e}"))?;
 

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -8,7 +8,6 @@
 
 use std::path::Path;
 
-use anyhow::{Context, Result};
 use ignore::WalkBuilder;
 
 /// Directory names never worth walking into, matching the `--walker-skip` list
@@ -23,34 +22,44 @@ const WALKER_SKIP: &[&str] = &[
     "lib",
 ];
 
-/// List files under `root`, as paths relative to `root`, sorted.
+/// Files under `root`, as paths relative to `root`.
 ///
-/// Dotfiles are included — config files are common targets — while ignore
-/// files and [`WALKER_SKIP`] are respected.
-pub fn list_files(root: &Path) -> Result<Vec<String>> {
-    let walker = WalkBuilder::new(root)
+/// Lazy: the walk advances as the iterator is drained, so a picker fed from it
+/// opens on the first filename rather than the last. Dotfiles are included —
+/// config files are common targets — while ignore files and [`WALKER_SKIP`] are
+/// respected, and entries are sorted within each directory so the order is the
+/// same twice running.
+///
+/// **Unreadable paths are skipped, not reported.** This is `fzf`'s
+/// `find … 2>/dev/null`: a walk of `$HOME` on macOS crosses directories that
+/// only an app with Full Disk Access can read (`~/Library/CallHistory…` and
+/// friends), and failing the whole picker over one of them — or printing at a
+/// terminal skim is drawing on — is worse than leaving them out. There is
+/// nothing to grant from in here either: Full Disk Access is given to the
+/// terminal application, not to a process that asks for it.
+pub fn files(root: &Path) -> impl Iterator<Item = String> + Send + 'static {
+    let root = root.to_path_buf();
+    WalkBuilder::new(&root)
         .hidden(false) // include dotfiles; config files are common targets
         .require_git(false) // honour .gitignore/.ignore even outside a git repo
         .add_custom_ignore_filename(".fdignore") // shared with fd, if the user has one
+        .sort_by_file_path(Ord::cmp) // stable order, one directory at a time
         .filter_entry(|entry| {
             entry
                 .file_name()
                 .to_str()
                 .is_none_or(|name| !WALKER_SKIP.contains(&name))
         })
-        .build();
-
-    let mut files = Vec::new();
-    for entry in walker {
-        let entry = entry.context("walking the directory")?;
-        if entry.file_type().is_some_and(|ft| ft.is_file()) {
+        .build()
+        .filter_map(move |entry| {
+            let entry = entry.ok()?;
+            if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+                return None;
+            }
             let path = entry.path();
-            let rel = path.strip_prefix(root).unwrap_or(path);
-            files.push(rel.to_string_lossy().into_owned());
-        }
-    }
-    files.sort();
-    Ok(files)
+            let rel = path.strip_prefix(&root).unwrap_or(path);
+            Some(rel.to_string_lossy().into_owned())
+        })
 }
 
 #[cfg(test)]
@@ -59,8 +68,12 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
+    fn list(root: &Path) -> Vec<String> {
+        files(root).collect()
+    }
+
     #[test]
-    fn list_files_walks_and_skips() {
+    fn files_walks_and_skips() {
         let dir = TempDir::new().unwrap();
         let root = dir.path();
         fs::write(root.join("a.txt"), "").unwrap();
@@ -72,7 +85,7 @@ mod tests {
         fs::write(root.join(".gitignore"), "ignored.txt\n").unwrap();
         fs::write(root.join("ignored.txt"), "").unwrap();
 
-        let got = list_files(root).unwrap();
+        let got = list(root);
 
         assert!(got.contains(&"a.txt".to_string()));
         assert!(got.contains(&"src/main.rs".to_string()));
@@ -90,19 +103,68 @@ mod tests {
     /// fd reads `.fdignore` in addition to `.gitignore`; a user who keeps one
     /// expects the same paths to stay out of scriv's pickers.
     #[test]
-    fn list_files_honours_fdignore() {
+    fn files_honours_fdignore() {
         let dir = TempDir::new().unwrap();
         let root = dir.path();
         fs::write(root.join("keep.txt"), "").unwrap();
         fs::write(root.join(".fdignore"), "drop.txt\n").unwrap();
         fs::write(root.join("drop.txt"), "").unwrap();
 
-        let got = list_files(root).unwrap();
+        let got = list(root);
 
         assert!(got.contains(&"keep.txt".to_string()));
         assert!(
             !got.contains(&"drop.txt".to_string()),
             ".fdignore not honoured: {got:?}"
         );
+    }
+
+    /// A directory the user cannot read must cost its own subtree and nothing
+    /// else — on macOS a walk of `$HOME` hits several, and losing the whole
+    /// picker to one is what this replaced.
+    #[cfg(unix)]
+    #[test]
+    fn files_skips_unreadable_directories() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        fs::write(root.join("readable.txt"), "").unwrap();
+        let locked = root.join("locked");
+        fs::create_dir(&locked).unwrap();
+        fs::write(locked.join("hidden.txt"), "").unwrap();
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let got = list(root);
+
+        // Restore before the TempDir tries to remove it.
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(
+            got.contains(&"readable.txt".to_string()),
+            "an unreadable sibling swallowed the walk: {got:?}"
+        );
+        assert!(!got.iter().any(|f| f.contains("hidden.txt")));
+    }
+
+    /// The walk must not run ahead of what is asked of it — a picker fed from
+    /// it shows rows long before the tree is exhausted. Observed by writing
+    /// into a directory the walk has not reached yet: only a lazy walk can
+    /// still find it.
+    #[test]
+    fn files_is_lazy() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        fs::create_dir(root.join("a")).unwrap();
+        fs::write(root.join("a/early.txt"), "").unwrap();
+        fs::create_dir(root.join("b")).unwrap();
+
+        let mut walk = files(root);
+        assert_eq!(walk.next().as_deref(), Some("a/early.txt"));
+        fs::write(root.join("b/late.txt"), "").unwrap();
+
+        let rest: Vec<String> = walk.collect();
+
+        assert_eq!(rest, vec!["b/late.txt".to_string()]);
     }
 }


### PR DESCRIPTION
`scriv edit` and `file add` collected the entire directory tree, sorted it, and built a preview command for every row before skim was allowed to open. In a home directory of a million files that is sixteen seconds of nothing, and a single unreadable path — macOS keeps several under `~/Library` that no terminal-launched process may enter — failed the whole command:

```
error: walking the directory: ./Library/Application Support/CallHistoryTransactions: Operation not permitted (os error 1)
```

Both are the same mistake: treating a walk as a value to be finished rather than a source to be read from.

## Streaming

`walk::files` is now a lazy iterator, fed to skim on a background thread in batches of 512 rows or every 15ms, whichever comes first. Sending each row on its own would put a million channel round-trips in front of the walk; 15ms is under a frame, so the list still fills as fast as the eye reads it.

The feeder stops walking the moment the channel closes, so cancelling ends the walk rather than leaving it to finish into a picker nobody is looking at.

skim needed no changes for any of this — its reader already drains the channel incrementally and restarts the matcher while the source is live.

Measured over a `$HOME` of 1,117,980 files:

| | |
| --- | --- |
| first row | 2ms |
| 20,000 rows | 188ms |
| full walk (background) | 16.5s |

Entries are sorted within each directory, so the order is the same twice running without buffering the tree.

## Permission errors

Unreadable paths are skipped rather than reported, which is what `fzf` does with its `2>/dev/null` and the only thing that makes a walk of `$HOME` work at all. There is nothing to prompt for: Full Disk Access is granted to the terminal application in System Settings, not to a process that asks, and the protected paths are not worth offering anyway. A warning would have to be printed either over skim's own output or after the fact about paths nobody wanted.

## Falling out of a million rows

`PickItem` was built for twenty of them, and two things had to give:

- `Preview::File` renders the `bat`/`head` command when a row is highlighted instead of when the row is created.
- `PickItem`'s value is `None` when it equals the label, which is every path row. Read it through `PickItem::value()`.

Together, some 350MB not allocated for panes and strings that are never read.

## The one behaviour lost

The `no files found in the current directory` error is gone. With a stream there is no moment at which the tree is known to be empty before the picker opens, and guessing races the walk: cancel quickly in a large directory and it would claim the directory is empty. An empty tree now gives an empty picker, as it would in `fzf`.

## The three docs that go stale silently

- **CLI help text** — untouched. No command, flag or example changed.
- **README** — updated: the `edit` paragraph now says the walk streams and skips what it cannot read.
- **`docs/demo.gif`** — no re-record. `demo.tape` does not record `edit` or `file add`, and no other picker's rows changed.

## Testing

`make` is green. New tests in `walk.rs` cover the two behaviours this turns on: a directory with mode `0o000` costs its own subtree and nothing else, and the walk is observably lazy — a file written into a directory the walk has not reached yet still turns up.