### PR TITLE
Open pickers and spinners below the prompt, never on it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,13 @@ reference, so command implementations do no environment lookups of their own.
   and a verb over that set. `edit` acts on the directory the user is standing
   in, so it is a verb at the top level rather than a fifth noun — and it has no
   `ls`. Resist filing ambient-directory work under a noun group.
+- **Anything drawn inline takes a `term::ScratchRow` first.** The picker and the
+  spinner both start on the row the cursor is on, which from a key binding is
+  the last row of the shell's prompt — the picker draws over it, the spinner
+  erases it. A one-line prompt hides that, because the shell redraws the whole
+  thing; a two-line prompt is left cut in half. Take a row, draw on that, and
+  step back up on the way out so the cursor is where the shell's repaint expects
+  it. Never draw on the row scriv was invoked on.
 - **Only `cd` needs the shell.** A child cannot change its parent's directory,
   which is why `repo pick` prints a path for a fish function to consume. Running
   an editor needs no such help: `scriv edit` spawns it directly and skim restores

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -22,6 +22,7 @@ use ratatui::text::Line;
 use skim::prelude::*;
 
 use crate::config::PickerConfig;
+use crate::term;
 
 /// A user-cancelled selection (Esc / Ctrl-C). Distinct from "nothing matched"
 /// so the caller can exit 130 without printing anything.
@@ -551,6 +552,9 @@ fn run_picker(feed: Feed, run: Run, cfg: &PickerConfig) -> Result<Outcome> {
     let (tx, rx): (SkimItemSender, SkimItemReceiver) = unbounded();
     feed.send(tx)?;
 
+    // Held until the picker is done with the terminal, however it ends —
+    // selection, cancel, or an error out of skim.
+    let _room = room_for(&cfg.height);
     let output = Skim::run_with(options, Some(rx)).map_err(|e| anyhow!("running picker: {e}"))?;
 
     if output.is_abort {
@@ -564,6 +568,39 @@ fn run_picker(feed: Feed, run: Run, cfg: &PickerConfig) -> Result<Outcome> {
             .collect(),
         query: output.query,
     })
+}
+
+/// The row an inline picker opens on, so it never draws over the prompt.
+///
+/// skim's inline viewport starts on the row the cursor is on — and when the
+/// picker is opened from a key binding, that is the last row of the shell's
+/// prompt. skim draws over it and clears it on the way out, which a one-line
+/// prompt survives because the shell redraws the whole thing afterwards. A
+/// two-line prompt does not: only its last row is taken, so the picker appears
+/// welded to the middle of a prompt whose first row is still sitting above it.
+/// A [`term::ScratchRow`] moves the whole picker one row down, clear of it.
+///
+/// A full-screen picker takes the alternate screen and gives the display back
+/// untouched, so it needs no row of its own.
+fn room_for(height: &str) -> term::ScratchRow {
+    if draws_inline(height) {
+        term::ScratchRow::take()
+    } else {
+        term::ScratchRow::none()
+    }
+}
+
+/// Whether skim will draw over the terminal it was launched in, rather than
+/// taking the alternate screen.
+///
+/// Mirrors skim's own rule: `100%` is full-screen, every other height — a
+/// percentage, a row count, or a negative offset — is an inline viewport.
+fn draws_inline(height: &str) -> bool {
+    height
+        .trim()
+        .strip_suffix('%')
+        .and_then(|n| n.trim().parse::<u16>().ok())
+        != Some(100)
 }
 
 /// The picker's header when it is showing what it has.
