### PR TITLE
Say what auto-merge leaves behind

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,22 +56,26 @@ merge.
 Merging means handing the PR to GitHub rather than sitting and watching CI:
 
 ```
-gh pr merge --squash --auto --delete-branch
+gh pr merge --squash --auto
 ```
 
-`--auto` lands the PR itself once the checks pass, which keeps the squash and
-the branch deletion matching the existing history without a poll loop. It is
-load-bearing that `build` and `demo` are *required* status checks on `main`
-(the `default` ruleset): auto-merge only queues behind checks that are
-required, so if that rule is ever removed, `--auto` stops waiting and merges
-on the spot. Repo settings already delete the remote branch on merge, so
-`--delete-branch` is there for the local one.
+`--auto` lands the PR itself once the checks pass, squash-merging to match the
+existing history, with no poll loop in between. It is load-bearing that `build`
+and `demo` are *required* status checks on `main` (the `default` ruleset):
+auto-merge only queues behind checks that are required, so if that rule is ever
+removed, `--auto` stops waiting and merges on the spot.
 
-Enabling auto-merge is not the same as walking away. Something still has to
-observe the result, because a red check leaves the PR sitting open forever
-rather than reporting a failure to anyone. Say in the reply that auto-merge is
-armed, and check back — with a backgrounded `gh pr checks <n> --watch`, or on
-the next turn — so a failure gets fixed rather than silently parked.
+Two things auto-merge does not do for you:
+
+- **The local branch survives.** `gh` exits the moment auto-merge is armed, so
+  `--delete-branch` never gets to run — and the squash rewrites the commit, so
+  even afterwards `git branch -d` calls the branch unmerged. Clean up with
+  `git checkout main && git pull && git branch -D <branch>` once it lands. The
+  remote branch is handled by the repo's `delete_branch_on_merge`.
+- **A failure tells nobody.** A red check leaves the PR sitting open
+  indefinitely. Say in the reply that auto-merge is armed, and check back —
+  with a backgrounded wait on `gh pr view <n> --json state`, or on the next
+  turn — so a failure gets fixed rather than silently parked.
 
 Never commit straight to `main`. The pull request is what leaves a reviewable
 record of work nobody watched happen — which matters more when there is no


### PR DESCRIPTION
## Why

#30 documented `gh pr merge --squash --auto --delete-branch` and claimed `--delete-branch` was there to remove the local branch. That is wrong, and #30 itself proved it: after auto-merge landed, `automerge-docs` was still sitting in `git branch`.

Two reasons it cannot work:

- `gh` exits the moment auto-merge is armed — minutes before the merge actually happens — so `--delete-branch` never gets a chance to run.
- The squash rewrites the commit, so even after pulling `main`, `git branch -d` reports the branch as not fully merged. It takes `-D`.

## What

- Drops `--delete-branch` from the documented command rather than leaving a flag in it that does nothing on this path.
- Spells out the cleanup: `git checkout main && git pull && git branch -D <branch>`, and notes the remote branch is handled by the repo's `delete_branch_on_merge` setting.
- Files it alongside the other thing auto-merge does not do for you — reporting a failure — since both are "the command returned, but you are not done" traps.

## Docs walked

Docs-only, and none of the three staleness-prone docs are touched: no CLI surface changed, the README covers the tool rather than the contribution flow, and no picker output changed, so `docs/demo.gif` needs no re-record.