### PR TITLE
Move fish key bindings from alt to ctrl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,8 +123,14 @@ reference, so command implementations do no environment lookups of their own.
   work from a child process.
 - **Colour is dropped when stdout is not a terminal**, and `NO_COLOR` is
   honoured — `ls` output has to stay pipe-safe. Use `term::stdout_color()`.
-- **Key bindings use `alt-<letter>`.** fish leaves that space entirely unbound,
-  while function keys past `f3` are commonly taken by users' own tools.
+- **Key bindings use `ctrl-<letter>`, and never `alt-`.** ctrl is the modifier
+  people put under a pinky, so it is where a picker worth a keystroke belongs.
+  fish leaves only `ctrl-o` and `ctrl-q` unbound, so anything further has to
+  displace a preset binding deliberately and say which one in the comment above
+  `scriv_key_bindings`. alt is not the escape hatch it looks like: fish binds
+  most of `alt-<letter>` (`alt-b`, `alt-e`, `alt-o`, `alt-p` among them).
+  `ctrl-i`/`ctrl-j`/`ctrl-m` are tab/newline/enter and are never bindable;
+  function keys past `f3` are commonly taken by users' own tools.
 
 ## The demo
 

--- a/README.md
+++ b/README.md
@@ -178,11 +178,16 @@ end
 
 | Key | Does |
 | --- | --- |
-| `ctrl-o`, `alt-o` | pick a repository and `cd` into it |
-| `alt-e` | pick a file below `$PWD` and open it in `$EDITOR` |
+| `ctrl-o` | pick a repository and `cd` into it |
+| `ctrl-g` | pick a branch and check it out |
+| `ctrl-p` | pick a pull request and check it out |
 | `f3` | pick a tracked file and open it in `$EDITOR` |
-| `alt-b`, `alt-g` | pick a branch and check it out |
-| `alt-p` | pick a pull request and check it out |
+| `ctrl-q` | pick a file below `$PWD` and open it in `$EDITOR` |
+
+Of those, `ctrl-o` and `ctrl-q` are unbound in fish; `ctrl-g` replaces `cancel`,
+which `escape` and `ctrl-c` also do, and `ctrl-p` replaces `up-line`, leaving
+`up` and `ctrl-r` to search history. alt is left untouched, since fish binds
+most of it already.
 
 It also defines `fe` — find, fuzzy-pick, edit — as a short alias for
 `scriv edit`, forwarding its arguments so `fe -t` and `fe src/main.rs` work

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -70,10 +70,16 @@ function scriv-pr-checkout --description "Pick a GitHub pull request and check i
     command scriv pr checkout
 end
 
-# Bindings use alt-<letter>, which fish leaves entirely unbound by default, and
-# are chosen so the chord falls under one hand: alt-b (branch), alt-g (git) and
-# alt-e (edit) are left-hand, alt-o and alt-p right-hand. Rebind any of them by
-# calling `bind` yourself after `scriv_key_bindings`.
+# Bindings are ctrl-<letter>, reachable without leaving the home row on a layout
+# where ctrl sits under the left pinky. Only ctrl-o and ctrl-q are unbound in
+# fish, so the other two displace a preset binding on purpose:
+#
+#   ctrl-g  branch checkout, over `cancel` — escape and ctrl-c both do that too
+#   ctrl-p  pr checkout, over `up-line` — up and ctrl-r still search history
+#
+# Rebind any of them by calling `bind` yourself after `scriv_key_bindings`; the
+# last binding for a key wins. alt-<letter> is left alone on purpose — it looks
+# free but is not, since fish presets alt-b, alt-e, alt-o and alt-p among others.
 #
 # Every binding ends in `commandline -f repaint`, never `execute`. The picker
 # renders inline, and scriv opens it on a row of its own below the prompt so it
@@ -85,12 +91,10 @@ end
 # would execute whatever was there.
 function scriv_key_bindings --description "Bind scriv pickers to keys"
     bind ctrl-o "scriv-repo-cd; commandline -f repaint"
-    bind alt-o  "scriv-repo-cd; commandline -f repaint"
-    bind alt-e  "scriv-edit; commandline -f repaint"
+    bind ctrl-q "scriv-edit; commandline -f repaint"
     bind f3     "scriv-file-edit; commandline -f repaint"
-    bind alt-b  "scriv-branch-checkout; commandline -f repaint"
-    bind alt-g  "scriv-branch-checkout; commandline -f repaint"
-    bind alt-p  "scriv-pr-checkout; commandline -f repaint"
+    bind ctrl-g "scriv-branch-checkout; commandline -f repaint"
+    bind ctrl-p "scriv-pr-checkout; commandline -f repaint"
 end
 "#;
 