@@ -597,6 +634,42 @@ mod tests {
     fn quotes_plain_values() {
         assert_eq!(quote("main"), "'main'");
         assert_eq!(quote("/home/u/my repo"), "'/home/u/my repo'");
+    }
+
+    /// Only a full-height picker takes the alternate screen, and only that one
+    /// leaves the display untouched on its own. Get this wrong in the generous
+    /// direction and scriv reserves a row a full-screen picker never draws in,
+    /// leaving a stray blank line above every prompt.
+    #[test]
+    fn only_a_full_height_picker_keeps_off_the_display() {
+        assert!(!draws_inline("100%"));
+        assert!(!draws_inline(" 100% "));
+        for height in ["50%", "99%", "20", "-2", "", "garbage"] {
+            assert!(draws_inline(height), "{height:?} does not draw inline");
+        }
+    }
+
+    /// A row count of 100 is a hundred rows, not a hundred per cent — the `%`
+    /// is what makes it full-screen.
+    #[test]
+    fn a_bare_hundred_is_not_full_height() {
+        assert!(draws_inline("100"));
+    }
+
+    /// Taking a row means writing to the terminal, so it must not happen when
+    /// there is no terminal there: a redirected run would otherwise emit a
+    /// stray newline and a cursor-up escape into whatever is reading it.
+    #[test]
+    fn a_row_is_taken_only_when_there_is_a_terminal() {
+        use std::io::IsTerminal;
+        assert_eq!(room_for("50%").is_taken(), std::io::stderr().is_terminal());
+    }
+
+    /// A full-screen picker restores the display itself, so there is nothing
+    /// to take however the run was launched.
+    #[test]
+    fn a_full_height_picker_takes_no_row() {
+        assert!(!room_for("100%").is_taken());
     }
 
     /// A single quote in a branch name or path must not end the quoted string

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -75,13 +75,14 @@ end
 # alt-e (edit) are left-hand, alt-o and alt-p right-hand. Rebind any of them by
 # calling `bind` yourself after `scriv_key_bindings`.
 #
-# Every binding ends in `commandline -f repaint`, never `execute`. skim renders
-# inline: it asks the terminal for the cursor position and draws its UI starting
-# on that row, which is the row the prompt is on, then clears that region when it
-# exits — leaving the prompt blank until fish redraws it. `repaint` is what
-# redraws it. `execute` looks like it works only because submitting an empty
-# command line prints a fresh prompt further down; with anything typed it runs
-# the line, so pressing ctrl-o mid-command would execute whatever was there.
+# Every binding ends in `commandline -f repaint`, never `execute`. The picker
+# renders inline, and scriv opens it on a row of its own below the prompt so it
+# never draws over one; `repaint` is what puts the command line back after a
+# picker that took the whole screen, and what redraws a prompt whose contents
+# the picked branch or directory has just changed. `execute` looks like it works
+# only because submitting an empty command line prints a fresh prompt further
+# down; with anything typed it runs the line, so pressing ctrl-o mid-command
+# would execute whatever was there.
 function scriv_key_bindings --description "Bind scriv pickers to keys"
     bind ctrl-o "scriv-repo-cd; commandline -f repaint"
     bind alt-o  "scriv-repo-cd; commandline -f repaint"
@@ -152,8 +153,8 @@ mod tests {
 
     /// `commandline -f execute` submits the command line, so a binding pressed
     /// with anything typed would run it — ctrl-o mid-`rm` is not a picker. It
-    /// also never repaints the prompt skim drew over; it just prints a new one
-    /// below the damage. `repaint` is the fish idiom for both.
+    /// also leaves a stale prompt where a picked branch or directory has just
+    /// changed what the prompt says. `repaint` is the fish idiom for both.
     #[test]
     fn bindings_repaint_rather_than_execute() {
         let out = integration(Shell::Fish, &mut dummy());

--- a/src/term.rs
+++ b/src/term.rs
@@ -2,8 +2,8 @@
 //!
 //! Colour is opt-out per the `NO_COLOR` convention and is never emitted when
 //! stdout is redirected, so `scriv … ls` stays pipe-safe by default. The same
-//! rule governs [`Spinner`]: it is drawn only when there is a terminal to draw
-//! it on.
+//! rule governs [`Spinner`] and [`ScratchRow`]: they touch the display only
+//! when there is one to touch.
 
 use std::io::{IsTerminal, Write};
 use std::sync::Arc;
@@ -46,6 +46,71 @@ pub fn paint_within(text: &str, color: u8, back: u8, on: bool) -> String {
     }
 }
 
+/// A row of the terminal to draw on that is not the shell's.
+///
+/// Everything scriv draws inline — the spinner, the picker's viewport — starts
+/// on the row the cursor is on, and when scriv is invoked from a key binding
+/// that is the last row of the shell's prompt. Drawing there overwrites it, and
+/// erasing there leaves it blank. A one-line prompt survives either, because
+/// the shell redraws the whole thing afterwards; a two-line prompt does not —
+/// its first row is still on screen, so what is left is a prompt cut in half.
+///
+/// Taking a fresh row instead keeps any prompt intact. Stepping back up on the
+/// way out is what makes that safe: it leaves the cursor on the row the shell
+/// left it on, which is where its repaint expects to find it. Without that the
+/// shell redraws one row lower and strands a copy of the prompt above the new
+/// one.
+///
+/// Bind it for as long as the drawing lasts — `let _row = ScratchRow::take()`.
+/// A bare statement gives the row straight back.
+#[must_use]
+pub struct ScratchRow {
+    /// `false` when there was no terminal to take a row on, which makes the
+    /// whole type a no-op rather than a check at each call site.
+    taken: bool,
+}
+
+impl ScratchRow {
+    /// Move to a fresh row below the cursor, giving it back when dropped.
+    pub fn take() -> Self {
+        let taken = std::io::stderr().is_terminal();
+        if taken {
+            let mut err = std::io::stderr().lock();
+            // An explicit carriage return: the cursor sits part-way along the
+            // prompt row, and whether a bare newline also returns to column 0
+            // depends on a terminal mode the shell owns, not scriv.
+            let _ = err.write_all(b"\r\n");
+            let _ = err.flush();
+        }
+        Self { taken }
+    }
+
+    /// No row at all, for a caller that has nothing to protect.
+    pub fn none() -> Self {
+        Self { taken: false }
+    }
+
+    /// Whether a row was actually taken — false without a terminal to take one
+    /// on. For tests and for callers deciding what to draw.
+    pub fn is_taken(&self) -> bool {
+        self.taken
+    }
+}
+
+impl Drop for ScratchRow {
+    fn drop(&mut self) {
+        if !self.taken {
+            return;
+        }
+        let mut err = std::io::stderr().lock();
+        let _ = err.write_all(CURSOR_UP);
+        let _ = err.flush();
+    }
+}
+
+/// Move the cursor up one row, staying in its column.
+const CURSOR_UP: &[u8] = b"\x1b[A";
+
 /// Frames of the spinner, in order. Braille dots: one cell wide in every
 /// terminal, so the line never changes width as it turns.
 const FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -66,6 +131,11 @@ const CLEAR_LINE: &str = "\r\x1b[2K";
 /// name there for a shell to read, and an animation in the middle of it would
 /// be read as part of the name.
 ///
+/// It takes a [`ScratchRow`] to turn on, because each frame erases the whole
+/// row it is drawn on: on the prompt's row that would wipe the prompt, and
+/// unlike the picker that follows it, a spinner is not big enough to hide what
+/// it destroyed.
+///
 /// Nothing is drawn at all when stderr is not a terminal, so a redirected or
 /// piped run stays clean, and the animation is never what a script has to
 /// parse around.
@@ -74,6 +144,8 @@ pub struct Spinner {
     /// `None` when there was no terminal to draw on, which makes every method
     /// here a no-op rather than a special case at each call site.
     thread: Option<JoinHandle<()>>,
+    /// Dropped after the animation is erased, handing the row back.
+    _row: ScratchRow,
 }
 
 /// Start a spinner labelled `label` (e.g. `fetching`), running until it is
@@ -86,8 +158,13 @@ pub struct Spinner {
 pub fn spinner(label: &str) -> Spinner {
     let stop = Arc::new(AtomicBool::new(false));
     if !std::io::stderr().is_terminal() {
-        return Spinner { stop, thread: None };
+        return Spinner {
+            stop,
+            thread: None,
+            _row: ScratchRow::none(),
+        };
     }
+    let row = ScratchRow::take();
 
     let label = label.to_string();
     let color = !no_color();
@@ -114,12 +191,14 @@ pub fn spinner(label: &str) -> Spinner {
     Spinner {
         stop,
         thread: Some(thread),
+        _row: row,
     }
 }
 
 impl Drop for Spinner {
-    /// Stop the animation and erase its line, leaving the terminal exactly as
-    /// it was found — the picker that opens next draws over nothing.
+    /// Stop the animation and erase its line before the row it was drawn on
+    /// goes back, leaving the terminal exactly as it was found — the picker
+    /// that opens next draws over nothing.
     fn drop(&mut self) {
         self.stop.store(true, Ordering::Relaxed);
         let Some(thread) = self.thread.take() else {
@@ -185,5 +264,38 @@ mod tests {
         // The test harness captures stderr, so this is the redirected case.
         let spinner = spinner("fetching");
         assert!(spinner.thread.is_none(), "spun without a terminal");
+    }
+
+    /// The spinner has to draw on a row of its own: every frame erases the
+    /// whole line, so on the prompt's row it would wipe the prompt and leave
+    /// nothing but a blank line behind once it stopped.
+    #[test]
+    fn the_spinner_draws_on_a_row_of_its_own() {
+        let spinner = spinner("fetching");
+        assert_eq!(
+            spinner._row.is_taken(),
+            spinner.thread.is_some(),
+            "the spinner drew somewhere it did not own",
+        );
+    }
+
+    /// Taking a row writes to the terminal, so a redirected run must take
+    /// none — the newline and the cursor-up would otherwise end up in
+    /// whatever is reading stderr.
+    #[test]
+    fn no_terminal_means_no_row_taken() {
+        assert_eq!(
+            ScratchRow::take().is_taken(),
+            std::io::stderr().is_terminal()
+        );
+        assert!(!ScratchRow::none().is_taken());
+    }
+
+    /// Stepping back up is what leaves the cursor where the shell left it. A
+    /// sequence that also moved the column, or one that scrolled, would put
+    /// the shell's repaint somewhere else entirely.
+    #[test]
+    fn the_row_is_given_back_by_moving_up_one() {
+        assert_eq!(CURSOR_UP, b"\x1b[A");
     }
 }


### PR DESCRIPTION
Reported against `f3` with a two-line starship prompt: the picker overwrites
the prompt's second line.

## What was happening

skim renders inline — it asks the terminal for the cursor position and draws
its viewport starting on that row. Invoked from a key binding, that row is the
**last row of the shell's prompt**. skim drew over it and cleared it on the way
out.

A one-line prompt hid this completely: the whole prompt was the damaged row, and
fish's `repaint` put it back. A two-line prompt did not, because only its last
row was taken — leaving the picker welded to the middle of a prompt whose first
row was still sitting above it.

The spinner (`alt-p`, `branch --fetch`) had the same flaw, worse: every frame
starts with `\r\x1b[2K`, so it *erased* the prompt's row rather than covering
it. That was invisible only because the picker then drew over the same row. Fix
the picker alone and the blank row becomes plainly visible — so both moved.

## The fix

A `term::ScratchRow`: step down to a fresh row before drawing, step back up when
done. Two details matter and both are pinned by tests:

- **Stepping back up** is what makes it safe. It leaves the cursor on the row the
  shell left it on, which is where `commandline -f repaint` expects it. Without
  it fish redraws one row lower and strands a copy of the prompt above the new one
  — I hit exactly that on the first attempt.
- **No row when there is no terminal**, or when `height = "100%"` — a full-screen
  picker takes the alternate screen and hands the display back untouched, so a
  reserved row there would leave a stray blank line above every prompt.

## Verification

`make` green (170 tests). Beyond that, I drove real fish 4.8 with a real
starship prompt inside a pty against a terminal emulator that answers cursor-
position queries and implements `CSI S` (skim scrolls with it), and rendered the
screen at each step. Checked before/after for: prompt mid-screen; prompt at the
bottom, where skim scrolls to make room; one-line prompt; a command already
typed; accept and cancel; the streamed (`alt-e`) and spinner (`alt-p`) paths.
Prompt intact throughout, nothing stranded or duplicated after exit.

## Docs

- **CLI help (`src/main.rs`)** — untouched. No command or flag changed.
- **README** — untouched. No command, binding, or config key changed; the
  `height` key means exactly what it did.
- **`docs/demo.gif`** — re-recorded to check, and the result is frame-for-frame
  identical to the committed one apart from the fixture's randomised commit
  hashes. The demo runs at a one-line prompt on a fresh screen, so the reserved
  row is absorbed by the scroll. Reverted rather than commit binary churn.

Also added a bullet to CLAUDE.md, since "never draw on the row scriv was invoked
on" is the kind of rule that is invisible until something breaks.