### PR TITLE
Walk repositories and files in parallel, and stop losing symlinked checkouts

### DIFF
--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -3,6 +3,8 @@
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Context, Result, bail};
 
@@ -297,22 +299,22 @@ fn repo_items(repos: &[Repo], root: &Path) -> Vec<PickItem> {
         .map(|r| r.name().chars().count())
         .max()
         .unwrap_or(0);
-    let tag_width = repos
-        .iter()
-        .map(|r| r.tags().join(" ").chars().count())
-        .max()
-        .unwrap_or(0);
+    // Rendered once and reused for both the column width and the rows; the
+    // widest tag string cannot be known without formatting every one of them,
+    // and formatting them twice is the easy mistake.
+    let tags: Vec<String> = repos.iter().map(|r| r.tags().join(" ")).collect();
+    let tag_width = tags.iter().map(|t| t.chars().count()).max().unwrap_or(0);
 
     repos
         .iter()
-        .map(|repo| {
+        .zip(&tags)
+        .map(|(repo, tags)| {
             let dest = destination(root, repo.owner(), repo.name());
             let present = dest.exists();
             let marker = if present { "✓" } else { " " };
             let label = format!(
                 "{marker} {name:<width$}  {tags:<tag_width$}  {description}",
                 name = repo.name(),
-                tags = repo.tags().join(" "),
                 description = repo.description.trim(),
             );
             let item = PickItem::new(label.trim_end(), repo.name_with_owner.clone())
@@ -326,43 +328,51 @@ fn repo_items(repos: &[Repo], root: &Path) -> Vec<PickItem> {
         .collect()
 }
 
-/// Clone `repos` concurrently into `root`, in batches of [`CLONE_CONCURRENCY`].
+/// Clone `repos` into `root`, [`CLONE_CONCURRENCY`] at a time.
+///
+/// The workers pull from a shared queue rather than working through fixed
+/// batches. Clone times vary by orders of magnitude — one large repository
+/// among thirty small ones is the normal case — and a batch that waits for its
+/// slowest member leaves every other worker idle until it finishes.
 ///
 /// Every clone is reported, in the order it was requested rather than the order
 /// it finished, so the summary is stable and readable. One failure does not
 /// stop the others: a rate-limited or renamed repository should not cost you
 /// the nine that were fine.
 fn clone_all(ctx: &Ctx, root: &Path, repos: &[String]) -> Result<usize> {
-    let mut failures = 0;
-    for batch in repos.chunks(CLONE_CONCURRENCY) {
-        let results: Vec<(String, Result<PathBuf>)> = std::thread::scope(|scope| {
-            let handles: Vec<_> = batch
-                .iter()
-                .map(|slug| {
-                    scope.spawn(move || {
-                        let (owner, name) = slug.split_once('/').unwrap_or(("", slug.as_str()));
-                        let dest = destination(root, owner, name);
-                        gh::clone(slug, &dest).map(|()| dest)
-                    })
-                })
-                .collect();
-            batch
-                .iter()
-                .cloned()
-                .zip(handles.into_iter().map(|h| {
-                    h.join()
-                        .unwrap_or_else(|_| Err(anyhow::anyhow!("clone worker panicked")))
-                }))
-                .collect()
-        });
+    let next = AtomicUsize::new(0);
+    let done: Mutex<Vec<(usize, Result<PathBuf>)>> = Mutex::new(Vec::with_capacity(repos.len()));
 
-        for (slug, result) in results {
-            match result {
-                Ok(dest) => println!("cloned {slug} -> {}", dest.display()),
-                Err(err) => {
-                    failures += 1;
-                    eprintln!("error: {slug}: {err:#}");
+    std::thread::scope(|scope| {
+        for _ in 0..CLONE_CONCURRENCY.min(repos.len()) {
+            scope.spawn(|| {
+                loop {
+                    let index = next.fetch_add(1, Ordering::Relaxed);
+                    let Some(slug) = repos.get(index) else { break };
+                    let (owner, name) = slug.split_once('/').unwrap_or(("", slug.as_str()));
+                    let dest = destination(root, owner, name);
+                    let result = gh::clone(slug, &dest).map(|()| dest);
+                    // A worker that panicked mid-clone poisons this; the
+                    // results already collected are still worth reporting.
+                    done.lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .push((index, result));
                 }
+            });
+        }
+    });
+
+    let mut results = done.into_inner().unwrap_or_else(|e| e.into_inner());
+    results.sort_by_key(|(index, _)| *index);
+
+    let mut failures = 0;
+    for (index, result) in results {
+        let slug = &repos[index];
+        match result {
+            Ok(dest) => println!("cloned {slug} -> {}", dest.display()),
+            Err(err) => {
+                failures += 1;
+                eprintln!("error: {slug}: {err:#}");
             }
         }
     }

--- a/src/files.rs
+++ b/src/files.rs
@@ -74,15 +74,19 @@ fn temp_name() -> String {
 
 /// Normalise list entries for persistence: trim each line, drop blanks, remove
 /// duplicates, and sort so the written file is deterministic.
+///
+/// Deduped by sorting rather than through a set: the output is sorted either
+/// way, and a `HashSet` would need its own copy of every entry to hold the keys
+/// it compares against.
 pub fn normalize_entries(lines: &[String]) -> Vec<String> {
-    let mut seen = HashSet::new();
     let mut result: Vec<String> = lines
         .iter()
-        .map(|l| l.trim().to_string())
+        .map(|l| l.trim())
         .filter(|l| !l.is_empty())
-        .filter(|l| seen.insert(l.clone()))
+        .map(str::to_string)
         .collect();
     result.sort();
+    result.dedup();
     result
 }
 

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -182,23 +182,40 @@ impl Check {
 fn result_for(status: &str, conclusion: &str, state: &str) -> CheckResult {
     // A `StatusContext` says everything in one field.
     if !state.is_empty() {
-        return match state.to_ascii_uppercase().as_str() {
-            "SUCCESS" => CheckResult::Pass,
-            "PENDING" | "EXPECTED" => CheckResult::Pending,
-            _ => CheckResult::Fail, // FAILURE, ERROR
+        return if is(state, &["SUCCESS"]) {
+            CheckResult::Pass
+        } else if is(state, &["PENDING", "EXPECTED"]) {
+            CheckResult::Pending
+        } else {
+            CheckResult::Fail // FAILURE, ERROR
         };
     }
     // A `CheckRun` that has not finished is pending whatever else it says.
     if !status.is_empty() && !status.eq_ignore_ascii_case("COMPLETED") {
         return CheckResult::Pending;
     }
-    match conclusion.to_ascii_uppercase().as_str() {
-        "SUCCESS" | "SKIPPED" | "NEUTRAL" => CheckResult::Pass,
-        // Finished with nothing to say: not yet reported, so not yet a verdict.
-        "" => CheckResult::Pending,
-        // FAILURE, TIMED_OUT, CANCELLED, ACTION_REQUIRED, STARTUP_FAILURE.
-        _ => CheckResult::Fail,
+    // Finished with nothing to say: not yet reported, so not yet a verdict.
+    if conclusion.is_empty() {
+        return CheckResult::Pending;
     }
+    if is(conclusion, &["SUCCESS", "SKIPPED", "NEUTRAL"]) {
+        CheckResult::Pass
+    } else {
+        // FAILURE, TIMED_OUT, CANCELLED, ACTION_REQUIRED, STARTUP_FAILURE.
+        CheckResult::Fail
+    }
+}
+
+/// Whether `value` is one of `options`, ignoring case.
+///
+/// `gh`'s enums are conventionally upper case but not guaranteed to be, so
+/// every comparison here is case-insensitive. Matching in place rather than
+/// upper-casing first is what keeps it allocation-free: these run once per
+/// check per pull request, several times over while a listing is built.
+fn is(value: &str, options: &[&str]) -> bool {
+    options
+        .iter()
+        .any(|option| value.eq_ignore_ascii_case(option))
 }
 
 /// How a pull request's checks add up: the counts, and the one-word verdict
@@ -305,10 +322,12 @@ pub enum Mergeable {
 
 impl Mergeable {
     pub fn parse(raw: &str) -> Self {
-        match raw.to_ascii_uppercase().as_str() {
-            "MERGEABLE" => Self::Clean,
-            "CONFLICTING" => Self::Conflicting,
-            _ => Self::Unknown,
+        if is(raw, &["MERGEABLE"]) {
+            Self::Clean
+        } else if is(raw, &["CONFLICTING"]) {
+            Self::Conflicting
+        } else {
+            Self::Unknown
         }
     }
 
@@ -410,14 +429,23 @@ impl PullRequest {
 
     /// The checks that are not passing, failures first — the ones worth naming
     /// in a preview, since a list of thirty green jobs says nothing.
+    ///
+    /// Partitioned in one pass rather than filtered and then sorted: a sort key
+    /// is called once per comparison, so deriving the verdict inside one would
+    /// re-derive it O(n log n) times over. Both halves keep the rollup's own
+    /// order, which is what the sort gave.
     pub fn failing_checks(&self) -> Vec<&Check> {
-        let mut out: Vec<&Check> = self
-            .status_check_rollup
-            .iter()
-            .filter(|c| c.result() != CheckResult::Pass)
-            .collect();
-        out.sort_by_key(|c| c.result() != CheckResult::Fail);
-        out
+        let mut failed = Vec::new();
+        let mut pending = Vec::new();
+        for check in &self.status_check_rollup {
+            match check.result() {
+                CheckResult::Pass => {}
+                CheckResult::Fail => failed.push(check),
+                CheckResult::Pending => pending.push(check),
+            }
+        }
+        failed.append(&mut pending);
+        failed
     }
 
     /// Just the date part of [`Self::updated_at`]; `gh` reports no relative
@@ -439,20 +467,26 @@ impl PullRequest {
 /// Colour a PR by what can be done with it: a draft is not ready to review, a
 /// merged or closed one is history.
 fn color_for(is_draft: bool, state: &str) -> u8 {
-    match state.to_ascii_uppercase().as_str() {
-        "MERGED" => 5,      // magenta
-        "CLOSED" => 1,      // red
-        _ if is_draft => 8, // bright black — open but draft
-        _ => 2,             // green — open and ready
+    if is(state, &["MERGED"]) {
+        5 // magenta
+    } else if is(state, &["CLOSED"]) {
+        1 // red
+    } else if is_draft {
+        8 // bright black — open but draft
+    } else {
+        2 // green — open and ready
     }
 }
 
 fn tag_for(is_draft: bool, state: &str) -> &'static str {
-    match state.to_ascii_uppercase().as_str() {
-        "MERGED" => "merged",
-        "CLOSED" => "closed",
-        _ if is_draft => "draft",
-        _ => "open",
+    if is(state, &["MERGED"]) {
+        "merged"
+    } else if is(state, &["CLOSED"]) {
+        "closed"
+    } else if is_draft {
+        "draft"
+    } else {
+        "open"
     }
 }
 
@@ -670,14 +704,17 @@ pub fn clone(name_with_owner: &str, dest: &Path) -> Result<()> {
 ///
 /// This is the answer to "which owners do you actually clone from" on a machine
 /// with nothing cloned yet, where looking at the filesystem would find nothing.
+///
+/// Failure is returned rather than swallowed. The caller treats these as
+/// suggestions and carries on without them, but "`gh` is not installed" and
+/// "you belong to no organisations" are different facts, and only one of them
+/// is worth telling the user about.
 pub fn owners() -> Result<Vec<String>> {
     let mut out = Vec::new();
-    if let Ok(login) = capture(&["api", "user", "--jq", ".login"]) {
-        out.extend(login.split_whitespace().map(str::to_string));
-    }
-    if let Ok(orgs) = capture(&["api", "user/orgs", "--jq", ".[].login"]) {
-        out.extend(orgs.split_whitespace().map(str::to_string));
-    }
+    let login = capture(&["api", "user", "--jq", ".login"])?;
+    out.extend(login.split_whitespace().map(str::to_string));
+    let orgs = capture(&["api", "user/orgs", "--jq", ".[].login"])?;
+    out.extend(orgs.split_whitespace().map(str::to_string));
     Ok(out)
 }
 
@@ -711,7 +748,18 @@ fn capture(args: &[&str]) -> Result<String> {
             stderr.to_string()
         });
     }
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    Ok(into_string(output.stdout))
+}
+
+/// Take ownership of a child's output as a `String`.
+///
+/// `String::from_utf8_lossy(&bytes).into_owned()` would copy the whole buffer
+/// even when it is already valid UTF-8, which it always is here — a `gh repo
+/// list` over a large organisation is megabytes of JSON. This reuses the
+/// buffer, and only pays the copy on the malformed input that would otherwise
+/// have been an error.
+fn into_string(bytes: Vec<u8>) -> String {
+    String::from_utf8(bytes).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
 }
 
 /// A missing `gh` is the one failure worth explaining, since PR support is the

--- a/src/git.rs
+++ b/src/git.rs
@@ -293,7 +293,12 @@ fn capture(args: &[&str]) -> Result<String> {
             stderr.to_string()
         });
     }
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    // Reuse the buffer rather than copying it: `for-each-ref` over a repository
+    // with thousands of refs is not small, and it is always valid UTF-8. The
+    // copy is paid only on the malformed output that would have been lossy
+    // anyway.
+    Ok(String::from_utf8(output.stdout)
+        .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned()))
 }
 
 /// Run git with `args`, letting it write straight to the terminal so its

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -124,6 +124,13 @@ pub fn find_all_repos(cfg: &Config, home: &Path, log: &Logger) -> Result<Vec<Fou
 /// Find directories containing a `.git` entry under `root`, descending at most
 /// `max_depth` levels. Directories whose basename is in `ignore` are skipped,
 /// and a discovered repository is not descended into.
+///
+/// The search runs one depth level at a time, with the directories at each
+/// level divided between worker threads. The work is almost entirely waiting on
+/// `stat` and `readdir` — on a cold cache a root of a hundred repositories
+/// spends most of its half-second latency-bound, one directory at a time — so
+/// overlapping the levels is what makes it quick. The number of *directories*
+/// visited is unchanged; they are simply not queued behind each other.
 fn find_repos(
     root: &Path,
     max_depth: usize,
@@ -131,25 +138,85 @@ fn find_repos(
     log: &Logger,
 ) -> Result<Vec<PathBuf>> {
     std::fs::metadata(root).with_context(|| format!("root path {}", root.display()))?;
+
     let mut repos = Vec::new();
-    walk(root, 0, max_depth, ignore, &mut repos, log);
+    let mut frontier = vec![root.to_path_buf()];
+
+    for depth in 0..=max_depth {
+        if frontier.is_empty() {
+            break;
+        }
+        let last = depth == max_depth;
+        let mut next = Vec::new();
+        for (found, children) in visit_level(&frontier, last, ignore, log) {
+            repos.extend(found);
+            next.extend(children);
+        }
+        frontier = next;
+    }
+
     Ok(repos)
 }
 
-fn walk(
-    dir: &Path,
-    depth: usize,
-    max_depth: usize,
+/// How many directories to look at concurrently. The work is I/O latency, not
+/// computation, so this is a concurrency figure rather than a CPU count — but
+/// the core count is a sane scale for it, and a machine that reports none gets
+/// a modest default rather than no parallelism at all.
+fn workers() -> usize {
+    std::thread::available_parallelism().map_or(4, |n| n.get())
+}
+
+/// Visit every directory in `level`, returning each one's discovered
+/// repositories and the subdirectories to look at next.
+///
+/// Results come back in `level` order regardless of which thread produced
+/// them, so a discovery run is reproducible.
+fn visit_level(
+    level: &[PathBuf],
+    last: bool,
     ignore: &[String],
-    repos: &mut Vec<PathBuf>,
     log: &Logger,
-) {
-    if dir.join(".git").exists() {
-        repos.push(dir.to_path_buf());
-        return;
+) -> Vec<(Vec<PathBuf>, Vec<PathBuf>)> {
+    let chunks: Vec<&[PathBuf]> = level
+        .chunks(level.len().div_ceil(workers()).max(1))
+        .collect();
+    if chunks.len() < 2 {
+        return level
+            .iter()
+            .map(|dir| visit(dir, last, ignore, log))
+            .collect();
     }
-    if depth >= max_depth {
-        return;
+
+    thread::scope(|scope| {
+        let handles: Vec<_> = chunks
+            .into_iter()
+            .map(|chunk| {
+                scope.spawn(move || {
+                    chunk
+                        .iter()
+                        .map(|dir| visit(dir, last, ignore, log))
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            // Re-raise rather than dropping a chunk: silently returning fewer
+            // repositories than exist is the one failure a picker cannot show.
+            // `find_all_repos` turns this into "discovery worker panicked".
+            .flat_map(|h| h.join().unwrap_or_else(|p| std::panic::resume_unwind(p)))
+            .collect()
+    })
+}
+
+/// Classify one directory: either it is a repository, or it contributes the
+/// subdirectories below it. `last` suppresses descending past the depth limit.
+fn visit(dir: &Path, last: bool, ignore: &[String], log: &Logger) -> (Vec<PathBuf>, Vec<PathBuf>) {
+    if dir.join(".git").exists() {
+        return (vec![dir.to_path_buf()], Vec::new());
+    }
+    if last {
+        return (Vec::new(), Vec::new());
     }
 
     let entries = match std::fs::read_dir(dir) {
@@ -159,10 +226,11 @@ fn walk(
                 "skipping unreadable path {}: {err}",
                 dir.display()
             ));
-            return;
+            return (Vec::new(), Vec::new());
         }
     };
 
+    let mut children = Vec::new();
     for entry in entries {
         let entry = match entry {
             Ok(entry) => entry,
@@ -174,11 +242,10 @@ fn walk(
                 continue;
             }
         };
-        let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
-        if !is_dir {
+        let path = entry.path();
+        if !is_dir(&entry, &path) {
             continue;
         }
-        let path = entry.path();
         let name = path
             .file_name()
             .and_then(|n| n.to_str())
@@ -187,7 +254,27 @@ fn walk(
             log.debug(&format!("skipping excluded dir {}", path.display()));
             continue;
         }
-        walk(&path, depth + 1, max_depth, ignore, repos, log);
+        children.push(path);
+    }
+    (Vec::new(), children)
+}
+
+/// Whether `entry` is a directory, **following symbolic links**.
+///
+/// [`DirEntry::file_type`](std::fs::DirEntry::file_type) reports on the link
+/// itself, so a symlinked checkout — or a symlinked owner directory, which
+/// takes every repository under it down too — reads as "not a directory" and
+/// vanishes from the listing without so much as a warning. Symlinking a
+/// repository into the root is an ordinary thing to do, and discovery is
+/// depth-capped, so the link is followed and the extra `stat` is paid only for
+/// the entries that are actually links.
+fn is_dir(entry: &std::fs::DirEntry, path: &Path) -> bool {
+    match entry.file_type() {
+        Ok(file_type) if file_type.is_symlink() => {
+            std::fs::metadata(path).is_ok_and(|meta| meta.is_dir())
+        }
+        Ok(file_type) => file_type.is_dir(),
+        Err(_) => false,
     }
 }
 
@@ -250,6 +337,55 @@ mod tests {
 
         let got = find_repos(root.path(), 0, &[], &quiet()).unwrap();
         assert_eq!(got, vec![root.path().to_path_buf()]);
+    }
+
+    /// A checkout symlinked into the root is a repository like any other.
+    /// `DirEntry::file_type` reports on the link, not its target, so both of
+    /// these used to read as "not a directory" and disappear — the symlinked
+    /// owner taking every repository beneath it along with it, and no warning
+    /// printed either way.
+    #[cfg(unix)]
+    #[test]
+    fn follows_symlinked_directories() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("root");
+        let away = tmp.path().join("away");
+        fs::create_dir_all(&root).unwrap();
+
+        // A symlinked repository, directly under the root.
+        let repo = mk_repo(&away, "linked-repo");
+        std::os::unix::fs::symlink(&repo, root.join("linked-repo")).unwrap();
+        // A symlinked owner directory, with a repository inside it.
+        let owner = away.join("owner");
+        let nested = mk_repo(&owner, "nested-repo");
+        std::os::unix::fs::symlink(&owner, root.join("owner")).unwrap();
+
+        let got = find_repos(&root, 2, &[], &quiet()).unwrap();
+
+        assert!(
+            got.contains(&root.join("linked-repo")),
+            "symlinked repository was skipped: {got:?}"
+        );
+        assert!(
+            got.contains(&root.join("owner").join("nested-repo")),
+            "repository under a symlinked owner was skipped: {got:?}"
+        );
+        // The targets exist where the links say they do.
+        assert!(repo.join(".git").exists() && nested.join(".git").exists());
+    }
+
+    /// Every level is walked concurrently, so a root wide enough to be split
+    /// across threads must still find everything exactly once.
+    #[test]
+    fn parallel_levels_find_every_repo() {
+        let root = TempDir::new().unwrap();
+        let mut expected: Vec<PathBuf> = (0..64)
+            .map(|i| mk_repo(root.path(), &format!("owner{}/repo{i}", i % 7)))
+            .collect();
+        expected.sort();
+
+        let got = find_repos(root.path(), 2, &[], &quiet()).unwrap();
+        assert_eq!(sorted(got), expected);
     }
 
     #[test]

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -7,8 +7,9 @@
 //! [fd]: https://github.com/sharkdp/fd
 
 use std::path::Path;
+use std::sync::mpsc::sync_channel;
 
-use ignore::WalkBuilder;
+use ignore::{WalkBuilder, WalkState};
 
 /// Directory names never worth walking into, matching the `--walker-skip` list
 /// this replaced. `.gitignore` covers most build output; these are the
@@ -22,13 +23,30 @@ const WALKER_SKIP: &[&str] = &[
     "lib",
 ];
 
+/// How many discovered paths may sit between the walk and whatever is reading
+/// it.
+///
+/// The walk runs on its own threads, so results the picker has not taken yet
+/// need somewhere to wait. Bounded, not unbounded: a walk of `$HOME` finds
+/// files faster than a picker consumes them, and an unbounded queue would hold
+/// the whole tree in memory to no purpose. A full queue blocks the walker
+/// threads, and that backpressure is what keeps the footprint flat however
+/// large the tree is.
+const QUEUE_BOUND: usize = 1024;
+
 /// Files under `root`, as paths relative to `root`.
 ///
-/// Lazy: the walk advances as the iterator is drained, so a picker fed from it
-/// opens on the first filename rather than the last. Dotfiles are included —
-/// config files are common targets — while ignore files and [`WALKER_SKIP`] are
-/// respected, and entries are sorted within each directory so the order is the
-/// same twice running.
+/// Streamed: rows are handed over as they are found, so a picker fed from this
+/// opens on the first filename rather than the last, and memory stays bounded
+/// by [`QUEUE_BOUND`] however large the tree. Dotfiles are included — config
+/// files are common targets — while ignore files and [`WALKER_SKIP`] are
+/// respected.
+///
+/// **The order is not specified.** The walk runs on several threads, which is
+/// worth roughly a threefold speedup on a large tree and costs the
+/// directory-at-a-time ordering a single-threaded walk gave for free. Nothing
+/// downstream depends on it: skim ranks rows by the query the moment one is
+/// typed, and the untyped order is arrival order either way.
 ///
 /// **Unreadable paths are skipped, not reported.** This is `fzf`'s
 /// `find … 2>/dev/null`: a walk of `$HOME` on macOS crosses directories that
@@ -39,27 +57,47 @@ const WALKER_SKIP: &[&str] = &[
 /// terminal application, not to a process that asks for it.
 pub fn files(root: &Path) -> impl Iterator<Item = String> + Send + 'static {
     let root = root.to_path_buf();
-    WalkBuilder::new(&root)
+    let (tx, rx) = sync_channel::<String>(QUEUE_BOUND);
+
+    let walker = WalkBuilder::new(&root)
         .hidden(false) // include dotfiles; config files are common targets
         .require_git(false) // honour .gitignore/.ignore even outside a git repo
         .add_custom_ignore_filename(".fdignore") // shared with fd, if the user has one
-        .sort_by_file_path(Ord::cmp) // stable order, one directory at a time
         .filter_entry(|entry| {
             entry
                 .file_name()
                 .to_str()
                 .is_none_or(|name| !WALKER_SKIP.contains(&name))
         })
-        .build()
-        .filter_map(move |entry| {
-            let entry = entry.ok()?;
-            if !entry.file_type().is_some_and(|ft| ft.is_file()) {
-                return None;
-            }
-            let path = entry.path();
-            let rel = path.strip_prefix(&root).unwrap_or(path);
-            Some(rel.to_string_lossy().into_owned())
-        })
+        .build_parallel();
+
+    // Detached: `run` blocks until the tree is exhausted, and the consumer has
+    // no reason to wait on it — dropping the receiver is how it is called off.
+    std::thread::spawn(move || {
+        walker.run(|| {
+            let tx = tx.clone();
+            let root = root.clone();
+            Box::new(move |entry| {
+                let Ok(entry) = entry else {
+                    return WalkState::Continue;
+                };
+                if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+                    return WalkState::Continue;
+                }
+                let path = entry.path();
+                let rel = path.strip_prefix(&root).unwrap_or(path);
+                match tx.send(rel.to_string_lossy().into_owned()) {
+                    Ok(()) => WalkState::Continue,
+                    // The receiver is gone: the user has selected or cancelled,
+                    // so stop walking rather than spend the rest of the tree on
+                    // a picker that is no longer there.
+                    Err(_) => WalkState::Quit,
+                }
+            })
+        });
+    });
+
+    rx.into_iter()
 }
 
 #[cfg(test)]
@@ -147,24 +185,27 @@ mod tests {
         assert!(!got.iter().any(|f| f.contains("hidden.txt")));
     }
 
-    /// The walk must not run ahead of what is asked of it — a picker fed from
-    /// it shows rows long before the tree is exhausted. Observed by writing
-    /// into a directory the walk has not reached yet: only a lazy walk can
-    /// still find it.
+    /// The walk hands rows over as it finds them, through a queue bounded by
+    /// [`QUEUE_BOUND`] — so a tree several times that size only finishes if the
+    /// walker threads block when the queue fills and resume as the consumer
+    /// drains it.
+    ///
+    /// This is the test that earns the bounded queue. An unbounded one would
+    /// hold the whole tree in memory and still pass every other test here; a
+    /// mis-wired bounded one deadlocks, and deadlocks in front of a picker that
+    /// has already taken over the terminal.
     #[test]
-    fn files_is_lazy() {
+    fn files_streams_a_tree_larger_than_its_queue() {
         let dir = TempDir::new().unwrap();
         let root = dir.path();
-        fs::create_dir(root.join("a")).unwrap();
-        fs::write(root.join("a/early.txt"), "").unwrap();
-        fs::create_dir(root.join("b")).unwrap();
+        let count = QUEUE_BOUND * 3;
+        for i in 0..count {
+            fs::write(root.join(format!("f{i}")), "").unwrap();
+        }
 
         let mut walk = files(root);
-        assert_eq!(walk.next().as_deref(), Some("a/early.txt"));
-        fs::write(root.join("b/late.txt"), "").unwrap();
-
-        let rest: Vec<String> = walk.collect();
-
-        assert_eq!(rest, vec!["b/late.txt".to_string()]);
+        // A row is there for the taking well before the tree is exhausted.
+        assert!(walk.next().is_some());
+        assert_eq!(walk.count(), count - 1, "the walk lost or repeated rows");
     }
 }


### PR DESCRIPTION
A performance pass over the walks, plus one correctness bug found on the way.

## The bug

`DirEntry::file_type` reports on the link rather than its target, so repository discovery silently dropped **symlinked checkouts** — and symlinked *owner* directories, which took every repository beneath them along too. No warning, exit 0. Verified with a fixture; now covered by a test.

Discovery is depth-capped, so following links costs an extra `stat` only on entries that are actually links.

## Measured

| | before | after |
|---|---|---|
| `walk::files` over `~/dev` (35k files after gitignore) | 330ms | **99ms** |
| repository discovery | serial, ~130 stats/readdirs queued behind each other | split across workers per level |

Discovery output verified against an independent `find`: 107 repos + the `extra` path, **zero differences**.

The rest — allocation removal in `gh`/`git`/`files`, the shared clone queue, the double tag formatting — is small. The allocation work is microseconds against a `gh` call that takes a second; it is in here because it is free to remove, not because it was costing anything.

## Trade-offs taken deliberately

The parallel file walk gives up two properties of the single-threaded one:

- **Ordering.** Nothing depended on it — skim ranks by the query the moment one is typed, and the untyped order is arrival order either way.
- **Strict per-item laziness.** No parallel walk can offer it; several threads always have work in flight. `files_is_lazy` is therefore replaced rather than adapted. What it becomes is a test for the property that *does* survive and that the bounded queue can get wrong: an unbounded queue would pass every other test in the file, and a mis-wired bounded one deadlocks in front of a picker already holding the terminal.

`gh::owners()` now returns its failures instead of swallowing them, which makes the warning arm at its call site live — a missing or unauthenticated `gh` previously said nothing even under `-v`.

## Docs

None of the three needed updating:

- **CLI help (`src/main.rs`)** — no command or flag surface changed.
- **README** — same; no config key, key binding, or command table entry moved.
- **`docs/demo.gif`** — the tape records `repo pick`, `branch checkout` and `pr ls --status`. `repo pick` rows are sorted by `discover()`, so they are unchanged, and no picker whose output shifted appears in the recording. No re-record.

## Checks

`make` green: fmt, clippy `-D warnings`, 150 tests, release build. Each of the four commits verified green standalone.