@@ -120,12 +124,36 @@ mod tests {
         let out = integration(Shell::Fish, &mut dummy());
         assert!(out.contains("complete -c scriv"));
         assert!(out.contains("bind ctrl-o"));
-        assert!(out.contains("bind alt-o"));
-        assert!(out.contains("bind alt-e"));
+        assert!(out.contains("bind ctrl-q"));
         assert!(out.contains("bind f3"));
-        assert!(out.contains("bind alt-b"));
-        assert!(out.contains("bind alt-g"));
-        assert!(out.contains("bind alt-p"));
+        assert!(out.contains("bind ctrl-g"));
+        assert!(out.contains("bind ctrl-p"));
+    }
+
+    /// fish binds most of alt-<letter> itself — alt-b is backward-word, alt-e
+    /// opens the command line in `$EDITOR`, alt-o pages the file at the cursor,
+    /// alt-p pipes the job through the pager — so scriv taking any of it would
+    /// quietly replace a binding the user did not ask it to touch.
+    #[test]
+    fn fish_leaves_alt_alone() {
+        let out = integration(Shell::Fish, &mut dummy());
+        let alt: Vec<&str> = out
+            .lines()
+            .map(str::trim)
+            .filter(|l| l.starts_with("bind alt-"))
+            .collect();
+        assert!(alt.is_empty(), "scriv binds alt keys: {alt:?}");
+    }
+
+    /// Historic control codes: ctrl-i *is* tab, ctrl-j newline and ctrl-m enter.
+    /// Terminals that speak a modern key encoding can tell them apart, but on
+    /// the ones that cannot, binding these breaks completion or the enter key.
+    #[test]
+    fn fish_avoids_keys_that_collide_with_tab_and_enter() {
+        let out = integration(Shell::Fish, &mut dummy());
+        for key in ["bind ctrl-i", "bind ctrl-j", "bind ctrl-m"] {
+            assert!(!out.contains(key), "{key} collides with tab or enter");
+        }
     }
 
     /// `fe` takes arguments, so it stands in for `scriv edit` completely rather
@@ -176,8 +204,8 @@ mod tests {
         }
     }
 
-    /// f4 and f5 are common in user configs (awsvault, editors); fish leaves
-    /// the whole alt-<letter> space free, so scriv stays out of the way.
+    /// f4 and f5 are common in user configs (awsvault, editors), so f3 is as far
+    /// up the function keys as scriv reaches.
     #[test]
     fn fish_avoids_function_keys_beyond_f3() {
         let out = integration(Shell::Fish, &mut dummy());


### PR DESCRIPTION
## Why

The bindings sat on `alt-<letter>` on the premise — stated in `shell.rs` and in `CLAUDE.md` — that fish leaves that space entirely unbound. It doesn't. Four of the five bindings scriv emitted were replacing a fish preset without saying so:

| scriv binding | fish preset it overwrote |
| --- | --- |
| `alt-e` | `edit_command_buffer` — edit the command line in `$EDITOR` |
| `alt-b` | `backward-word` |
| `alt-o` | open the file at the cursor in a pager |
| `alt-p` | append `&\| less` to the job under the cursor |

alt is also the modifier least likely to be under a resting finger, whereas ctrl commonly sits under the left pinky (caps lock remapped, or a layout that puts it there).

## What

| key | action | trade |
| --- | --- | --- |
| `ctrl-o` | repo pick + `cd` | unchanged |
| `ctrl-g` | branch checkout | over `cancel` — `escape` and `ctrl-c` both do that |
| `ctrl-p` | pr checkout | over `up-line` — `up` and `ctrl-r` still search history |
| `f3` | tracked-file edit | unchanged |
| `ctrl-q` | `scriv edit` | none, unbound in fish |

Only `ctrl-o` and `ctrl-q` are unbound in fish, so branch and pr checkout — the most valuable pickers after repo-cd — each displace one preset, picked for having a duplicate elsewhere. The comment above `scriv_key_bindings` names both trades so the next reader doesn't have to rediscover them. Flow control being disabled in fish is what makes `ctrl-q` safe.

This is a breaking change for anyone with the old keys in muscle memory; the README says how to rebind, and `scriv_key_bindings` was already designed to be overridden.

## Tests

The old test asserted each key by name, which locks in the keys without protecting anything. Replaced with the two guarantees underneath:

- `fish_leaves_alt_alone` — scriv emits no `bind alt-*` at all, so the clash above cannot come back.
- `fish_avoids_keys_that_collide_with_tab_and_enter` — never `ctrl-i`/`ctrl-j`/`ctrl-m`, which are tab, newline and enter in the historic encoding.

`make` green; 172 tests pass.

## Docs walked

1. **CLI help text** — no change needed. Nothing in `main.rs` mentions the shell bindings; the `ctrl-r` in the branch and pr doc comments is skim's own reload key inside the picker, unrelated to fish bindings.
2. **README.md** — key-binding table rewritten, with a sentence on which presets are displaced. The feature table, `Commands` section and sample `config.toml` are untouched by this change.
3. **`docs/demo.gif`** — no re-record needed. The tape drives scriv by typing commands, not key bindings, and no picker's on-screen output changed.

`CLAUDE.md` also carried the incorrect alt rationale; it now states the ctrl rule, which keys are actually free, and why alt is off limits.