### PR TITLE
Group config settings by the command that reads them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .idea
+.claude

--- a/README.md
+++ b/README.md
@@ -138,8 +138,7 @@ Select several with `tab` and they open together. The walk honours
 `.gitignore`, `.ignore` and `.fdignore`, streams into the picker as it goes —
 so a directory of a million files is typeable in milliseconds, not once the
 last one is found — and quietly skips paths it is not allowed to read. The
-editor is `$VISUAL`, then `$EDITOR`, unless the config sets `editor`. `edit`
-abbreviates to `e`.
+editor is `$VISUAL`, then `$EDITOR`. `edit` abbreviates to `e`.
 
 Every `pick` prints one line and nothing else, so it composes:
 
@@ -202,7 +201,14 @@ emit completions.
 
 `scriv config init` writes `~/.config/scriv/config.toml`:
 
+Settings are grouped by the command that reads them. A key lives in a command's
+table when exactly one command reads it; anything genuinely shared — the picker
+— stays at the top level.
+
 ```toml
+# `scriv repo`: where your repositories are, and how they are labelled.
+[repo]
+
 # Every repository lives under one root, laid out as <owner>/<repo> — the same
 # shape as GitHub itself. `repo clone` writes here, so a clone always lands
 # somewhere `repo pick` will find it.
@@ -215,34 +221,40 @@ extra = ["~/bin"]
 # Directory names to skip while searching.
 ignore = ["node_modules", "target"]
 
-# Editor launched by `scriv edit`. Defaults to $VISUAL, then $EDITOR.
-editor = "nvim"
+# Repo path rendering: relative | tilde | full
+display = "relative"
 
-# Categories label owners, one category to many owners, so everything you touch
-# for work colours as one group however many orgs it spans. `work` is cyan and
-# `personal` green wherever they appear; any other category takes one of the
-# remaining hues. An owner in no category still shows up, in the terminal's
-# ordinary foreground.
-[owners]
-personal = ["joakimen"]
-work = ["capralifecycle", "nsbno"]
+# Labels name owners, one label to many owners, so everything you touch for work
+# colours as one group however many orgs it spans. `work` is cyan and `personal`
+# green wherever they appear; any other label takes one of the remaining hues. An
+# owner with no label still shows up, in the terminal's ordinary foreground.
+labels = { personal = ["joakimen"], work = ["capralifecycle", "nsbno"] }
 
+# The built-in fuzzy picker, shared by every command that opens one.
 [picker]
-height = "50%"                # built-in finder height
-display = "relative"          # repo path rendering: relative | tilde | full
+height = "50%"                # finder height
 preview = true                # show a preview pane for the highlighted row
 preview_window = "right:50%"  # preview layout
 ```
 
+`labels` is written inline, on one line, rather than as a `[repo.labels]`
+header. Both parse the same, but a header captures every bare key written after
+it — add `ignore` below a `[repo.labels]` header and it silently becomes a label
+named "ignore" instead of an error. The inline table has no such ordering rule.
+
 One root, always two levels deep. The depth is not a setting because it is not a
 preference: the root mirrors GitHub's own namespace, and fixing it is what lets
-`repo clone` work out where a repository belongs without being told. Categories
-label *owners* rather than directories, so moving an org between `work` and
-`personal` is a one-word edit instead of a reshuffle on disk.
+`repo clone` work out where a repository belongs without being told. Labels name
+*owners* rather than directories, so moving an org between `work` and `personal`
+is a one-word edit instead of a reshuffle on disk.
 
-A config still using the older `[[paths.*]]` format is refused with the
-replacement written out for you, derived from what was there — including which
-of your paths become `extra`.
+The editor is `$VISUAL`, then `$EDITOR`. There is no config key for it: it is
+already stated once where every other terminal tool reads it, and a third place
+to set it is a third place to forget it is set.
+
+A config still using an older layout — top-level `root`/`owners`, or the
+`[[paths.*]]` format before that — is refused with the replacement written out
+for you, derived from what was there.
 
 The tracked-files list sits beside the config in `~/.config/scriv/files`, one
 path per line, managed by `scriv file add`/`remove`.

--- a/demo/fixture.sh
+++ b/demo/fixture.sh
@@ -102,17 +102,16 @@ done
 
 # --- configuration -----------------------------------------------------------
 cat > "$FIX/.config/scriv/config.toml" <<EOF
+[repo]
 root = "~/dev/github.com"
 ignore = ["node_modules", "target"]
+display = "relative"
 
-# Categories label owners, so the picker colours acme's repos as work.
-[owners]
-work = ["acme"]
-personal = ["personal"]
+# Labels name owners, so the picker colours acme's repos as work.
+labels = { work = ["acme"], personal = ["personal"] }
 
 [picker]
 height = "100%"
-display = "relative"
 preview = true
 preview_window = "right:38%"
 EOF

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -7,9 +7,13 @@ use anyhow::{Context, Result, bail};
 
 use crate::Ctx;
 
-/// A commented starter config covering the common layout: search roots grouped
-/// by label and the default picker. Users edit it to taste.
-const TEMPLATE: &str = r#"# scriv configuration.
+/// A commented starter config. Settings are grouped by the command that reads
+/// them; users edit it to taste.
+const TEMPLATE: &str = r#"# scriv configuration. Settings are grouped by the command that reads them,
+# with `[picker]` — shared by every picker — at the end.
+
+# `scriv repo`: where your repositories are, and how they are labelled.
+[repo]
 
 # Every repository lives under one root, laid out as <owner>/<repo> — the same
 # shape as GitHub itself. `repo clone` writes here, so a clone always lands
@@ -23,20 +27,20 @@ root = "~/dev/github.com"
 # Directory names to skip while searching.
 ignore = ["node_modules", "target"]
 
-# Editor launched by `scriv edit`. Defaults to $VISUAL, then $EDITOR.
-# editor = "nvim"
+# How repository paths are rendered: relative | tilde | full
+# display = "relative"
 
-# Categories label owners, one category to many owners, so everything you touch
-# for work colours as one group in the picker however many orgs it spans. An
-# owner in no category still shows up — just uncoloured.
-[owners]
-# personal = ["your-github-user"]
-# work = ["acme", "acme-labs"]
+# Labels name owners, one label to many owners, so everything you touch for work
+# colours as one group in the picker however many orgs it spans. An owner with
+# no label still shows up — just uncoloured.
+#
+# Written inline, on one line, so it stays an ordinary `[repo]` key: a
+# `[repo.labels]` header would swallow every `[repo]` key written after it.
+# labels = { personal = ["your-github-user"], work = ["acme", "acme-labs"] }
 
-# Built-in fuzzy picker.
+# The built-in fuzzy picker, shared by every command that opens one.
 [picker]
 height = "50%"        # finder height, e.g. "50%" or "20"
-# display = "relative" # repo path rendering: relative | tilde | full
 # preview = true       # show a preview pane for the highlighted row
 # preview_window = "right:50%" # preview layout: [up|down|left|right][:SIZE][:hidden]
 "#;
@@ -87,22 +91,26 @@ pub fn print(ctx: &Ctx) -> Result<()> {
         ctx.config_path.display()
     ));
 
