### PR TITLE
Open a picked repository on GitHub with `repo open`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ candidates apart without leaving the picker.
 
 | | |
 | --- | --- |
-| **repos** | pick one of your repositories and `cd` into it, or clone new ones |
+| **repos** | pick one of your repositories and `cd` into it, open it on GitHub, or clone new ones |
 | **files** | keep a list of files you return to, and open one |
 | **editing** | fuzzy-find a file where you are standing and open it in `$EDITOR` |
 | **branches** | switch to a local branch, or check out a remote one |
@@ -77,6 +77,12 @@ scriv repo clone                # pick an owner, then repositories
 scriv repo clone capralifecycle # scope to one owner (any owner, not just yours)
 scriv repo clone tailscale/tailscale   # skip both pickers
 ```
+
+`scriv repo open` picks from that same list and opens the repository's GitHub
+page, via `gh repo view --web` — which reads the page from that checkout's git
+remotes, so a directory renamed on clone and a fork both land where they should.
+It picks over every repository you have rather than acting on the one you are
+standing in; for that one, `gh repo view --web` is already the whole answer.
 
 `scriv file add`/`remove` maintain the tracked list, and `scriv config` /
 `scriv init` handle setup. `branch` abbreviates to `br`, `checkout` to `co`,
@@ -180,13 +186,15 @@ end
 | `ctrl-o` | pick a repository and `cd` into it |
 | `ctrl-g` | pick a branch and check it out |
 | `ctrl-p` | pick a pull request and check it out |
+| `f1` | pick a repository and open it on GitHub |
 | `f3` | pick a tracked file and open it in `$EDITOR` |
 | `ctrl-q` | pick a file below `$PWD` and open it in `$EDITOR` |
 
 Of those, `ctrl-o` and `ctrl-q` are unbound in fish; `ctrl-g` replaces `cancel`,
 which `escape` and `ctrl-c` also do, and `ctrl-p` replaces `up-line`, leaving
-`up` and `ctrl-r` to search history. alt is left untouched, since fish binds
-most of it already.
+`up` and `ctrl-r` to search history. `f1` and `f3` replace nothing — fish binds
+no function key itself, and the low ones are where users' own tools are least
+likely to already be. alt is left untouched, since fish binds most of it already.
 
 It also defines `fe` — find, fuzzy-pick, edit — as a short alias for
 `scriv edit`, forwarding its arguments so `fe -t` and `fe src/main.rs` work

--- a/demo/fixture.sh
+++ b/demo/fixture.sh
@@ -194,6 +194,14 @@ if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = "--web" ]; then
     exit 0
 fi
 
+# `gh repo view --web` opens whatever repository it is run *in*, so the stub
+# reports the directory it was called from — which is exactly the choice
+# `scriv repo open` is making on its behalf.
+if [ "$1" = "repo" ] && [ "$2" = "view" ] && [ "$3" = "--web" ]; then
+    echo "demo stub: would open https://github.com/$(basename "$(dirname "$PWD")")/$(basename "$PWD")"
+    exit 0
+fi
+
 if [ "$1" = "pr" ] && [ "$2" = "merge" ]; then
     echo "demo stub: would merge pull request $3"
     exit 0

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -129,15 +129,15 @@ fn preview(path: &str) -> Preview {
     ))
 }
 
-/// `scriv repo pick` — fuzzy-select one repository and print its absolute path.
+/// The picker rows for the discovered repositories.
 ///
 /// Each row is prefixed with its label, coloured per label so a `work`
 /// checkout is distinguishable from a personal one at a glance — several owners
 /// can share one label and therefore one colour, and a repository with no label
-/// is left uncoloured. Paths render per `repo.display`. The printed path is
-/// always absolute so a shell shim can `cd` to it directly.
-pub fn pick(ctx: &Ctx) -> Result<()> {
-    let repos = discover(ctx)?;
+/// is left uncoloured. Paths render per `repo.display`. Every row's value is the
+/// absolute path, so a caller can `cd` to it or run a command in it without
+/// re-expanding `~`.
+fn repo_rows(ctx: &Ctx, repos: &[FoundRepo]) -> Vec<PickItem> {
     let colors = label_colors(&ctx.config.repo.labels);
 
     // Character count, not bytes: `{:<width$}` pads by characters, so a byte
@@ -149,7 +149,7 @@ pub fn pick(ctx: &Ctx) -> Result<()> {
         .unwrap_or(0);
 
     let mode = ctx.config.repo.display;
-    let items: Vec<PickItem> = repos
+    repos
         .iter()
         .map(|repo| {
             let abs = repo.path.to_string_lossy().into_owned();
@@ -165,11 +165,32 @@ pub fn pick(ctx: &Ctx) -> Result<()> {
                 None => item,
             }
         })
-        .collect();
+        .collect()
+}
 
-    let choice = pick::pick_one(items, "Pick a repository", &ctx.config.picker)?;
+/// `scriv repo pick` — fuzzy-select one repository and print its absolute path.
+///
+/// The path is printed absolute so a shell shim can `cd` to it directly.
+pub fn pick(ctx: &Ctx) -> Result<()> {
+    let repos = discover(ctx)?;
+    let rows = repo_rows(ctx, &repos);
+    let choice = pick::pick_one(rows, "Pick a repository", &ctx.config.picker)?;
     println!("{choice}");
     Ok(())
+}
+
+/// `scriv repo open` — fuzzy-select one repository and open its GitHub page.
+///
+/// A verb over the same set `ls` and `pick` cover, so it picks from every
+/// repository scriv found rather than acting on the one the shell happens to be
+/// standing in. That case is already `gh repo view --web`, which needs no fuzzy
+/// finder to do it; choosing among the hundred you are *not* standing in is the
+/// part worth a command.
+pub fn open(ctx: &Ctx) -> Result<()> {
+    let repos = discover(ctx)?;
+    let rows = repo_rows(ctx, &repos);
+    let choice = pick::pick_one(rows, "Open a repository on GitHub", &ctx.config.picker)?;
+    gh::view_repo_web(Path::new(&choice))
 }
 
 // --- clone ------------------------------------------------------------------

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -700,6 +700,20 @@ pub fn clone(name_with_owner: &str, dest: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Open the GitHub page of the repository checked out at `dir`.
+///
+/// `gh repo view --web` is what does the opening, for the same reasons as
+/// [`view_web`]: it knows the host, so GitHub Enterprise works, and it defers to
+/// `$BROWSER` and the platform's opener.
+///
+/// Which repository that is comes from `dir`'s git remotes rather than from the
+/// path, because the two disagree often enough to matter — a directory renamed
+/// on clone, or a fork whose `origin` is not the owner it sits under. Asking git
+/// is the answer scriv would otherwise guess at.
+pub fn view_repo_web(dir: &Path) -> Result<()> {
+    run_at(Some(dir), &["repo", "view", "--web"])
+}
+
 /// The authenticated user's login, and the organisations they belong to.
 ///
 /// This is the answer to "which owners do you actually clone from" on a machine
@@ -718,15 +732,27 @@ pub fn owners() -> Result<Vec<String>> {
     Ok(out)
 }
 
-/// Run `gh` with the terminal attached, passing its exit status through.
+/// Run `gh` with the terminal attached, in the working directory scriv was
+/// invoked from.
 ///
 /// `gh` writes its own diagnostics, so a failure is [`Reported`] rather than
 /// restated in vaguer words on top.
 fn run(args: &[&str]) -> Result<()> {
-    let status = Command::new("gh")
-        .args(args)
-        .status()
-        .map_err(spawn_error)?;
+    run_at(None, args)
+}
+
+/// [`run`], optionally somewhere else.
+///
+/// Most `gh` subcommands resolve which repository they are about from the git
+/// remotes of the directory they run in, which is the whole reason `dir` exists:
+/// a command about a repository the user picked has to run *there*, not here.
+fn run_at(dir: Option<&Path>, args: &[&str]) -> Result<()> {
+    let mut cmd = Command::new("gh");
+    cmd.args(args);
+    if let Some(dir) = dir {
+        cmd.current_dir(dir);
+    }
+    let status = cmd.status().map_err(spawn_error)?;
     if !status.success() {
         return Err(Reported(status.code().unwrap_or(1)).into());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,13 @@ enum RepoCmd {
     },
     /// Fuzzy-select a repository and print its absolute path
     Pick,
+    /// Fuzzy-select a repository and open its GitHub page in the browser
+    ///
+    /// Picks from every repository under your search paths, then hands off to
+    /// `gh repo view --web`, which resolves the page from that checkout's git
+    /// remotes. To open the repository you are already standing in, run
+    /// `gh repo view --web` directly — there is nothing to pick.
+    Open,
     /// Clone repositories from GitHub into your root
     ///
     /// With no argument, pick an owner — suggested from your config, the owners
@@ -376,6 +383,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         Command::Repo { command } => match command {
             RepoCmd::Ls { absolute_paths } => cmd::repo::ls(&ctx, absolute_paths),
             RepoCmd::Pick => cmd::repo::pick(&ctx),
+            RepoCmd::Open => cmd::repo::open(&ctx),
             RepoCmd::Clone { target, limit } => cmd::repo::clone(&ctx, target.as_deref(), limit),
         },
         Command::File { command } => match command {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -44,6 +44,12 @@ function scriv-repo-cd --description "Pick a repository and cd into it"
     test -n "$dir"; and builtin cd $dir
 end
 
+# Unlike cd, opening a browser needs no shell help — this is a thin wrapper kept
+# only to hang a key binding off.
+function scriv-repo-open --description "Pick a repository and open it on GitHub"
+    command scriv repo open
+end
+
 # `scriv edit` spawns the editor itself — unlike cd, that needs no shell help —
 # so these are thin wrappers kept only to hang key bindings off.
 function scriv-edit --description "Pick a file under \$PWD and open it in \$EDITOR"
@@ -77,6 +83,11 @@ end
 #   ctrl-g  branch checkout, over `cancel` — escape and ctrl-c both do that too
 #   ctrl-p  pr checkout, over `up-line` — up and ctrl-r still search history
 #
+# The two function keys displace nothing: fish binds none of f1-f12 itself, and
+# f1 and f3 are the low end that users' own tools tend to leave alone — f4 and f5
+# upwards are commonly taken already. They carry the two pickers that are reached
+# least often, since a function key is a longer reach than a ctrl chord.
+#
 # Rebind any of them by calling `bind` yourself after `scriv_key_bindings`; the
 # last binding for a key wins. alt-<letter> is left alone on purpose — it looks
 # free but is not, since fish presets alt-b, alt-e, alt-o and alt-p among others.
@@ -92,6 +103,7 @@ end
 function scriv_key_bindings --description "Bind scriv pickers to keys"
     bind ctrl-o "scriv-repo-cd; commandline -f repaint"
     bind ctrl-q "scriv-edit; commandline -f repaint"
+    bind f1     "scriv-repo-open; commandline -f repaint"
     bind f3     "scriv-file-edit; commandline -f repaint"
     bind ctrl-g "scriv-branch-checkout; commandline -f repaint"
     bind ctrl-p "scriv-pr-checkout; commandline -f repaint"
@@ -111,6 +123,7 @@ mod tests {
     fn fish_emits_helper_functions() {
         let out = integration(Shell::Fish, &mut dummy());
         assert!(out.contains("function scriv-repo-cd"));
+        assert!(out.contains("function scriv-repo-open"));
         assert!(out.contains("function scriv-edit"));
         assert!(out.contains("function scriv-file-edit"));
         assert!(out.contains("function fe"));
@@ -125,6 +138,7 @@ mod tests {
         assert!(out.contains("complete -c scriv"));
         assert!(out.contains("bind ctrl-o"));
         assert!(out.contains("bind ctrl-q"));
+        assert!(out.contains("bind f1"));
         assert!(out.contains("bind f3"));
         assert!(out.contains("bind ctrl-g"));
         assert!(out.contains("bind ctrl-p"));


### PR DESCRIPTION
`scriv repo pick` gets you *into* a repository and `scriv pr open` gets a pull
request into the browser, but nothing got you from "which of these two hundred"
to the repository's own GitHub page without typing the slug out.

`repo open` is that verb over the set `ls` and `pick` already cover: fuzzy-pick
from every repository scriv found, then hand off to `gh repo view --web`, run in
the chosen checkout.

```fish
scriv repo open   # pick a repository, open it on github.com
```

Bound to `f1` in the fish integration.

## Notes on the two decisions worth naming

**It picks, rather than acting on `$PWD`.** Opening the repository you are
standing in is already `gh repo view --web` and needs no fuzzy finder; choosing
among the ones you are *not* standing in is the part that does. This keeps `repo`
a registry — a set scriv knows about, with `ls`/`pick` and verbs over that set —
rather than sneaking ambient-directory work under a noun group.

**`gh` resolves the repository from the directory's git remotes, not from its
path.** `run_at` runs `gh` with `current_dir` set to the picked checkout instead
of deriving an `owner/repo` slug from the path. The two disagree often enough to
matter: a directory renamed on clone, or a fork whose `origin` is not the owner
it sits under. Deriving the slug would guess; git knows.

Rows come from the same builder `pick` uses, extracted as `repo_rows`, so the two
pickers cannot drift apart in layout or colour.

## `f1` conflicts with nothing

Verified rather than assumed — fish binds no function key at all:

```
$ fish --no-config -c 'bind | grep "f1"'   # nothing, exit 1
$ fish -c 'bind | grep "f1"'               # nothing under my own config either
$ fish -c 'scriv init fish | source; scriv_key_bindings; bind | grep scriv'
bind f1 'scriv-repo-open; commandline -f repaint'
```

So unlike `ctrl-g` (over `cancel`) and `ctrl-p` (over `up-line`), this displaces
nothing. `f1` and `f3` are also the low end of the function keys, where users'
own tools are least likely to already be — the comment above `scriv_key_bindings`
now says so.

## Verification

`make` green — fmt, clippy `-D warnings`, 172 tests, release build — plus
`make demo-check`.

The handoff itself was exercised end to end through a real terminal (vhs, since
the picker needs genuine cursor-position replies), against the demo sandbox with
its `gh` stub instrumented to log its working directory. Typing `invoice` and
pressing enter produced:

```
GH_CALL args=[repo view --web] cwd=.../demo-fixture/dev/github.com/acme/invoice-worker
```

— the picked repository, with `gh` running inside it, which is exactly the
contract.

## The three docs that go stale silently

1. **CLI help text** — `RepoCmd::Open` has a doc comment covering both what it
   picks from and the `$PWD` case it deliberately leaves to `gh`. `EXAMPLES` is
   untouched on purpose: it covers the common entry point of each command *group*,
   and `repo` already has three lines.
2. **README.md** — feature table, a paragraph in `Commands` after `repo clone`,
   and the key-binding table plus the sentence under it explaining that `f1`
   replaces nothing. No config key added, so the sample `config.toml` is
   unchanged; the command table and `scriv --help` still agree.
3. **`docs/demo.gif`** — **not** re-recorded, and does not need to be. This adds
   a command without altering any existing picker's rows, colours or preview, and
   `demo/demo.tape` drives `repo pick`, `branch checkout` and `pr ls --status`,
   none of whose output changes.

`demo/fixture.sh` grew a `repo view --web` arm on its `gh` stub, so `repo open`
can be tried by hand in the sandbox like `pr open` already could. It reports the
directory it was called from, which is the choice `repo open` is making.