### PR TITLE
Reload branch and pull request pickers in place, without git chatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,12 +153,18 @@ title, failing checks and description for pull requests, and contents for
 files. They come from data already fetched, or from local commands kept to tens
 of milliseconds, so scrolling a long list never stalls.
 
-In a branch or pull request picker, `ctrl-r` reloads the list in place —
-`git fetch --all --prune` for branches, another `gh pr list` for pull requests —
-and reopens it with whatever you had typed still in the query. Those are the two
-lists that go stale while you read them: a colleague pushes, a check goes green.
+In a branch or pull request picker, `ctrl-r` reloads the list — `git fetch --all
+--prune` for branches, another `gh pr list` for pull requests. The picker never
+closes: the header says `⟳ refreshing…` while the work runs in the background,
+and the rows are replaced underneath your query and cursor when it lands. Those
+are the two lists that go stale while you read them — a colleague pushes, a check
+goes green. Neither command's output reaches your terminal; a failure leaves the
+list alone and is reported once you are out of the picker.
+
 The pickers over local data have nothing to re-ask, so they leave `ctrl-r` to
-skim, where it switches between fuzzy and regex matching.
+skim, where it switches between fuzzy and regex matching. Waits that happen
+before a picker can open — `--fetch`, the first `gh pr list` — get a spinner on
+stderr instead, so a slow network never looks like a hang.
 
 ## Shell integration (fish)
 

--- a/src/cmd/branch.rs
+++ b/src/cmd/branch.rs
@@ -9,6 +9,8 @@
 //! then local, then remote-only, newest first within each — so the top of the
 //! list is where the answer usually is.
 
+use std::sync::{Arc, Mutex};
+
 use anyhow::{Result, bail};
 
 use crate::git::{self, Branch, Filter};
@@ -17,9 +19,14 @@ use crate::term;
 use crate::{Ctx, pick};
 
 /// Every branch in the current repository, optionally refreshing remotes first.
