### PR TITLE
Hand finished pull requests to GitHub auto-merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,27 @@ work worth doing.
 The gate is confidence that the change is sound, and that has a definition
 here already: `make` green, each commit building and testing green on its own,
 and the three docs above walked and accounted for in the PR body. Meet it and
-merge. Squash-merge and delete the branch, matching the existing history.
+merge.
+
+Merging means handing the PR to GitHub rather than sitting and watching CI:
+
+```
+gh pr merge --squash --auto --delete-branch
+```
+
+`--auto` lands the PR itself once the checks pass, which keeps the squash and
+the branch deletion matching the existing history without a poll loop. It is
+load-bearing that `build` and `demo` are *required* status checks on `main`
+(the `default` ruleset): auto-merge only queues behind checks that are
+required, so if that rule is ever removed, `--auto` stops waiting and merges
+on the spot. Repo settings already delete the remote branch on merge, so
+`--delete-branch` is there for the local one.
+
+Enabling auto-merge is not the same as walking away. Something still has to
+observe the result, because a red check leaves the PR sitting open forever
+rather than reporting a failure to anyone. Say in the reply that auto-merge is
+armed, and check back — with a backgrounded `gh pr checks <n> --watch`, or on
+the next turn — so a failure gets fixed rather than silently parked.
 
 Never commit straight to `main`. The pull request is what leaves a reviewable
 record of work nobody watched happen — which matters more when there is no


### PR DESCRIPTION
## Why

Auto-merge is now enabled on the repository, so a finished PR no longer needs a poll loop and a second command to land it.

## What

`CLAUDE.md`'s shipping section now says to merge with:

```
gh pr merge --squash --auto --delete-branch
```

Two things the note is careful about:

- **It only waits because the checks are required.** GitHub auto-merge queues behind *required* status checks and nothing else. `main` had none — the classic protection API returned 404 and the `default` ruleset held only `deletion` and `non_fast_forward` — so `--auto` on its own would have merged immediately, ahead of CI, which is the opposite of the intent. `build` and `demo` are now `required_status_checks` in that ruleset (`strict` left off, so a branch behind `main` still merges without a forced rebase). The note flags the dependency, since the flag silently changes meaning if the rule is ever dropped.
- **Arming auto-merge is not walking away.** A red check leaves the PR open and reports to nobody, so the result still has to be observed and said out loud.

`--delete-branch` stays for the local branch; `delete_branch_on_merge` already handles the remote one.

## Docs walked

Docs-only change, and none of the three staleness-prone docs are affected: no CLI surface changed (`main.rs` help untouched), the README documents the tool rather than the contribution flow, and no picker output changed, so `docs/demo.gif` does not need a re-record.

This PR is itself the first use of the flow it documents.