-    println!("root: {}", ctx.config.root.as_deref().unwrap_or("(unset)"));
-    if !ctx.config.extra.is_empty() {
-        println!("extra: {}", ctx.config.extra.join(", "));
+    let repo = &ctx.config.repo;
+    println!("[repo]");
+    println!("root: {}", repo.root.as_deref().unwrap_or("(unset)"));
+    if !repo.extra.is_empty() {
+        println!("extra: {}", repo.extra.join(", "));
     }
-    if !ctx.config.owners.is_empty() {
-        println!("owners:");
-        for (category, owners) in &ctx.config.owners {
-            println!("  {category}: {}", owners.join(", "));
+    println!("ignore: {}", repo.ignore.join(", "));
+    println!("display: {}", repo.display.as_str());
+    if !repo.labels.is_empty() {
+        println!("labels:");
+        for (label, owners) in &repo.labels {
+            println!("  {label}: {}", owners.join(", "));
         }
     }
+
     println!();
-    println!("ignore: {}", ctx.config.ignore.join(", "));
     println!(
         "editor: {}",
         ctx.editor_setting()
-            .unwrap_or("(unset — set $EDITOR or $VISUAL)")
+            .unwrap_or("(unset — set $VISUAL or $EDITOR)")
     );
     Ok(())
 }
@@ -111,4 +119,65 @@ pub fn print(ctx: &Ctx) -> Result<()> {
 pub fn path(ctx: &Ctx) -> Result<()> {
     println!("{}", ctx.config_path.display());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{RepoDisplay, load_config};
+
+    /// The starter config is the main thing teaching the current layout, so it
+    /// has to be a config scriv actually accepts — a template still written in
+    /// a superseded shape would hand every new user the migration error on
+    /// their first run.
+    #[test]
+    fn the_starter_template_parses() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, TEMPLATE).unwrap();
+
+        let cfg = load_config(&path).unwrap();
+        assert_eq!(cfg.repo.root.as_deref(), Some("~/dev/github.com"));
+        assert_eq!(
+            cfg.repo.ignore,
+            vec!["node_modules".to_string(), "target".to_string()]
+        );
+        assert_eq!(cfg.repo.display, RepoDisplay::Relative);
+        assert_eq!(cfg.picker.height, "50%");
+    }
+
+    /// Every commented-out key is advice, and advice that does not parse is
+    /// worse than none — uncommenting them all has to still yield a valid
+    /// config, including the inline `labels` table.
+    ///
+    /// A commented key is `# <name> = ...`; prose comments are left alone, so
+    /// this stays a test of the suggestions rather than of the heuristic.
+    #[test]
+    fn the_templates_commented_keys_parse_when_uncommented() {
+        let is_key = |line: &str| {
+            line.split_once(" = ").is_some_and(|(name, _)| {
+                !name.is_empty() && name.chars().all(|c| c.is_ascii_lowercase() || c == '_')
+            })
+        };
+        let uncommented: String = TEMPLATE
+            .lines()
+            .map(|line| match line.strip_prefix("# ") {
+                Some(rest) if is_key(rest) => rest,
+                _ => line,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(uncommented.contains("labels = {"), "{uncommented}");
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, &uncommented).unwrap();
+
+        let cfg = load_config(&path)
+            .unwrap_or_else(|e| panic!("uncommented template rejected: {e:#}\n\n{uncommented}"));
+        assert_eq!(cfg.repo.extra, vec!["~/bin".to_string()]);
+        assert_eq!(cfg.repo.display, RepoDisplay::Relative);
+        assert_eq!(cfg.repo.label_of("acme"), Some("work"));
+        assert!(!cfg.picker.preview_window.is_empty());
+    }
 }

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -8,16 +8,16 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Context, Result, bail};
 
-use crate::config::{Owners, RepoDisplay};
+use crate::config::{Labels, RepoDisplay};
 use crate::gh::{self, Repo};
 use crate::path::{display_path, expand_home_dir, relative_label};
 use crate::pick::{Choice, PickItem, Preview};
 use crate::repo::FoundRepo;
 use crate::{Ctx, pick, repo, term};
 
-/// Discover repositories, category-tagged and sorted by path.
+/// Discover repositories, label-tagged and sorted by path.
 fn discover(ctx: &Ctx) -> Result<Vec<FoundRepo>> {
-    if ctx.config.root.is_none() && ctx.config.extra.is_empty() {
+    if ctx.config.repo.root.is_none() && ctx.config.repo.extra.is_empty() {
         anyhow::bail!(
             "no `root` configured in {}; run `scriv config init` to create a starter config",
             ctx.config_path.display()
@@ -25,7 +25,7 @@ fn discover(ctx: &Ctx) -> Result<Vec<FoundRepo>> {
     }
     ctx.log.info(&format!(
         "settings: ignore = {}",
-        ctx.config.ignore.join(", ")
+        ctx.config.repo.ignore.join(", ")
     ));
 
     let mut repos = repo::find_all_repos(&ctx.config, ctx.home(), &ctx.log)
@@ -54,56 +54,56 @@ pub fn ls(ctx: &Ctx, absolute: bool) -> Result<()> {
     Ok(())
 }
 
-/// ANSI 256-colour indices used to tint categories, in assignment order.
+/// ANSI 256-colour indices used to tint labels, in assignment order.
 /// Standard hues (cyan, green, yellow, magenta, blue, red) so they read well and
-/// follow the terminal theme; cycles if there are more categories than colours.
-const CATEGORY_COLORS: &[u8] = &[6, 2, 3, 5, 4, 1];
+/// follow the terminal theme; cycles if there are more labels than colours.
+const LABEL_COLORS: &[u8] = &[6, 2, 3, 5, 4, 1];
 
-/// Categories whose colour is fixed by name rather than by config order.
+/// Labels whose colour is fixed by name rather than by config order.
 ///
 /// `work` and `personal` are the split nearly every config makes, and reading a
 /// row is faster when the hue means the same thing in every checkout — so they
 /// keep cyan and green wherever they appear in the file. Everything else takes
 /// the next unused hue, in config order.
-const NAMED_CATEGORY_COLORS: &[(&str, u8)] = &[("work", 6), ("personal", 2)];
+const NAMED_LABEL_COLORS: &[(&str, u8)] = &[("work", 6), ("personal", 2)];
 
-/// The fixed colour for `category`, if it is one of the conventional names.
-fn named_color(category: &str) -> Option<u8> {
-    NAMED_CATEGORY_COLORS
+/// The fixed colour for `label`, if it is one of the conventional names.
+fn named_color(label: &str) -> Option<u8> {
+    NAMED_LABEL_COLORS
         .iter()
-        .find(|(name, _)| name.eq_ignore_ascii_case(category))
+        .find(|(name, _)| name.eq_ignore_ascii_case(label))
         .map(|&(_, color)| color)
 }
 
-/// Map each configured category to a colour.
+/// Map each configured label to a colour.
 ///
-/// [`UNCATEGORIZED`](crate::config::UNCATEGORIZED) is deliberately not in the
-/// map: an uncategorised repository is not a category of its own competing for
-/// a hue, it is the absence of one, and stays the terminal's default foreground.
-/// Dimming it would read as "not this one", when it is an ordinary choice.
-fn category_colors(owners: &Owners) -> std::collections::HashMap<&str, u8> {
-    // Hues spoken for by a named category actually present, so an unnamed
-    // category never collides with `work`'s cyan.
-    let taken: Vec<u8> = owners.keys().filter_map(|c| named_color(c)).collect();
-    let mut free: Vec<u8> = CATEGORY_COLORS
+/// [`UNLABELLED`](crate::config::UNLABELLED) is deliberately not in the map: an
+/// unlabelled repository is not a label of its own competing for a hue, it is
+/// the absence of one, and stays the terminal's default foreground. Dimming it
+/// would read as "not this one", when it is an ordinary choice.
+fn label_colors(labels: &Labels) -> std::collections::HashMap<&str, u8> {
+    // Hues spoken for by a named label actually present, so an unnamed label
+    // never collides with `work`'s cyan.
+    let taken: Vec<u8> = labels.keys().filter_map(|l| named_color(l)).collect();
+    let mut free: Vec<u8> = LABEL_COLORS
         .iter()
         .copied()
         .filter(|c| !taken.contains(c))
         .collect();
     if free.is_empty() {
-        free = CATEGORY_COLORS.to_vec();
+        free = LABEL_COLORS.to_vec();
     }
 
     let mut next = 0;
-    owners
+    labels
         .keys()
-        .map(|category| {
-            let color = named_color(category).unwrap_or_else(|| {
+        .map(|label| {
+            let color = named_color(label).unwrap_or_else(|| {
                 let color = free[next % free.len()];
                 next += 1;
                 color
             });
-            (category.as_str(), color)
+            (label.as_str(), color)
         })
         .collect()
 }
@@ -131,24 +131,24 @@ fn preview(path: &str) -> Preview {
 
 /// `scriv repo pick` — fuzzy-select one repository and print its absolute path.
 ///
-/// Each row is prefixed with its category, coloured per category so a `work`
+/// Each row is prefixed with its label, coloured per label so a `work`
 /// checkout is distinguishable from a personal one at a glance — several owners
-/// can share one category and therefore one colour, and a repository in no
-/// category is left uncoloured. Paths render per `picker.display`. The printed
-/// path is always absolute so a shell shim can `cd` to it directly.
+/// can share one label and therefore one colour, and a repository with no label
+/// is left uncoloured. Paths render per `repo.display`. The printed path is
+/// always absolute so a shell shim can `cd` to it directly.
 pub fn pick(ctx: &Ctx) -> Result<()> {
     let repos = discover(ctx)?;
-    let colors = category_colors(&ctx.config.owners);
+    let colors = label_colors(&ctx.config.repo.labels);
 
     // Character count, not bytes: `{:<width$}` pads by characters, so a byte
-    // length would over-pad a category label containing non-ASCII.
+    // length would over-pad a label containing non-ASCII.
     let width = repos
         .iter()
-        .map(|r| r.category.chars().count())
+        .map(|r| r.label.chars().count())
         .max()
         .unwrap_or(0);
 
-    let mode = ctx.config.picker.display;
+    let mode = ctx.config.repo.display;
     let items: Vec<PickItem> = repos
         .iter()
         .map(|repo| {
@@ -158,9 +158,9 @@ pub fn pick(ctx: &Ctx) -> Result<()> {
                 RepoDisplay::Tilde => display_path(&abs, ctx.home_str(), false),
                 RepoDisplay::Full => abs.clone(),
             };
-            let label = format!("{category:<width$}  {shown}", category = repo.category);
-            let item = PickItem::new(label, abs.clone()).preview(preview(&abs));
-            match colors.get(repo.category.as_str()) {
+            let row = format!("{label:<width$}  {shown}", label = repo.label);
+            let item = PickItem::new(row, abs.clone()).preview(preview(&abs));
+            match colors.get(repo.label.as_str()) {
                 Some(&color) => item.color(color),
                 None => item,
             }
@@ -187,7 +187,7 @@ const PRESENT_COLOR: u8 = 8;
 
 /// The configured root, expanded — the one directory clones are written to.
 fn clone_root(ctx: &Ctx) -> Result<PathBuf> {
-    let root = ctx.config.root.as_deref().ok_or_else(|| {
+    let root = ctx.config.repo.root.as_deref().ok_or_else(|| {
         anyhow::anyhow!(
             "no `root` configured in {}; `repo clone` writes to <root>/<owner>/<repo>",
             ctx.config_path.display()
@@ -222,7 +222,7 @@ fn owner_candidates(ctx: &Ctx, root: &Path) -> Vec<String> {
         }
     };
 
-    for owner in ctx.config.known_owners() {
+    for owner in ctx.config.repo.known_owners() {
         push(owner, &mut out);
     }
     if let Ok(entries) = std::fs::read_dir(root) {
@@ -254,17 +254,17 @@ fn select_owner(ctx: &Ctx, root: &Path) -> Result<String> {
     ctx.log
         .info(&format!("{} owner candidates", candidates.len()));
 
-    let colors = category_colors(&ctx.config.owners);
+    let colors = label_colors(&ctx.config.repo.labels);
     let items: Vec<PickItem> = candidates
         .iter()
         .map(|owner| {
-            let category = ctx.config.category_of(owner);
-            let label = match category {
-                Some(c) => format!("{owner}  ({c})"),
+            let label = ctx.config.repo.label_of(owner);
+            let row = match label {
+                Some(l) => format!("{owner}  ({l})"),
                 None => owner.clone(),
             };
-            let item = PickItem::new(label, owner.clone());
-            match category.and_then(|c| colors.get(c).copied()) {
+            let item = PickItem::new(row, owner.clone());
+            match label.and_then(|l| colors.get(l).copied()) {
                 Some(color) => item.color(color),
                 None => item,
             }
@@ -498,47 +498,43 @@ mod tests {
         .unwrap()
     }
 
-    fn owners(categories: &[&str]) -> Owners {
-        categories
+    fn labels(names: &[&str]) -> Labels {
+        names
             .iter()
-            .map(|c| ((*c).to_string(), Vec::new()))
+            .map(|n| ((*n).to_string(), Vec::new()))
             .collect()
     }
 
     /// `work` and `personal` mean the same colour in every config, so a row's
     /// hue can be read without remembering what order the file was written in.
     #[test]
-    fn the_conventional_categories_keep_their_colours() {
-        let (first, last) = (owners(&["work", "personal"]), owners(&["personal", "work"]));
-        let listed_first = category_colors(&first);
-        let listed_last = category_colors(&last);
+    fn the_conventional_labels_keep_their_colours() {
+        let (first, last) = (labels(&["work", "personal"]), labels(&["personal", "work"]));
+        let listed_first = label_colors(&first);
+        let listed_last = label_colors(&last);
         assert_eq!(listed_first.get("work"), Some(&6), "work is cyan");
         assert_eq!(listed_first.get("personal"), Some(&2), "personal is green");
         assert_eq!(
             listed_first, listed_last,
             "config order changed the colours"
         );
-        // No entry for the absence of a category: those rows stay uncoloured.
-        assert!(!listed_first.contains_key(crate::config::UNCATEGORIZED));
+        // No entry for the absence of a label: those rows stay uncoloured.
+        assert!(!listed_first.contains_key(crate::config::UNLABELLED));
     }
 
-    /// Any other category takes a hue, but never one a named category is
-    /// already using — two groups the same colour is the one thing the tint
-    /// exists to avoid.
+    /// Any other label takes a hue, but never one a named label is already
+    /// using — two groups the same colour is the one thing the tint exists to
+    /// avoid.
     #[test]
-    fn other_categories_avoid_the_reserved_hues() {
-        let configured = owners(&["client", "work", "oss", "personal"]);
-        let colors = category_colors(&configured);
+    fn other_labels_avoid_the_reserved_hues() {
+        let configured = labels(&["client", "work", "oss", "personal"]);
+        let colors = label_colors(&configured);
         assert_eq!(colors.get("work"), Some(&6));
         assert_eq!(colors.get("personal"), Some(&2));
         let mut assigned: Vec<u8> = colors.values().copied().collect();
         assigned.sort_unstable();
         assigned.dedup();
-        assert_eq!(
-            assigned.len(),
-            4,
-            "two categories share a colour: {colors:?}"
-        );
+        assert_eq!(assigned.len(), 4, "two labels share a colour: {colors:?}");
     }
 
     /// A clone must land exactly where discovery looks for it, or cloning

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,12 +4,18 @@
 //!
 //! Two files live side by side under the config directory:
 //!
-//! - `config.toml` — hand-edited settings (repository paths, ignore list,
-//!   picker preferences). A legacy `config.json` is still read when no TOML
+//! - `config.toml` — hand-edited settings, grouped by the command that reads
+//!   them: `[repo]` for discovery and labelling, `[picker]` for the finder
+//!   every command shares. A legacy `config.json` is still read when no TOML
 //!   file is present.
 //! - `files` — the known-files list, rewritten programmatically by
 //!   `scriv file add`/`forget`/`prune`. Kept separate so machine writes never
 //!   clobber hand-written settings or comments.
+//!
+//! A key belongs in a command's table when exactly one command reads it;
+//! anything genuinely shared stays at the top level. That is why `[picker]`
+//! sits beside `[repo]` rather than inside it, and why `display` — a repo
+//! path-rendering choice no other picker has — sits in `[repo]`.
 
 use anyhow::{Context, Result};
 use indexmap::IndexMap;
@@ -25,23 +31,40 @@ pub const XDG_ENV_VAR: &str = "XDG_CONFIG_HOME";
 
 const DEFAULT_IGNORED_DIRS: &[&str] = &["node_modules", "vendor", "dist", "build", "target"];
 
-/// How deep below [`Config::root`] a repository sits: `<root>/<owner>/<repo>`.
+/// How deep below [`RepoConfig::root`] a repository sits: `<root>/<owner>/<repo>`.
 ///
 /// Fixed rather than configurable. The root mirrors GitHub's own namespace, so
 /// the depth is a property of that layout, not a preference — and fixing it is
 /// what lets `repo clone` know where a clone belongs without being told.
 pub const ROOT_DEPTH: usize = 2;
 
-/// Category label for a repository whose owner is in no configured category.
-pub const UNCATEGORIZED: &str = "-";
+/// Stand-in label for a repository whose owner carries no configured label.
+pub const UNLABELLED: &str = "-";
 
-/// Owner categories, keyed by label. Insertion order is preserved so categories
-/// sort, and take their leftover colours, in the order they were written —
-/// `work` and `personal` are coloured by name and do not depend on it.
-pub type Owners = IndexMap<String, Vec<String>>;
+/// Owner labels: a label to the GitHub owners it covers. Insertion order is
+/// preserved so labels sort, and take their leftover colours, in the order they
+/// were written — `work` and `personal` are coloured by name and do not depend
+/// on it.
+pub type Labels = IndexMap<String, Vec<String>>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Config {
+    pub repo: RepoConfig,
+    pub picker: PickerConfig,
+}
+
+impl Config {
+    /// The config used when no config file exists. Repository discovery has
+    /// nothing to search, but the known-files commands remain fully usable.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+}
+
+/// `[repo]` — where repositories live and how they are labelled and rendered.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct RepoConfig {
     /// The directory holding `<owner>/<repo>` checkouts, e.g.
     /// `~/dev/github.com`. Everything cloned lands here.
     pub root: Option<String>,
@@ -49,60 +72,65 @@ pub struct Config {
     /// hatch for checkouts that predate the single-root layout — not somewhere
     /// `clone` will ever write.
     pub extra: Vec<String>,
-    /// Owner categories: a label to the GitHub owners it covers, one label to
-    /// many owners, so `work` can span several orgs and colour as one.
-    pub owners: Owners,
+    /// Owner labels: a label to the GitHub owners it covers, one label to many
+    /// owners, so `work` can span several orgs and colour as one.
+    ///
+    /// Written as an inline table — `labels = { work = ["acme"] }` — so it is
+    /// an ordinary key of `[repo]` rather than a subtable header. A
+    /// `[repo.labels]` header parses identically, but swallows every bare
+    /// `[repo]` key written after it, which in a hand-edited file is a silent
+    /// misconfiguration rather than an error.
+    pub labels: Labels,
+    /// Directory names skipped while searching for repositories.
     pub ignore: Vec<String>,
-    pub picker: PickerConfig,
-    /// Editor launched by `scriv edit`, overriding `$VISUAL` and `$EDITOR`.
-    pub editor: Option<String>,
+    /// How repository paths are rendered in `repo ls`/`pick`. See
+    /// [`RepoDisplay`].
+    pub display: RepoDisplay,
 }
 
-impl Config {
-    /// The config used when no config file exists. Repository discovery has
-    /// nothing to search, but the known-files commands remain fully usable.
-    pub fn empty() -> Self {
+impl Default for RepoConfig {
+    fn default() -> Self {
         Self {
             root: None,
             extra: Vec::new(),
-            owners: Owners::new(),
+            labels: Labels::new(),
             ignore: default_ignored_dirs(),
-            picker: PickerConfig::default(),
-            editor: None,
+            display: RepoDisplay::default(),
         }
     }
+}
 
-    /// The category `owner` belongs to, or `None` when it is in no category.
+impl RepoConfig {
+    /// The label `owner` carries, or `None` when it has none.
     ///
     /// Matched case-insensitively: GitHub treats `CapraLifecycle` and
     /// `capralifecycle` as the same owner, and a directory on disk may be
     /// spelled either way.
-    pub fn category_of(&self, owner: &str) -> Option<&str> {
-        self.owners
+    pub fn label_of(&self, owner: &str) -> Option<&str> {
+        self.labels
             .iter()
             .find(|(_, owners)| owners.iter().any(|o| o.eq_ignore_ascii_case(owner)))
             .map(|(label, _)| label.as_str())
     }
 
-    /// Every owner named in the config, in category order — the owners worth
+    /// Every owner named in the config, in label order — the owners worth
     /// offering first when there is an owner to choose.
     pub fn known_owners(&self) -> Vec<&str> {
-        self.owners.values().flatten().map(String::as_str).collect()
+        self.labels.values().flatten().map(String::as_str).collect()
     }
 }
 
-/// Pick the editor `scriv edit` launches: the `editor` config key first, then
-/// `$VISUAL`, then `$EDITOR` — the order every other terminal tool uses, with
-/// the config key on top so scriv can differ from the rest of the shell.
+/// Pick the editor `scriv edit` launches: `$VISUAL`, then `$EDITOR` — the order
+/// every other terminal tool uses.
+///
+/// There is deliberately no config key on top. An editor is a property of the
+/// shell session, already stated once where every other tool reads it, and a
+/// third place to set it is a third place to forget it is set.
 ///
 /// Blank and whitespace-only values count as unset: `EDITOR=""` is a common way
 /// to say "no editor", and honouring it literally would try to spawn `""`.
-pub fn resolve_editor(
-    configured: Option<&str>,
-    visual: Option<&str>,
-    editor: Option<&str>,
-) -> Option<String> {
-    [configured, visual, editor]
+pub fn resolve_editor(visual: Option<&str>, editor: Option<&str>) -> Option<String> {
+    [visual, editor]
         .into_iter()
         .flatten()
         .map(str::trim)
@@ -128,16 +156,14 @@ pub struct PathEntry {
     pub depth: usize,
 }
 
-/// Settings for the built-in fuzzy picker (skim).
+/// Settings for the built-in fuzzy picker (skim), shared by every command that
+/// opens one.
 ///
 /// The picker is compiled in — there is no external `fzf` dependency.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-#[serde(default)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PickerConfig {
     /// Finder height, e.g. `"50%"` or `"20"`. Passed through to skim.
     pub height: String,
-    /// How repository paths are rendered in `repo pick`. See [`RepoDisplay`].
-    pub display: RepoDisplay,
     /// Whether the picker shows a preview pane for the highlighted row.
     pub preview: bool,
     /// Preview pane layout in skim's syntax, e.g. `"right:50%"`, `"down:40%"`,
@@ -145,12 +171,12 @@ pub struct PickerConfig {
     pub preview_window: String,
 }
 
-/// How `repo pick` renders each repository's path.
+/// How `repo ls`/`pick` renders each repository's path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RepoDisplay {
     /// Path relative to the search root it was found under, so the shared base
-    /// (named by the group) is not repeated on every row. The default.
+    /// is not repeated on every row. The default.
     #[default]
     Relative,
     /// Absolute path with the home directory collapsed to `~`.
@@ -159,11 +185,21 @@ pub enum RepoDisplay {
     Full,
 }
 
+impl RepoDisplay {
+    /// The name this mode is written under in the config file.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Relative => "relative",
+            Self::Tilde => "tilde",
+            Self::Full => "full",
+        }
+    }
+}
+
 impl Default for PickerConfig {
     fn default() -> Self {
         Self {
             height: "50%".to_string(),
-            display: RepoDisplay::default(),
             preview: true,
             preview_window: "right:50%".to_string(),
         }
@@ -171,25 +207,87 @@ impl Default for PickerConfig {
 }
 
 /// The serialized shape of `config.toml`.
+///
+/// Every key of the layout that preceded `[repo]` is still spelled out here, at
+/// the top level, so an old config can be recognised and explained rather than
+/// half-read: serde ignores what it does not know, and a silently ignored
+/// `root` would look like a config that simply found no repositories.
 #[derive(Deserialize)]
 struct RawToml {
+    #[serde(default)]
+    repo: RepoConfig,
+    #[serde(default)]
+    picker: RawPicker,
+
+    // Superseded top-level keys, present for detection only.
     root: Option<String>,
-    #[serde(default)]
-    extra: Vec<String>,
-    #[serde(default)]
-    owners: Owners,
+    extra: Option<Vec<String>>,
+    owners: Option<Labels>,
     ignore: Option<Vec<String>>,
-    #[serde(default)]
-    picker: PickerConfig,
     editor: Option<String>,
-    /// Only ever present in a pre-root config, and only so it can be detected
-    /// and turned into migration advice. See [`migration_hint`].
-    #[serde(default)]
+    /// The `paths` key from the layout before that. See [`migration_hint`].
     paths: Option<LegacyPaths>,
 }
 
-/// The `paths` key from the config format that preceded [`Config::root`]:
-/// either grouped (`[[paths.work]]`) or a bare list (`[[paths]]`).
+/// `[picker]` as written, including the `display` key that moved to `[repo]`.
+///
+/// Every field is optional so an absent one takes [`PickerConfig`]'s default
+/// while an explicitly written one is preserved.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct RawPicker {
+    height: Option<String>,
+    preview: Option<bool>,
+    preview_window: Option<String>,
+    /// Superseded by `[repo] display`, present for detection only.
+    display: Option<RepoDisplay>,
+}
+
+impl From<RawPicker> for PickerConfig {
+    fn from(raw: RawPicker) -> Self {
+        let default = Self::default();
+        Self {
+            height: raw.height.unwrap_or(default.height),
+            preview: raw.preview.unwrap_or(default.preview),
+            preview_window: raw.preview_window.unwrap_or(default.preview_window),
+        }
+    }
+}
+
+/// A config written in the flat layout that preceded `[repo]`, gathered so the
+/// error can hand back the whole replacement rather than one key at a time.
+struct FlatLayout {
+    root: Option<String>,
+    extra: Vec<String>,
+    labels: Labels,
+    ignore: Option<Vec<String>>,
+    display: Option<RepoDisplay>,
+    editor: bool,
+}
+
+impl RawToml {
+    /// The superseded keys this config uses, or `None` if it uses none.
+    fn flat_layout(&self) -> Option<FlatLayout> {
+        let flat = FlatLayout {
+            root: self.root.clone(),
+            extra: self.extra.clone().unwrap_or_default(),
+            labels: self.owners.clone().unwrap_or_default(),
+            ignore: self.ignore.clone(),
+            display: self.picker.display,
+            editor: self.editor.is_some(),
+        };
+        let used = flat.root.is_some()
+            || !flat.extra.is_empty()
+            || !flat.labels.is_empty()
+            || flat.ignore.is_some()
+            || flat.display.is_some()
+            || flat.editor;
+        used.then_some(flat)
+    }
+}
+
+/// The `paths` key from the config format that preceded `root`: either grouped
+/// (`[[paths.work]]`) or a bare list (`[[paths]]`).
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub enum LegacyPaths {
@@ -198,7 +296,7 @@ pub enum LegacyPaths {
 }
 
 impl LegacyPaths {
-    /// Flatten to (category, entry) pairs; a bare list has no category.
+    /// Flatten to (label, entry) pairs; a bare list has no label.
     fn entries(&self) -> Vec<(Option<&str>, &PathEntry)> {
         match self {
             Self::Grouped(groups) => groups
@@ -210,27 +308,67 @@ impl LegacyPaths {
     }
 }
 
+/// Render a `[repo]` section, as text the user can paste.
+///
+/// `labels` is written as an inline table rather than a `[repo.labels]` header
+/// precisely because this is advice being pasted into a file that already has
+/// other keys: a header would capture whatever follows it.
+fn render_repo_section(
+    root: &str,
+    extra: &[String],
+    ignore: Option<&[String]>,
+    display: Option<RepoDisplay>,
+    labels: &Labels,
+) -> String {
+    let list = |items: &[String]| -> String {
+        items
+            .iter()
+            .map(|i| format!("{i:?}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+
+    let mut out = format!("[repo]\nroot = {root:?}\n");
+    if !extra.is_empty() {
+        out.push_str(&format!("extra = [{}]\n", list(extra)));
+    }
+    if let Some(ignore) = ignore {
+        out.push_str(&format!("ignore = [{}]\n", list(ignore)));
+    }
+    if let Some(display) = display {
+        out.push_str(&format!("display = {:?}\n", display.as_str()));
+    }
+    if !labels.is_empty() {
+        let pairs: Vec<String> = labels
+            .iter()
+            .map(|(label, owners)| format!("{label} = [{}]", list(owners)))
+            .collect();
+        out.push_str(&format!("labels = {{ {} }}\n", pairs.join(", ")));
+    }
+    out
+}
+
 /// Turn an old `paths` config into the config that replaces it, as text the
 /// user can paste.
 ///
 /// The old format encoded the owner in the path — `~/dev/github.com/joakimen`
 /// at depth 1 — which is exactly the two facts the new format wants stated
-/// separately: one root, and which owners fall in which category. An entry that
-/// does not fit that shape (`~/bin` at depth 0) becomes an `extra` path, since
-/// that is what `extra` is for.
+/// separately: one root, and which owners carry which label. An entry that does
+/// not fit that shape (`~/bin` at depth 0) becomes an `extra` path, since that
+/// is what `extra` is for.
 pub fn migration_hint(paths: &LegacyPaths) -> String {
     let mut roots: IndexMap<String, usize> = IndexMap::new();
-    let mut owners: Owners = Owners::new();
+    let mut labels: Labels = Labels::new();
     let mut extra: Vec<String> = Vec::new();
 
-    for (category, entry) in paths.entries() {
+    for (label, entry) in paths.entries() {
         // `<root>/<owner>` at depth 1 is the layout the new root replaces.
         let split = entry.path.rsplit_once('/');
         match (entry.depth, split) {
             (1, Some((root, owner))) if !root.is_empty() && !owner.is_empty() => {
                 *roots.entry(root.to_string()).or_insert(0) += 1;
-                owners
-                    .entry(category.unwrap_or("personal").to_string())
+                labels
+                    .entry(label.unwrap_or("personal").to_string())
                     .or_default()
                     .push(owner.to_string());
             }
@@ -245,29 +383,53 @@ pub fn migration_hint(paths: &LegacyPaths) -> String {
         .map(|(r, _)| r)
         .unwrap_or_else(|| "~/dev/github.com".to_string());
 
-    let mut out = format!("root = {root:?}\n");
-    if !extra.is_empty() {
-        let list: Vec<String> = extra.iter().map(|p| format!("{p:?}")).collect();
-        out.push_str(&format!("extra = [{}]\n", list.join(", ")));
-    }
-    if !owners.is_empty() {
-        out.push_str("\n[owners]\n");
-        for (category, list) in &owners {
-            let list: Vec<String> = list.iter().map(|o| format!("{o:?}")).collect();
-            out.push_str(&format!("{category} = [{}]\n", list.join(", ")));
-        }
-    }
-    out
+    render_repo_section(&root, &extra, None, None, &labels)
 }
 
 /// The error raised for a config still written in the old `paths` format.
-fn legacy_error(paths: &LegacyPaths) -> anyhow::Error {
+fn legacy_paths_error(paths: &LegacyPaths) -> anyhow::Error {
     anyhow::anyhow!(
         "this config uses the old `paths` format, which scriv no longer reads.\n\n\
-         Repositories now live under one root as `<owner>/<repo>`, and categories \
-         label owners rather than paths. Rewrite the `paths` section as:\n\n{}\n\
+         Repositories now live under one root as `<owner>/<repo>`, and labels name \
+         owners rather than paths. Rewrite the `paths` section as:\n\n{}\n\n\
          `extra` is for repositories outside the root; drop the key if there are none.",
         indent(&migration_hint(paths))
+    )
+}
+
+impl FlatLayout {
+    /// The `[repo]` section that replaces these keys, as text the user can
+    /// paste.
+    fn replacement(&self) -> String {
+        render_repo_section(
+            self.root.as_deref().unwrap_or("~/dev/github.com"),
+            &self.extra,
+            self.ignore.as_deref(),
+            self.display,
+            &self.labels,
+        )
+    }
+}
+
+/// The error raised for a config still using the flat, ungrouped keys.
+fn legacy_flat_error(flat: &FlatLayout) -> anyhow::Error {
+    let replacement = flat.replacement();
+
+    let mut note = String::new();
+    if flat.editor {
+        note.push_str(
+            "\n\n`editor` is gone: scriv uses $VISUAL, then $EDITOR, like every \
+             other terminal tool.",
+        );
+    }
+
+    anyhow::anyhow!(
+        "this config uses the old flat layout, which scriv no longer reads.\n\n\
+         Settings are now grouped by the command that reads them: repository \
+         discovery under `[repo]`, and `owners` renamed to `labels`. Rewrite as:\n\n{}\n\n\
+         `[picker]` keeps `height`, `preview` and `preview_window`.{}",
+        indent(&replacement),
+        note
     )
 }
 
@@ -288,15 +450,14 @@ fn indent(text: &str) -> String {
 fn parse_toml(data: &str) -> Result<Config> {
     let raw: RawToml = toml::from_str(data).context("parsing configuration file")?;
     if let Some(paths) = &raw.paths {
-        return Err(legacy_error(paths));
+        return Err(legacy_paths_error(paths));
+    }
+    if let Some(flat) = raw.flat_layout() {
+        return Err(legacy_flat_error(&flat));
     }
     Ok(Config {
-        root: raw.root,
-        extra: raw.extra,
-        owners: raw.owners,
-        ignore: raw.ignore.unwrap_or_else(default_ignored_dirs),
-        picker: raw.picker,
-        editor: raw.editor,
+        repo: raw.repo,
+        picker: raw.picker.into(),
     })
 }
 
@@ -313,7 +474,7 @@ struct RawJson {
 /// become long before now.
 fn parse_json(data: &str) -> Result<Config> {
     let raw: RawJson = serde_json::from_str(data).context("parsing configuration file")?;
-    Err(legacy_error(&LegacyPaths::Flat(raw.paths)))
+    Err(legacy_paths_error(&LegacyPaths::Flat(raw.paths)))
 }
 
 /// Read and parse the config file at `path`, dispatching on its extension.
@@ -417,53 +578,97 @@ mod tests {
     }
 
     #[test]
-    fn parses_root_extra_and_owners() {
+    fn parses_root_extra_and_labels() {
         let cfg = parse_toml(
             r#"
+[repo]
 root = "~/dev/github.com"
 extra = ["~/bin"]
-
-[owners]
-personal = ["joakimen"]
-work = ["capralifecycle", "nsbno"]
+labels = { personal = ["joakimen"], work = ["capralifecycle", "nsbno"] }
 "#,
         )
         .unwrap();
-        assert_eq!(cfg.root.as_deref(), Some("~/dev/github.com"));
-        assert_eq!(cfg.extra, vec!["~/bin".to_string()]);
+        assert_eq!(cfg.repo.root.as_deref(), Some("~/dev/github.com"));
+        assert_eq!(cfg.repo.extra, vec!["~/bin".to_string()]);
         // Config order, not alphabetical: it drives colour assignment.
         assert_eq!(
-            cfg.owners.keys().collect::<Vec<_>>(),
+            cfg.repo.labels.keys().collect::<Vec<_>>(),
             vec!["personal", "work"]
         );
     }
 
-    /// One category covers many owners, which is the whole point: everything
+    /// The inline table is what the template teaches, because a `[repo.labels]`
+    /// header swallows any bare `[repo]` key written after it. Both spellings
+    /// have to keep working for anyone who prefers the header.
+    #[test]
+    fn labels_accept_a_subtable_header_too() {
+        let cfg = parse_toml(
+            r#"
+[repo]
+root = "~/src"
+
+[repo.labels]
+work = ["acme"]
+"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.repo.root.as_deref(), Some("~/src"));
+        assert_eq!(cfg.repo.label_of("acme"), Some("work"));
+    }
+
+    /// A key written after an inline `labels` is still a `[repo]` key — the
+    /// ordering fragility the inline form exists to avoid.
+    #[test]
+    fn keys_after_inline_labels_stay_repo_keys() {
+        let cfg = parse_toml(
+            r#"
+[repo]
+labels = { work = ["acme"] }
+ignore = ["node_modules"]
+"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.repo.ignore, vec!["node_modules".to_string()]);
+        assert_eq!(cfg.repo.label_of("acme"), Some("work"));
+    }
+
+    /// One label covers many owners, which is the whole point: everything
     /// touched for work colours alike however many orgs it spans.
     #[test]
-    fn a_category_spans_several_owners() {
-        let cfg = parse_toml("[owners]\nwork = [\"capralifecycle\", \"nsbno\"]\n").unwrap();
-        assert_eq!(cfg.category_of("capralifecycle"), Some("work"));
-        assert_eq!(cfg.category_of("nsbno"), Some("work"));
-        assert_eq!(cfg.category_of("joakimen"), None);
+    fn a_label_spans_several_owners() {
+        let cfg =
+            parse_toml("[repo]\nlabels = { work = [\"capralifecycle\", \"nsbno\"] }\n").unwrap();
+        assert_eq!(cfg.repo.label_of("capralifecycle"), Some("work"));
+        assert_eq!(cfg.repo.label_of("nsbno"), Some("work"));
+        assert_eq!(cfg.repo.label_of("joakimen"), None);
     }
 
     /// GitHub owners are case-insensitive, and a directory on disk may be
     /// spelled differently from the config.
     #[test]
     fn owner_lookup_ignores_case() {
-        let cfg = parse_toml("[owners]\nwork = [\"CapraLifecycle\"]\n").unwrap();
-        assert_eq!(cfg.category_of("capralifecycle"), Some("work"));
-        assert_eq!(cfg.category_of("CAPRALIFECYCLE"), Some("work"));
+        let cfg = parse_toml("[repo]\nlabels = { work = [\"CapraLifecycle\"] }\n").unwrap();
+        assert_eq!(cfg.repo.label_of("capralifecycle"), Some("work"));
+        assert_eq!(cfg.repo.label_of("CAPRALIFECYCLE"), Some("work"));
+    }
+
+    #[test]
+    fn known_owners_follow_label_order() {
+        let cfg = parse_toml(
+            "[repo]\nlabels = { work = [\"acme\", \"acme-labs\"], personal = [\"me\"] }\n",
+        )
+        .unwrap();
+        assert_eq!(cfg.repo.known_owners(), vec!["acme", "acme-labs", "me"]);
     }
 
     #[test]
     fn empty_toml_has_no_root() {
         let cfg = parse_toml("").unwrap();
-        assert_eq!(cfg.root, None);
-        assert!(cfg.extra.is_empty());
-        assert!(cfg.owners.is_empty());
-        assert_eq!(cfg.ignore, default_ignored_dirs());
+        assert_eq!(cfg.repo.root, None);
+        assert!(cfg.repo.extra.is_empty());
+        assert!(cfg.repo.labels.is_empty());
+        assert_eq!(cfg.repo.ignore, default_ignored_dirs());
+        assert_eq!(cfg.repo.display, RepoDisplay::Relative);
     }
 
     /// The old format is refused rather than half-understood — but the error
@@ -491,9 +696,12 @@ depth = 1
         .to_string();
 
         assert!(err.contains("old `paths` format"), "{err}");
+        assert!(err.contains("[repo]"), "{err}");
         assert!(err.contains(r#"root = "~/dev/github.com""#), "{err}");
-        assert!(err.contains(r#"personal = ["joakimen"]"#), "{err}");
-        assert!(err.contains(r#"work = ["capralifecycle"]"#), "{err}");
+        assert!(
+            err.contains(r#"labels = { personal = ["joakimen"], work = ["capralifecycle"] }"#),
+            "{err}"
+        );
         // ~/bin does not fit <root>/<owner>, so it becomes an extra path.
         assert!(err.contains(r#"extra = ["~/bin"]"#), "{err}");
     }
@@ -519,8 +727,8 @@ depth = 1
         );
     }
 
-    /// A flat legacy list has no categories to carry over, but still needs a
-    /// root and must not lose any path.
+    /// A flat legacy list has no labels to carry over, but still needs a root
+    /// and must not lose any path.
     #[test]
     fn migration_handles_an_ungrouped_list() {
         let hint = migration_hint(&LegacyPaths::Flat(vec![
@@ -542,6 +750,121 @@ depth = 1
         assert!(err.contains(r#"root = "~/dev/github.com""#), "{err}");
     }
 
+    /// The flat layout is refused with its own replacement written out, for the
+    /// same reason: serde would otherwise ignore every superseded key and the
+    /// config would look like one that simply found nothing.
+    #[test]
+    fn flat_layout_is_rejected_with_a_migration() {
+        let err = parse_toml(
+            r#"
+root = "~/dev/github.com"
+extra = ["~/bin"]
+ignore = ["target"]
+editor = "nvim"
+
+[owners]
+work = ["acme"]
+
+[picker]
+height = "30%"
+display = "tilde"
+"#,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("old flat layout"), "{err}");
+        assert!(err.contains("[repo]"), "{err}");
+        assert!(err.contains(r#"root = "~/dev/github.com""#), "{err}");
+        assert!(err.contains(r#"extra = ["~/bin"]"#), "{err}");
+        assert!(err.contains(r#"ignore = ["target"]"#), "{err}");
+        assert!(err.contains(r#"display = "tilde""#), "{err}");
+        assert!(err.contains(r#"labels = { work = ["acme"] }"#), "{err}");
+        assert!(err.contains("$EDITOR"), "{err}");
+    }
+
+    /// Advice that does not parse is not advice. Whatever either migration
+    /// error prints has to be a config the very next run accepts, or the user
+    /// pastes it and gets a second error.
+    #[test]
+    fn the_generated_replacements_parse() {
+        let hint = migration_hint(&LegacyPaths::Grouped(
+            [
+                (
+                    "work".to_string(),
+                    vec![entry("~/dev/github.com/capralifecycle", 1)],
+                ),
+                (
+                    "personal".to_string(),
+                    vec![entry("~/dev/github.com/joakimen", 1), entry("~/bin", 0)],
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        ));
+        let cfg = parse_toml(&hint).unwrap_or_else(|e| panic!("{e:#}\n\n{hint}"));
+        assert_eq!(cfg.repo.label_of("capralifecycle"), Some("work"));
+        assert_eq!(cfg.repo.extra, vec!["~/bin".to_string()]);
+
+        let old = r#"
+root = "~/dev/github.com"
+extra = ["~/bin"]
+ignore = ["target"]
+
+[owners]
+work = ["acme"]
+
+[picker]
+display = "tilde"
+"#;
+        let raw: RawToml = toml::from_str(old).unwrap();
+        let replacement = raw.flat_layout().unwrap().replacement();
+        let cfg = parse_toml(&replacement).unwrap_or_else(|e| panic!("{e:#}\n\n{replacement}"));
+        assert_eq!(cfg.repo.root.as_deref(), Some("~/dev/github.com"));
+        assert_eq!(cfg.repo.extra, vec!["~/bin".to_string()]);
+        assert_eq!(cfg.repo.ignore, vec!["target".to_string()]);
+        assert_eq!(cfg.repo.display, RepoDisplay::Tilde);
+        assert_eq!(cfg.repo.label_of("acme"), Some("work"));
+    }
+
+    /// Every superseded key is detected on its own — a config that only set
+    /// `owners`, or only moved `display`, must not slip through.
+    #[test]
+    fn each_superseded_key_is_detected_alone() {
+        for old in [
+            "root = \"~/src\"",
+            "extra = [\"~/bin\"]",
+            "ignore = [\"target\"]",
+            "editor = \"nvim\"",
+            "[owners]\nwork = [\"acme\"]",
+            "[picker]\ndisplay = \"tilde\"",
+        ] {
+            let err = parse_toml(old).unwrap_err().to_string();
+            assert!(err.contains("old flat layout"), "{old} accepted: {err}");
+        }
+    }
+
+    /// Only the superseded keys trigger it: a `[picker]` with no `display` is
+    /// exactly what the current format asks for.
+    #[test]
+    fn the_current_layout_is_not_mistaken_for_the_old_one() {
+        let cfg = parse_toml(
+            r#"
+[repo]
+root = "~/src"
+display = "tilde"
+
+[picker]
+height = "30%"
+preview = false
+"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.repo.display, RepoDisplay::Tilde);
+        assert_eq!(cfg.picker.height, "30%");
+        assert!(!cfg.picker.preview);
+    }
+
     #[test]
     fn parses_picker_height() {
         let cfg = parse_toml("[picker]\nheight = \"30%\"\n").unwrap();
@@ -549,15 +872,16 @@ depth = 1
     }
 
     #[test]
-    fn parses_picker_display_mode() {
-        let cfg = parse_toml("[picker]\ndisplay = \"tilde\"\n").unwrap();
-        assert_eq!(cfg.picker.display, RepoDisplay::Tilde);
+    fn parses_repo_display_mode() {
+        let cfg = parse_toml("[repo]\ndisplay = \"tilde\"\n").unwrap();
+        assert_eq!(cfg.repo.display, RepoDisplay::Tilde);
     }
 
     #[test]
-    fn picker_display_defaults_to_relative() {
+    fn repo_display_defaults_to_relative() {
+        assert_eq!(parse_toml("").unwrap().repo.display, RepoDisplay::Relative);
         assert_eq!(
-            parse_toml("").unwrap().picker.display,
+            parse_toml("[repo]\n").unwrap().repo.display,
             RepoDisplay::Relative
         );
     }
@@ -593,7 +917,13 @@ depth = 1
 
     #[test]
     fn toml_preserves_explicit_empty_ignore() {
-        assert!(parse_toml("ignore = []").unwrap().ignore.is_empty());
+        assert!(
+            parse_toml("[repo]\nignore = []")
+                .unwrap()
+                .repo
+                .ignore
+                .is_empty()
+        );
     }
 
     #[test]
@@ -689,44 +1019,25 @@ depth = 1
     }
 
     #[test]
-    fn parses_editor() {
+    fn editor_precedence_prefers_visual() {
         assert_eq!(
-            parse_toml("editor = \"hx\"\n").unwrap().editor.as_deref(),
-            Some("hx")
-        );
-        assert_eq!(parse_toml("").unwrap().editor, None);
-    }
-
-    #[test]
-    fn editor_precedence_prefers_config_then_visual() {
-        assert_eq!(
-            resolve_editor(Some("hx"), Some("code"), Some("vi")).as_deref(),
-            Some("hx")
-        );
-        assert_eq!(
-            resolve_editor(None, Some("code"), Some("vi")).as_deref(),
+            resolve_editor(Some("code"), Some("vi")).as_deref(),
             Some("code")
         );
-        assert_eq!(
-            resolve_editor(None, None, Some("vi")).as_deref(),
-            Some("vi")
-        );
-        assert_eq!(resolve_editor(None, None, None), None);
+        assert_eq!(resolve_editor(None, Some("vi")).as_deref(), Some("vi"));
+        assert_eq!(resolve_editor(None, None), None);
     }
 
     /// `EDITOR=""` means "no editor", not a program named "".
     #[test]
     fn editor_ignores_blank_values() {
         assert_eq!(
-            resolve_editor(None, Some("  "), Some("vi")).as_deref(),
+            resolve_editor(Some("  "), Some("vi")).as_deref(),
             Some("vi")
         );
-        assert_eq!(resolve_editor(Some(""), None, None), None);
+        assert_eq!(resolve_editor(Some(""), None), None);
         // A value that is only padded still resolves, trimmed.
-        assert_eq!(
-            resolve_editor(Some(" hx "), None, None).as_deref(),
-            Some("hx")
-        );
+        assert_eq!(resolve_editor(Some(" hx "), None).as_deref(), Some("hx"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub struct Ctx {
     pub files_path: PathBuf,
     /// The standalone `kf` tool's config, read once to migrate its list.
     pub legacy_kf_path: PathBuf,
-    /// The editor `scriv edit` launches, from config or the environment.
+    /// The editor `scriv edit` launches, from the environment.
     editor: Option<String>,
     pub config: Config,
     pub log: Logger,
@@ -88,7 +88,6 @@ impl Ctx {
         let config = config::load_config(&config_path)?;
 
         let editor = config::resolve_editor(
-            config.editor.as_deref(),
             std::env::var("VISUAL").ok().as_deref(),
             std::env::var("EDITOR").ok().as_deref(),
         );
@@ -114,13 +113,13 @@ impl Ctx {
 
     /// The editor command to launch, split into program and arguments.
     ///
-    /// Errors when nothing is configured, naming every place the user can set
-    /// one rather than failing on an empty program name deeper in.
+    /// Errors when nothing is set, naming both variables the user can set
+    /// rather than failing on an empty program name deeper in.
     pub fn editor(&self) -> Result<Vec<String>> {
-        let command = self.editor.as_deref().context(
-            "no editor set — set $EDITOR or $VISUAL, \
-             or add `editor = \"nvim\"` to the config file",
-        )?;
+        let command = self
+            .editor
+            .as_deref()
+            .context("no editor set — set $VISUAL or $EDITOR")?;
         let parts = config::split_editor(command);
         if parts.is_empty() {
             anyhow::bail!("the configured editor is empty");

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,8 +81,7 @@ enum Command {
     ///
     /// Selection comes from the current directory tree, honouring `.gitignore`,
     /// or from your tracked files with `--tracked`. Selecting several opens them
-    /// all. The editor is `$VISUAL`, then `$EDITOR`, unless the config file sets
-    /// `editor`.
+    /// all. The editor is `$VISUAL`, then `$EDITOR`.
     #[command(alias = "e")]
     Edit {
         /// Files to open; omit to pick interactively

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -6,14 +6,14 @@ use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use std::thread;
 
-use crate::config::{Config, ROOT_DEPTH, UNCATEGORIZED};
+use crate::config::{Config, ROOT_DEPTH, UNLABELLED};
 use crate::logger::Logger;
 use crate::path::expand_home_dir;
 
 /// A discovered repository, together with where it was found and who owns it.
 pub struct FoundRepo {
-    /// The category its owner falls in, or [`UNCATEGORIZED`].
-    pub category: String,
+    /// The label its owner carries, or [`UNLABELLED`].
+    pub label: String,
     /// The GitHub owner, taken from the directory under the root. `None` for a
     /// repository from `extra`, which sits outside the `<owner>/<repo>` layout.
     pub owner: Option<String>,
@@ -53,23 +53,24 @@ pub fn owner_of(root: &Path, path: &Path) -> Option<String> {
 }
 
 /// Discover repositories under the configured root and any `extra` paths,
-/// expanding `~` against `home` and tagging each with its owner and category.
+/// expanding `~` against `home` and tagging each with its owner and label.
 ///
 /// Each search runs on its own thread. A missing path is a hard error — a typo
 /// in the root should say so rather than quietly finding nothing; unreadable
 /// subdirectories are logged and skipped.
 pub fn find_all_repos(cfg: &Config, home: &Path, log: &Logger) -> Result<Vec<FoundRepo>> {
-    if cfg.root.is_none() && cfg.extra.is_empty() {
+    if cfg.repo.root.is_none() && cfg.repo.extra.is_empty() {
         anyhow::bail!("no `root` set in config file");
     }
 
     // The root is searched at the owner/repo depth; each `extra` path is a
     // repository in its own right, so it is searched at depth 0.
     let jobs: Vec<(&str, usize, bool)> = cfg
+        .repo
         .root
         .iter()
         .map(|r| (r.as_str(), ROOT_DEPTH, true))
-        .chain(cfg.extra.iter().map(|p| (p.as_str(), 0, false)))
+        .chain(cfg.repo.extra.iter().map(|p| (p.as_str(), 0, false)))
         .collect();
 
     let results: Vec<Result<Vec<FoundRepo>>> = thread::scope(|scope| {
@@ -79,7 +80,7 @@ pub fn find_all_repos(cfg: &Config, home: &Path, log: &Logger) -> Result<Vec<Fou
                 scope.spawn(move || {
                     let root = expand_home_dir(path, home);
                     log.info(&format!("searching {path} (depth {depth})"));
-                    let repos = find_repos(&root, depth, &cfg.ignore, log)?;
+                    let repos = find_repos(&root, depth, &cfg.repo.ignore, log)?;
                     Ok(repos
                         .into_iter()
                         .map(|path| {
@@ -88,13 +89,13 @@ pub fn find_all_repos(cfg: &Config, home: &Path, log: &Logger) -> Result<Vec<Fou
                             } else {
                                 None
                             };
-                            let category = owner
+                            let label = owner
                                 .as_deref()
-                                .and_then(|o| cfg.category_of(o))
-                                .unwrap_or(UNCATEGORIZED)
+                                .and_then(|o| cfg.repo.label_of(o))
+                                .unwrap_or(UNLABELLED)
                                 .to_string();
                             FoundRepo {
-                                category,
+                                label,
                                 owner,
                                 root: root.clone(),
                                 path,


### PR DESCRIPTION
Renames the `owners` config key to `labels`, and reorganises `config.toml` so settings sit in the table of the command that reads them.

## Why

The flat layout hid the scopes. Six of the eight keys were single-command, and four of those were `repo`:

| key | read by |
| --- | --- |
| `root`, `extra`, `ignore` | `repo` discovery (the `edit`/`file add` walk uses `.gitignore` + a hardcoded skip list, not `ignore`) |
| `owners` | `repo` — picker colours, `clone` owner suggestions |
| `picker.display` | `repo` only |
| `picker.height`/`preview`/`preview_window` | all five pickers |
| `editor` | `edit` only |

So the config already *was* mostly repo settings plus a shared picker table; it just didn't say so. This also fixes an existing misfiling rather than inventing one: `display` is a repo path-rendering choice that was living in the table every picker shares.

## What changed

```toml
[repo]
root = "~/dev/github.com"
extra = ["~/bin"]
ignore = ["node_modules", "target"]
display = "relative"
labels = { personal = ["joakimen"], work = ["capralifecycle", "nsbno"] }

[picker]
height = "50%"
preview = true
preview_window = "right:50%"
```

The rule, written down in `config.rs`: a key earns a command's table when exactly one command reads it; anything genuinely shared stays top-level. `branch` and `pr` get no section — they have no settings, and empty tables mirroring the CLI would be symmetry for its own sake.

**`labels` is an inline table, not a `[repo.labels]` header.** Both parse identically, but a header captures every bare key written after it — add `ignore` below one and it silently becomes a label named `"ignore"` while the real setting vanishes, with no error. In a hand-edited file that is a trap. The header still parses for anyone with more labels than fits a line.

**`editor` is removed.** `$VISUAL`/`$EDITOR` already state it where every other terminal tool reads it.

**Naming follows the key:** `category_of` → `label_of`, `UNCATEGORIZED` → `UNLABELLED`, `FoundRepo.category` → `.label`, `category_colors` → `label_colors`.

## Migration

Both superseded layouts are refused rather than half-read — serde would otherwise ignore every moved key and leave a config that looks like one that simply found no repositories. Each error derives the replacement from what was actually there:

```
error: in config.toml: this config uses the old flat layout, which scriv no longer reads.

Settings are now grouped by the command that reads them: repository discovery
under `[repo]`, and `owners` renamed to `labels`. Rewrite as:

    [repo]
    root = "~/dev/github.com"
    extra = ["~/bin"]
    ignore = ["node_modules", "target"]
    display = "tilde"
    labels = { personal = ["joakimen"], work = ["capralifecycle", "nsbno"] }

`[picker]` keeps `height`, `preview` and `preview_window`.

`editor` is gone: scriv uses $VISUAL, then $EDITOR, like every other terminal tool.
```

A test parses that generated replacement, for both migration paths: advice that does not parse is not advice. Two more tests parse the `config init` template — as written, and with its commented-out keys uncommented — so the file new users are handed can't drift out of the format scriv accepts.

## The trade-off worth naming

This is a hard break for every existing config, with no silent-accept period. The alternative — reading both shapes for a while — means carrying two parsers and a config surface that is ambiguous exactly while people are learning it. Given the error hands back the complete replacement, the paste is a few seconds and the ambiguity never exists. That is the call I made; it costs a real interruption on first run after upgrade.

## The three docs

1. **CLI help (`src/main.rs`)** — touched. `edit`'s doc comment no longer claims the config can set `editor`. No new commands or flags, so `EXAMPLES` is unchanged.
2. **README.md** — touched. Config section rewritten around the new layout, with the inline-table rationale and the editor removal. Feature table, `Commands` section and key-binding table needed no change — no command, abbreviation or binding moved.
3. **`docs/demo.gif`** — **not re-recorded, and does not need to be.** `demo/fixture.sh` is rewritten into the new format, but it produces the same two labels (`work`, `personal`) over the same repositories, so every picker renders identically. Verified by building the fixture and running `repo ls` and `config print` against it.

## Verification

`make` green (fmt check, clippy `-D warnings`, 180 tests, release build). Both migration errors and the new format exercised end-to-end against real config files, and the demo fixture built and loaded.