+///
+/// The fetch is the only slow step here, and it is silent (see [`git::fetch`]),
+/// so it gets the spinner: a network round trip with nothing on screen is
+/// indistinguishable from a hang.
 fn load(ctx: &Ctx, fetch: bool) -> Result<Vec<Branch>> {
     git::ensure_repo()?;
     if fetch {
+        let _spinner = term::spinner("fetching");
         git::fetch()?;
     }
     let branches = git::branches()?;
@@ -144,37 +151,46 @@ fn items(branches: &[Branch]) -> Vec<PickItem> {
         .collect()
 }
 
-/// Fuzzy-select one branch, fetching and reopening on
-/// [`REFRESH_KEY`](pick::REFRESH_KEY).
+/// Fuzzy-select one branch, with [`REFRESH_KEY`](pick::REFRESH_KEY) fetching
+/// and rebuilding the list without closing the picker.
 ///
 /// Returns the chosen name (`main`, or `origin/main` for a branch that only
-/// exists on a remote) together with the unfiltered list it came from: a
-/// refresh replaces that list, and [`git::resolve`] must not decide what a
-/// checkout means from the one the picker opened with.
+/// exists on a remote) together with the branch list as it stood at that
+/// moment: a refresh replaces that list, and [`git::resolve`] must not decide
+/// what a checkout means from the one the picker opened with. That is what the
+/// shared `known` is for — the reload closure runs on skim's reader thread, so
+/// the two need somewhere to meet.
 ///
-/// The fetch happens between runs of the picker, which is the only place it can
-/// happen: skim owns the terminal while it is up, and its preview thread is the
-/// wrong place for a network round trip.
+/// A failed fetch leaves the rows exactly as they were and is reported once the
+/// picker is out of the way. Interrupting a branch list to say the network is
+/// down helps nobody: the list on screen is still perfectly usable, and it is
+/// almost certainly the branch you wanted.
 fn select(ctx: &Ctx, branches: Vec<Branch>, filter: Filter, prompt: &str) -> Result<Selection> {
-    let mut all = branches;
-    let mut query = String::new();
-    loop {
-        let offered = narrow(all.clone(), filter)?;
-        match pick::pick_one_refreshable(items(&offered), prompt, &query, &ctx.config.picker)? {
-            pick::Picked::Chosen(name) => {
-                return Ok(Selection {
-                    name,
-                    branches: all,
-                });
+    let offered = narrow(branches.clone(), filter)?;
+    let known = Arc::new(Mutex::new(branches));
+    let failure: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
+    let reload = {
+        let (known, failure) = (Arc::clone(&known), Arc::clone(&failure));
+        Box::new(move || {
+            let mut known = known.lock().expect("branch list poisoned");
+            match git::fetch().and_then(|()| git::branches()) {
+                Ok(fresh) => *known = fresh,
+                Err(err) => {
+                    *failure.lock().expect("failure slot poisoned") = Some(format!("{err:#}"))
+                }
             }
-            pick::Picked::Refresh { query: typed } => {
-                query = typed;
-                ctx.log.info("refreshing branches");
-                git::fetch_quiet()?;
-                all = git::branches()?;
-            }
-        }
+            items(&git::filtered(known.clone(), filter))
+        })
+    };
+
+    let name = pick::pick_one_reloading(items(&offered), prompt, &ctx.config.picker, reload)?;
+
+    if let Some(err) = failure.lock().expect("failure slot poisoned").take() {
+        eprintln!("warning: could not refresh branches: {err}");
     }
+    let branches = known.lock().expect("branch list poisoned").clone();
+    Ok(Selection { name, branches })
 }
 
 /// A chosen branch, and the branch list as it stood when it was chosen.

--- a/src/cmd/pr.rs
+++ b/src/cmd/pr.rs
@@ -4,6 +4,8 @@
 //! inherits whatever authentication `gh auth login` set up — including SSO and
 //! GitHub Enterprise hosts — and stores no credentials of its own.
 
+use std::sync::{Arc, Mutex};
+
 use anyhow::{Result, bail};
 
 use crate::Ctx;
@@ -12,8 +14,16 @@ use crate::pick::{self, PickItem, Preview};
 use crate::term;
 
 /// Fetch pull requests, failing with a useful message when there are none.
+///
+/// The spinner covers the whole `gh` call — a second or two of network on a
+/// good day, more on a large repository — which is otherwise a dead terminal.
+/// It draws on stderr and only when that is a terminal, so `pr ls | …` and
+/// `gh pr view (scriv pr pick)` are untouched by it.
 fn collect(ctx: &Ctx, state: &str, limit: usize) -> Result<Vec<PullRequest>> {
-    let prs = gh::list(state, limit)?;
+    let prs = {
+        let _spinner = term::spinner("loading pull requests");
+        gh::list(state, limit)?
+    };
     ctx.log.info(&format!("found {} pull requests", prs.len()));
     if prs.is_empty() {
         // `--state all` would otherwise read "no all pull requests found".
@@ -272,31 +282,53 @@ fn items(prs: &[PullRequest], tint: Tint) -> Vec<PickItem> {
         .collect()
 }
 
-/// Fuzzy-select one pull request and return its number, re-asking `gh` and
-/// reopening on [`REFRESH_KEY`](pick::REFRESH_KEY).
+/// Fuzzy-select one pull request and return its number, with
+/// [`REFRESH_KEY`](pick::REFRESH_KEY) asking `gh` again in place.
 ///
 /// A pull request list is stale the moment it is drawn — a check finishes, a
 /// review lands, someone merges — and a picker over it is exactly where you
-/// notice. The reload is the same `gh pr list` the command opened with, run
-/// between pickers rather than inside one: `gh` is a network round trip, and
-/// skim's preview thread is no place for it.
+/// notice. The reload is the same `gh pr list` the command opened with, run on
+/// skim's reader thread so the rows on screen stay put while it is in flight.
+///
+/// A `gh` that fails — rate limit, expired token, no network — leaves the rows
+/// as they were and says so after the picker closes. Losing a list you were
+/// halfway through choosing from would be a worse answer than a slightly old
+/// one.
 fn select(ctx: &Ctx, state: &str, limit: usize, prompt: &str, tint: Tint) -> Result<u64> {
-    let mut prs = collect(ctx, state, limit)?;
-    let mut query = String::new();
-    loop {
-        match pick::pick_one_refreshable(items(&prs, tint), prompt, &query, &ctx.config.picker)? {
-            pick::Picked::Chosen(choice) => {
-                return choice
-                    .parse()
-                    .map_err(|_| anyhow::anyhow!("unexpected picker result: {choice}"));
+    let prs = collect(ctx, state, limit)?;
+    // The opening rows are built before the shared list exists, and deliberately
+    // so: a `known.lock()` written inline in the `pick_one_reloading` call below
+    // would hold its guard for the whole statement — the entire lifetime of the
+    // picker — and the reload would block on it forever.
+    let rows = items(&prs, tint);
+    let known = Arc::new(Mutex::new(prs));
+    let failure: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
+    let reload = {
+        let (known, failure, state) = (Arc::clone(&known), Arc::clone(&failure), state.to_string());
+        Box::new(move || {
+            let mut known = known.lock().expect("pull request list poisoned");
+            match gh::list(&state, limit) {
+                Ok(fresh) if !fresh.is_empty() => *known = fresh,
+                // An empty answer is not worth blanking the list for: the
+                // pull request you were looking at was there a moment ago.
+                Ok(_) => {}
+                Err(err) => {
+                    *failure.lock().expect("failure slot poisoned") = Some(format!("{err:#}"));
+                }
             }
-            pick::Picked::Refresh { query: typed } => {
-                query = typed;
-                ctx.log.info("refreshing pull requests");
-                prs = collect(ctx, state, limit)?;
-            }
-        }
+            items(&known, tint)
+        })
+    };
+
+    let choice = pick::pick_one_reloading(rows, prompt, &ctx.config.picker, reload)?;
+
+    if let Some(err) = failure.lock().expect("failure slot poisoned").take() {
+        eprintln!("warning: could not refresh pull requests: {err}");
     }
+    choice
+        .parse()
+        .map_err(|_| anyhow::anyhow!("unexpected picker result: {choice}"))
 }
 
 /// `scriv pr pick` — fuzzy-select a pull request and print its number, so it

--- a/src/git.rs
+++ b/src/git.rs
@@ -388,30 +388,21 @@ pub fn branches() -> Result<Vec<Branch>> {
 }
 
 /// Refresh remote-tracking refs, dropping ones deleted upstream.
-pub fn fetch() -> Result<()> {
-    passthrough(&["fetch", "--all", "--prune"]).context("fetching from remotes")
-}
-
-/// [`fetch`], with git's stdout swallowed.
 ///
-/// For fetching from inside a picker: `scriv branch pick`'s stdout is very
-/// often a command substitution, and `git fetch --all` writes a `Fetching
-/// origin` line there. That line would be read as part of the branch name.
-/// stderr is left alone, so progress and any error still reach the user.
-pub fn fetch_quiet() -> Result<()> {
-    let status = Command::new("git")
-        .args(["fetch", "--all", "--prune"])
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .status()
-        .map_err(|e| match e.kind() {
-            ErrorKind::NotFound => anyhow!("`git` was not found on PATH"),
-            _ => anyhow!(e).context("fetching from remotes"),
-        })?;
-    if !status.success() {
-        return Err(Reported(status.code().unwrap_or(1)).into());
-    }
-    Ok(())
+/// Captured rather than passed through, which is the one place scriv silences
+/// git on purpose. `git fetch --all` narrates itself — `Fetching origin`,
+/// per-remote progress — and neither half of that is wanted here. The line goes
+/// to stdout, where `scriv branch pick` is writing a branch name for a shell to
+/// read; the progress goes to stderr, where it would scribble over the spinner
+/// the caller draws and leave the terminal to be redrawn underneath the picker.
+///
+/// A failure still speaks: [`capture`] returns git's stderr as the error, so
+/// "could not read from remote repository" arrives as scriv's error message
+/// rather than as noise nobody asked for.
+pub fn fetch() -> Result<()> {
+    capture(&["fetch", "--all", "--prune"])
+        .context("fetching from remotes")
+        .map(|_| ())
 }
 
 /// Perform a resolved checkout.

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,8 @@ enum Command {
     ///
     /// Listings lead with the current branch, then local branches, then
     /// remote-only ones, each most recently committed to first. In a branch
-    /// picker, ctrl-r fetches from every remote and reopens the list.
+    /// picker, ctrl-r fetches from every remote and reloads the list without
+    /// closing the picker.
     #[command(alias = "br")]
     Branch {
         #[command(subcommand)]
@@ -104,8 +105,8 @@ enum Command {
     },
     /// Work with GitHub pull requests (via the `gh` CLI)
     ///
-    /// In a pull request picker, ctrl-r asks GitHub again and reopens the list,
-    /// for when a check has finished while you were looking at it.
+    /// In a pull request picker, ctrl-r asks GitHub again and reloads the list
+    /// in place, for when a check has finished while you were looking at it.
     Pr {
         #[command(subcommand)]
         command: PrCmd,

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -13,6 +13,7 @@
 //! is what makes a walk of a large tree usable, since the picker opens on the
 //! first rows instead of the last.
 
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use anyhow::{Result, anyhow};
@@ -178,7 +179,7 @@ pub fn pick_one(items: Vec<PickItem>, prompt: &str, cfg: &PickerConfig) -> Resul
     one(Feed::batch(items), prompt, cfg)
 }
 
-/// The key that asks a refreshable picker to reload its rows.
+/// The key that asks a reloadable picker to go and get fresher rows.
 ///
 /// This displaces skim's own `ctrl-r` (rotate between matching modes), which is
 /// why only the pickers over remote data offer it: those are the lists that go
@@ -186,46 +187,110 @@ pub fn pick_one(items: Vec<PickItem>, prompt: &str, cfg: &PickerConfig) -> Resul
 /// switching to regex matching.
 pub const REFRESH_KEY: &str = "ctrl-r";
 
-/// The outcome of a picker that offers [`REFRESH_KEY`].
-pub enum Picked {
-    /// A row the user selected.
-    Chosen(String),
-    /// The user asked for fresher rows. `query` is what they had typed, so the
-    /// reopened picker can start where they left off rather than making them
-    /// type it again.
-    Refresh { query: String },
-}
+/// Fetches a fresh set of rows. Called on a background thread, so it may block
+/// for as long as the network takes.
+///
+/// Infallible by construction: a reload that fails is the caller's to explain,
+/// and the useful answer is almost always "keep showing what we had", which
+/// only the caller can rebuild. Hand back the old rows and remember the error.
+pub type Reload = Box<dyn FnMut() -> Vec<PickItem> + Send>;
 
-/// [`pick_one`], with [`REFRESH_KEY`] bound to "close and tell the caller to
-/// reload".
+/// [`pick_one`], with [`REFRESH_KEY`] bound to reloading the list in place.
 ///
-/// The reload itself is the caller's: only it knows whether fresh rows mean a
-/// `git fetch` or a `gh pr list`, and doing the work between runs of the picker
-/// rather than inside one keeps it off skim's preview thread, where a slow
-/// command piles up copies of itself.
+/// The picker does not close and reopen: `reload` runs on a background thread
+/// while skim keeps drawing, with its own reading spinner turning next to the
+/// row count, and the rows already on screen stay there until the new ones
+/// arrive. The query, the cursor and the preview pane are never disturbed —
+/// there is nothing to restore, because nothing was torn down.
 ///
-/// `query` pre-fills the input, which is how a refresh keeps its place.
-pub fn pick_one_refreshable(
+/// This works by handing skim a [`CommandCollector`] of scriv's own. skim's
+/// `reload` action clears the item pool and asks the collector for a new
+/// source; the stock collector runs a shell command, and this one calls
+/// `reload` instead. So the refresh rides skim's real reload path — including
+/// the spinner and the "still reading" state — without a shell in sight.
+pub fn pick_one_reloading(
     items: Vec<PickItem>,
     prompt: &str,
-    query: &str,
     cfg: &PickerConfig,
-) -> Result<Picked> {
+    reload: Reload,
+) -> Result<String> {
     let run = Run {
         prompt,
         multi: false,
-        query,
-        refreshable: true,
+        query: "",
+        reload: Some(reload),
     };
-    let out = run_picker(Feed::batch(items), &run, cfg)?;
-    if out.refresh {
-        return Ok(Picked::Refresh { query: out.query });
-    }
-    out.values
+    run_picker(Feed::batch(items), run, cfg)?
+        .values
         .into_iter()
         .next()
-        .map(Picked::Chosen)
         .ok_or_else(|| Cancelled.into())
+}
+
+/// The [`CommandCollector`] behind [`pick_one_reloading`]: skim thinks it is
+/// running a command, and it is calling a closure.
+struct ReloadCollector {
+    reload: Arc<Mutex<Reload>>,
+}
+
+/// How often the counted thread looks up from waiting to see whether skim has
+/// asked it to stop.
+const RELOAD_POLL: Duration = Duration::from_millis(20);
+
+impl CommandCollector for ReloadCollector {
+    fn invoke(
+        &mut self,
+        _cmd: &str,
+        components_to_stop: Arc<AtomicUsize>,
+    ) -> (SkimItemReceiver, Sender<i32>) {
+        let (tx_item, rx_item): (SkimItemSender, SkimItemReceiver) = unbounded();
+        let (tx_interrupt, rx_interrupt) = unbounded::<i32>();
+        let reload = Arc::clone(&self.reload);
+
+        // The counter is skim's only view of whether this collector has
+        // stopped, and `ReaderControl::kill` *busy-waits* on it. Whatever this
+        // thread does, it has to decrement quickly when asked — so the reload
+        // itself runs on a second, uncounted thread and this one only waits for
+        // it, giving up the moment skim interrupts.
+        //
+        // A reload started while another is still running therefore does not
+        // cancel it: the first finishes into a channel nobody is reading, and
+        // the second waits its turn on whatever the caller's closure locks.
+        // Pressing the key three times means three fetches, one after another,
+        // and a picker that stays responsive throughout — which is a better
+        // trade than killing a `git fetch` halfway.
+        components_to_stop.fetch_add(1, Ordering::SeqCst);
+        std::thread::spawn(move || {
+            let (tx_rows, rx_rows) = std::sync::mpsc::channel();
+            std::thread::spawn(move || {
+                let rows = (reload.lock().expect("reload closure poisoned"))();
+                // The receiver is gone if skim gave up waiting; the work is
+                // finished either way and its result is simply dropped.
+                let _ = tx_rows.send(rows);
+            });
+
+            loop {
+                if matches!(rx_interrupt.try_recv(), Ok(Some(_)) | Err(_)) {
+                    break;
+                }
+                match rx_rows.recv_timeout(RELOAD_POLL) {
+                    Ok(rows) => {
+                        let _ = tx_item.send(rows.into_iter().map(into_skim).collect());
+                        break;
+                    }
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                    // The worker panicked; leave the list as it is.
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                }
+            }
+            // Dropping `tx_item` here is what tells skim the read is over and
+            // stops its spinner, so it must happen before the count drops.
+            drop(tx_item);
+            components_to_stop.fetch_sub(1, Ordering::SeqCst);
+        });
+
+        (rx_item, tx_interrupt)
+    }
 }
 
 /// What [`pick_one_or_query`] came back with.
@@ -382,10 +447,10 @@ struct Run<'a> {
     prompt: &'a str,
     /// Whether several rows can be selected.
     multi: bool,
-    /// Text the input starts with, so a refreshed picker keeps its place.
+    /// Text the input starts with.
     query: &'a str,
-    /// Offer [`REFRESH_KEY`] and report it when pressed.
-    refreshable: bool,
+    /// Given one, [`REFRESH_KEY`] reloads the list through it.
+    reload: Option<Reload>,
 }
 
 impl<'a> Run<'a> {
@@ -394,7 +459,7 @@ impl<'a> Run<'a> {
             prompt,
             multi,
             query: "",
-            refreshable: false,
+            reload: None,
         }
     }
 }
@@ -405,8 +470,6 @@ struct Outcome {
     /// What the user had typed — the answer itself when the list is a set of
     /// suggestions and nothing matched.
     query: String,
-    /// [`REFRESH_KEY`] was pressed, so there is no selection to speak of.
-    refresh: bool,
 }
 
 /// Drive skim over `feed` and return the selected values.
@@ -421,12 +484,12 @@ fn run_with_query(
     multi: bool,
     cfg: &PickerConfig,
 ) -> Result<(Vec<String>, String)> {
-    let out = run_picker(feed, &Run::new(prompt, multi), cfg)?;
+    let out = run_picker(feed, Run::new(prompt, multi), cfg)?;
     Ok((out.values, out.query))
 }
 
-/// Drive skim over `feed` once.
-fn run_picker(feed: Feed, run: &Run, cfg: &PickerConfig) -> Result<Outcome> {
+/// Drive skim over `feed`.
+fn run_picker(feed: Feed, run: Run, cfg: &PickerConfig) -> Result<Outcome> {
     let (prompt, multi) = (run.prompt, run.multi);
     // skim needs a terminal for its UI. Fail with a clear message rather than
     // skim's raw "Device not configured" when there is none (e.g. in a pipe
@@ -458,13 +521,25 @@ fn run_picker(feed: Feed, run: &Run, cfg: &PickerConfig) -> Result<Outcome> {
         builder.query(run.query.to_string());
     }
 
-    // `accept(<key>)` is skim's `--expect`: it closes the picker and names the
-    // key that did it, which is how a keystroke can mean something other than
-    // "this row" without skim knowing what a refresh is.
-    if run.refreshable {
+    // skim's own `reload` action, pointed at a collector that calls a closure
+    // instead of running a shell command.
+    //
+    // `no_clear_if_empty` keeps skim from blanking the displayed rows the
+    // instant the key is pressed, which is all it can do: a reload empties the
+    // item pool by definition, so once the matcher runs again the list is empty
+    // until the new rows land. A reload that returns quickly therefore never
+    // flickers, and a slow one shows an empty list — which is what the busy
+    // header is for, since "still fetching" and "no branches" look identical
+    // otherwise.
+    if let Some(reload) = run.reload {
+        let collector = ReloadCollector {
+            reload: Arc::new(Mutex::new(reload)),
+        };
         builder
-            .bind(vec![refresh_bind()])
-            .header(format!("{REFRESH_KEY} to refresh"));
+            .bind(refresh_binds())
+            .header(IDLE_HEADER.to_string())
+            .no_clear_if_empty(true)
+            .cmd_collector(Rc::new(RefCell::new(collector)) as Rc<RefCell<dyn CommandCollector>>);
     }
 
     let options = builder
@@ -487,27 +562,31 @@ fn run_picker(feed: Feed, run: &Run, cfg: &PickerConfig) -> Result<Outcome> {
             .iter()
             .map(|item| item.output().to_string())
             .collect(),
-        refresh: accepted_with(&output.final_event, REFRESH_KEY),
         query: output.query,
     })
 }
 
-/// The skim binding that closes the picker and names [`REFRESH_KEY`] as the
-/// reason — the two halves of the round trip, written once.
-fn refresh_bind() -> String {
-    format!("{REFRESH_KEY}:accept({REFRESH_KEY})")
-}
+/// The picker's header when it is showing what it has.
+const IDLE_HEADER: &str = "ctrl-r to refresh";
 
-/// Whether skim closed because `key` was pressed, rather than `enter`.
+/// The header while a reload is in flight. skim empties the list for the
+/// duration of a reload — that is what `reload` means — so the header is what
+/// distinguishes "fetching, one moment" from "there are no branches". Its
+/// spinner keeps turning beside the row count throughout.
+const BUSY_HEADER: &str = "⟳ refreshing…";
+
+/// The skim bindings that turn [`REFRESH_KEY`] into a reload of the item list.
 ///
-/// The key comes back inside the accept event as the string it was bound
-/// under, which is why the binding above and this comparison use the same
-/// [`REFRESH_KEY`] constant.
-fn accepted_with(event: &Event, key: &str) -> bool {
-    matches!(
-        event,
-        Event::Action(Action::Accept(Some(pressed))) if pressed == key
-    )
+/// `reload` with no command of its own is skim's "read the source again"; the
+/// source here is [`ReloadCollector`], so this is what calls the closure. The
+/// second binding is skim's `load` event, which fires when a read finishes —
+/// including the first one — and puts the idle header back without scriv having
+/// to know when the reload landed.
+fn refresh_binds() -> Vec<String> {
+    vec![
+        format!("{REFRESH_KEY}:reload+set-header({BUSY_HEADER})"),
+        format!("load:set-header({IDLE_HEADER})"),
+    ]
 }
 
 #[cfg(test)]
@@ -528,26 +607,108 @@ mod tests {
         assert_eq!(quote("'; rm -rf /; '"), r"''\''; rm -rf /; '\'''");
     }
 
-    /// Enter and the refresh key both leave skim through `accept`; only the
-    /// key that came with it says which happened. Reading that wrong turns a
-    /// refresh into a selection of whatever row was highlighted.
+    /// The binding has to be skim's own `reload`, not an `accept`: an accept
+    /// closes the picker, which is the behaviour this exists to avoid. It also
+    /// has to parse — a binding skim cannot read is dropped, and the key would
+    /// silently do nothing.
     #[test]
-    fn only_the_refresh_key_reads_as_a_refresh() {
-        let accept = |key: Option<&str>| Event::Action(Action::Accept(key.map(str::to_string)));
-        assert!(accepted_with(&accept(Some(REFRESH_KEY)), REFRESH_KEY));
-        // Plain enter: accepted, but with no key attached.
-        assert!(!accepted_with(&accept(None), REFRESH_KEY));
-        assert!(!accepted_with(&accept(Some("ctrl-t")), REFRESH_KEY));
-        assert!(!accepted_with(&Event::Action(Action::Abort), REFRESH_KEY));
+    fn the_refresh_key_is_bound_to_a_reload() {
+        let binds = refresh_binds();
+        let (key, actions) = binds[0]
+            .split_once(':')
+            .expect("not a `key:action` binding");
+        assert_eq!(key, REFRESH_KEY);
+        assert!(
+            actions.starts_with("reload"),
+            "an accept would close the picker: {actions}"
+        );
+        assert!(actions.contains(BUSY_HEADER), "no busy header: {actions}");
     }
 
-    /// skim has to be told both which key to close on and what to call it, and
-    /// the name it reports back is what [`accepted_with`] matches. A binding
-    /// that named a different key would close the picker and refresh nothing.
+    /// The busy header has to be taken down again, or a picker sits there
+    /// claiming to be refreshing long after it finished. skim's `load` event
+    /// is what says a read is over.
     #[test]
-    fn the_binding_names_the_key_it_is_checked_against() {
-        assert_eq!(refresh_bind(), "ctrl-r:accept(ctrl-r)");
-        let reported = Event::Action(Action::Accept(Some(REFRESH_KEY.to_string())));
-        assert!(accepted_with(&reported, REFRESH_KEY));
+    fn finishing_a_read_restores_the_idle_header() {
+        let restore = refresh_binds()
+            .into_iter()
+            .find(|b| b.starts_with("load:"))
+            .expect("nothing puts the header back");
+        assert!(restore.contains(IDLE_HEADER), "{restore}");
+    }
+
+    /// Neither the parenthesis nor the comma may appear inside a binding's
+    /// argument: skim splits bindings on `,` and ends an argument at `)`, so a
+    /// header containing either would be parsed as something else entirely.
+    #[test]
+    fn header_text_cannot_break_the_binding_syntax() {
+        for header in [IDLE_HEADER, BUSY_HEADER] {
+            assert!(!header.contains(','), "{header:?} would split the binding");
+            assert!(!header.contains(')'), "{header:?} would end the argument");
+        }
+    }
+
+    /// The reload closure runs on a thread of the collector's making, and its
+    /// rows have to come back through the channel skim is reading. Driving the
+    /// collector directly is the only way to see that without a terminal.
+    #[test]
+    fn the_collector_hands_reloaded_rows_to_skim() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&calls);
+        let mut collector = ReloadCollector {
+            reload: Arc::new(Mutex::new(Box::new(move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                vec![PickItem::plain("fresh")]
+            }))),
+        };
+
+        let components = Arc::new(AtomicUsize::new(0));
+        let (rx, _interrupt) = collector.invoke("", Arc::clone(&components));
+
+        let batch = rx.recv().expect("the reload sent no rows");
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0].text(), "fresh");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        // The channel closing is how skim learns the read is over and stops
+        // its spinner; the counter reaching zero is how it learns the
+        // collector has stopped. Both have to happen, or the picker is left
+        // looking like it is still loading.
+        assert!(rx.recv().is_err(), "the source channel was left open");
+        while components.load(Ordering::SeqCst) != 0 {
+            std::thread::yield_now();
+        }
+    }
+
+    /// skim busy-waits on the component count when it kills a reader, so an
+    /// interrupted reload has to give it up promptly rather than after the
+    /// network has answered.
+    #[test]
+    fn an_interrupted_reload_stops_without_waiting_for_the_work() {
+        let (release, blocked) = std::sync::mpsc::channel::<()>();
+        let mut collector = ReloadCollector {
+            reload: Arc::new(Mutex::new(Box::new(move || {
+                // Stands in for a fetch that has not come back yet.
+                let _ = blocked.recv();
+                vec![PickItem::plain("late")]
+            }))),
+        };
+
+        let components = Arc::new(AtomicUsize::new(0));
+        let (_rx, interrupt) = collector.invoke("", Arc::clone(&components));
+        interrupt.send(1).expect("interrupt not delivered");
+
+        // Without the uncounted worker thread this would hang until the
+        // reload finished — exactly the freeze skim's spin would turn into a
+        // pegged core.
+        let start = Instant::now();
+        while components.load(Ordering::SeqCst) != 0 {
+            assert!(
+                start.elapsed() < Duration::from_secs(5),
+                "the collector waited for the reload it was told to abandon",
+            );
+            std::thread::yield_now();
+        }
+        drop(release);
     }
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,9 +1,15 @@
 //! Terminal capability checks shared by the printing commands.
 //!
 //! Colour is opt-out per the `NO_COLOR` convention and is never emitted when
-//! stdout is redirected, so `scriv … ls` stays pipe-safe by default.
+//! stdout is redirected, so `scriv … ls` stays pipe-safe by default. The same
+//! rule governs [`Spinner`]: it is drawn only when there is a terminal to draw
+//! it on.
 
-use std::io::IsTerminal;
+use std::io::{IsTerminal, Write};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::JoinHandle;
+use std::time::Duration;
 
 /// Whether stdout should carry ANSI colour: a terminal, and `NO_COLOR` unset.
 pub fn stdout_color() -> bool {
@@ -40,6 +46,94 @@ pub fn paint_within(text: &str, color: u8, back: u8, on: bool) -> String {
     }
 }
 
+/// Frames of the spinner, in order. Braille dots: one cell wide in every
+/// terminal, so the line never changes width as it turns.
+const FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// How long each frame is held. Ten frames at this rate is a full turn per
+/// second — visible movement, and nowhere near enough redraws to matter.
+const FRAME_TIME: Duration = Duration::from_millis(100);
+
+/// Erase the line the cursor is on and return to its start, so the next frame
+/// overwrites the previous one instead of stacking up.
+const CLEAR_LINE: &str = "\r\x1b[2K";
+
+/// A one-line "working on it" animation on stderr, erased when dropped.
+///
+/// For the waits scriv cannot make shorter — a `git fetch`, a `gh` round trip —
+/// where the alternative is a frozen terminal that looks like a hang. It draws
+/// on stderr because stdout is a result: `scriv branch pick` writes a branch
+/// name there for a shell to read, and an animation in the middle of it would
+/// be read as part of the name.
+///
+/// Nothing is drawn at all when stderr is not a terminal, so a redirected or
+/// piped run stays clean, and the animation is never what a script has to
+/// parse around.
+pub struct Spinner {
+    stop: Arc<AtomicBool>,
+    /// `None` when there was no terminal to draw on, which makes every method
+    /// here a no-op rather than a special case at each call site.
+    thread: Option<JoinHandle<()>>,
+}
+
+/// Start a spinner labelled `label` (e.g. `fetching`), running until it is
+/// dropped.
+///
+/// Bind it to a name — `let _spinner = term::spinner(…)` — for as long as the
+/// wait lasts. A bare `term::spinner(…)` statement drops it immediately and
+/// spins for nothing.
+#[must_use]
+pub fn spinner(label: &str) -> Spinner {
+    let stop = Arc::new(AtomicBool::new(false));
+    if !std::io::stderr().is_terminal() {
+        return Spinner { stop, thread: None };
+    }
+
+    let label = label.to_string();
+    let color = !no_color();
+    let flag = Arc::clone(&stop);
+    let thread = std::thread::spawn(move || {
+        let mut frames = FRAMES.iter().cycle();
+        while !flag.load(Ordering::Relaxed) {
+            let frame = frames.next().unwrap_or(&FRAMES[0]);
+            let mut err = std::io::stderr().lock();
+            // Cyan matches the "not here yet" hue the pickers already use for
+            // things that come from a remote.
+            let _ = write!(err, "{CLEAR_LINE}{} {label}", paint(frame, 6, color));
+            let _ = err.flush();
+            // Sleeping the whole frame would delay the erase by up to a frame
+            // after the work finishes; waking often keeps the exit prompt.
+            for _ in 0..10 {
+                if flag.load(Ordering::Relaxed) {
+                    return;
+                }
+                std::thread::sleep(FRAME_TIME / 10);
+            }
+        }
+    });
+    Spinner {
+        stop,
+        thread: Some(thread),
+    }
+}
+
+impl Drop for Spinner {
+    /// Stop the animation and erase its line, leaving the terminal exactly as
+    /// it was found — the picker that opens next draws over nothing.
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        let Some(thread) = self.thread.take() else {
+            return;
+        };
+        // Join before erasing: a frame still in flight would otherwise be
+        // written after the erase and left on screen.
+        let _ = thread.join();
+        let mut err = std::io::stderr().lock();
+        let _ = write!(err, "{CLEAR_LINE}");
+        let _ = err.flush();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,5 +158,32 @@ mod tests {
             "the cell must not end in a reset",
         );
         assert_eq!(paint_within("✓", 2, 5, false), "✓");
+    }
+
+    /// Every frame has to be one column wide, or the line jitters as it turns
+    /// and the erase leaves a tail behind.
+    #[test]
+    fn spinner_frames_are_a_single_character() {
+        for frame in FRAMES {
+            assert_eq!(frame.chars().count(), 1, "{frame:?} is not one character");
+        }
+    }
+
+    /// The erase has to clear the whole line, not just return to its start:
+    /// a shorter label drawn over a longer one would otherwise leave the tail
+    /// of the old text on screen.
+    #[test]
+    fn clearing_erases_the_line_it_returns_to() {
+        assert!(CLEAR_LINE.starts_with('\r'));
+        assert!(CLEAR_LINE.contains("\x1b[2K"), "no erase-line sequence");
+    }
+
+    /// With no terminal to draw on — a piped or redirected run — the spinner
+    /// starts no thread and writes nothing at all.
+    #[test]
+    fn no_terminal_means_no_animation() {
+        // The test harness captures stderr, so this is the redirected case.
+        let spinner = spinner("fetching");
+        assert!(spinner.thread.is_none(), "spun without a terminal");
     }
 }


### PR DESCRIPTION
## What

`ctrl-r` used to close the picker, run git in the open, and reopen it — so a
refresh looked like a burst of `Fetching origin` and progress output followed by
a full redraw. Now the list reloads inside the picker.

- The picker never tears down. Query, cursor and preview pane are untouched
  because there is nothing to restore.
- The header reads `⟳ refreshing…` while the reload runs, and goes back to
  `ctrl-r to refresh` on skim's `load` event.
- **git says nothing.** `git::fetch` is captured rather than passed through, so
  its stdout can no longer land inside `(scriv branch pick)` and its progress can
  no longer scribble over the picker. A failure still speaks — `capture` returns
  git's stderr as the error text.
- Waits that happen *before* a picker can open (`--fetch`, the first
  `gh pr list`) get a spinner on stderr, drawn only when stderr is a terminal.

## How

skim's `reload` action, pointed at a `CommandCollector` of scriv's own. The
stock collector runs a shell command and reads its lines; `ReloadCollector`
calls a Rust closure and sends back `PickItem`s. So the refresh rides skim's
real reload path — spinner, "still reading" state and all — with no shell
involved and no manual event loop.

Two details that are load-bearing:

- **The reload must not block skim.** `ReaderControl::kill` *busy-waits* on the
  collector's component counter, so a counted thread that sat through a 3-second
  fetch would peg a core and freeze the UI. The fetch runs on a second,
  uncounted thread; the counted one waits for it and gives up the instant skim
  interrupts.
- **Repeated `ctrl-r` queues rather than cancels.** Three presses are three
  sequential fetches, with the picker responsive throughout — a better trade
  than killing a `git fetch` halfway.

## A bug the visual test caught

The first PR-picker version deadlocked: `known.lock()` written inline as a call
argument holds its guard for the whole statement — the entire lifetime of the
picker — so the reload closure blocked on it forever and the header sat at
`⟳ refreshing…` permanently. Only visible by driving the real binary. The rows
are now built before the shared list is created, with a comment saying why.

## Verified

Unit tests cover the collector directly: rows come back through the channel, the
channel closes and the counter returns to zero (or skim is left looking like it
is still loading), an interrupted reload gives up without waiting for the work,
the binding is a `reload` and not an `accept`, and the header text can't contain
the `,`/`)` that would break skim's binding syntax.

End to end under VHS against the demo sandbox, with a shimmed slow `git`/`gh`:

- **branch** — a branch created in the bare remote *after* the picker opened
  appears on `ctrl-r` (4/4 → 5/5), picker never leaves the screen.
- **pull requests** — a `gh` that reports a changed title on its second call
  shows that title in place, preview included.
- **hammering** — three `ctrl-r` presses inside one slow fetch: no wedge, list
  and idle header return, still interactive.

## Docs

- **CLI help (`src/main.rs`)** — the `branch` and `pr` group docs said "reopens
  the list", which is no longer what happens; both now say it reloads in place.
- **README** — the `ctrl-r` paragraph rewritten for the new behaviour, plus a
  line about the pre-picker spinner.
- **`docs/demo.gif`** — re-recorded and then reverted deliberately: the demo
  never triggers a refresh or a fetch, and the picker header text is unchanged,
  so the new recording was visually identical. Not worth a 275 KB binary diff.