### PR TITLE
Move the pull request picker off ctrl-p to f7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,14 +147,18 @@ reference, so command implementations do no environment lookups of their own.
   work from a child process.
 - **Colour is dropped when stdout is not a terminal**, and `NO_COLOR` is
   honoured — `ls` output has to stay pipe-safe. Use `term::stdout_color()`.
-- **Key bindings use `ctrl-<letter>`, and never `alt-`.** ctrl is the modifier
-  people put under a pinky, so it is where a picker worth a keystroke belongs.
-  fish leaves only `ctrl-o` and `ctrl-q` unbound, so anything further has to
-  displace a preset binding deliberately and say which one in the comment above
-  `scriv_key_bindings`. alt is not the escape hatch it looks like: fish binds
+- **Key bindings prefer `ctrl-<letter>`, and never use `alt-`.** ctrl is the
+  modifier people put under a pinky, so it is where a picker worth a keystroke
+  belongs. fish leaves only `ctrl-o` and `ctrl-q` unbound, so anything further
+  has to displace a preset binding deliberately and say which one in the comment
+  above `scriv_key_bindings` — and some presets are not worth displacing:
+  `ctrl-p`/`ctrl-n` are `up-line`/`down-line`, which is how history gets walked
+  on a one-line prompt. alt is not the escape hatch it looks like: fish binds
   most of `alt-<letter>` (`alt-b`, `alt-e`, `alt-o`, `alt-p` among them).
-  `ctrl-i`/`ctrl-j`/`ctrl-m` are tab/newline/enter and are never bindable;
-  function keys past `f3` are commonly taken by users' own tools.
+  `ctrl-i`/`ctrl-j`/`ctrl-m` are tab/newline/enter and are never bindable. Once
+  the worthwhile ctrl chords are gone, function keys are the fallback: fish binds
+  none of `f1`-`f12`, so they displace nothing, but `f4` and `f5` are where
+  users' own tools cluster and are skipped.
 
 ## The demo
 

--- a/README.md
+++ b/README.md
@@ -185,16 +185,18 @@ end
 | --- | --- |
 | `ctrl-o` | pick a repository and `cd` into it |
 | `ctrl-g` | pick a branch and check it out |
-| `ctrl-p` | pick a pull request and check it out |
+| `ctrl-q` | pick a file below `$PWD` and open it in `$EDITOR` |
 | `f1` | pick a repository and open it on GitHub |
 | `f3` | pick a tracked file and open it in `$EDITOR` |
-| `ctrl-q` | pick a file below `$PWD` and open it in `$EDITOR` |
+| `f7` | pick a pull request and check it out |
 
-Of those, `ctrl-o` and `ctrl-q` are unbound in fish; `ctrl-g` replaces `cancel`,
-which `escape` and `ctrl-c` also do, and `ctrl-p` replaces `up-line`, leaving
-`up` and `ctrl-r` to search history. `f1` and `f3` replace nothing — fish binds
-no function key itself, and the low ones are where users' own tools are least
-likely to already be. alt is left untouched, since fish binds most of it already.
+Of those, `ctrl-o` and `ctrl-q` are unbound in fish, and `ctrl-g` replaces
+`cancel`, which `escape` and `ctrl-c` also do. The function keys replace nothing
+— fish binds none of them itself. `f1` and `f3` sit at the low end that users'
+own tools tend to leave alone, and `f7` steps over `f4`/`f5`, where those tools
+cluster. `ctrl-p` is left alone on purpose: it is fish's `up-line`, which is how
+history gets walked on a one-line prompt. alt is left untouched too, since fish
+binds most of it already.
 
 It also defines `fe` — find, fuzzy-pick, edit — as a short alias for
 `scriv edit`, forwarding its arguments so `fe -t` and `fe src/main.rs` work

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -76,17 +76,21 @@ function scriv-pr-checkout --description "Pick a GitHub pull request and check i
     command scriv pr checkout
 end
 
-# Bindings are ctrl-<letter>, reachable without leaving the home row on a layout
-# where ctrl sits under the left pinky. Only ctrl-o and ctrl-q are unbound in
-# fish, so the other two displace a preset binding on purpose:
+# Bindings are ctrl-<letter> where a ctrl chord is free, reachable without
+# leaving the home row on a layout where ctrl sits under the left pinky. Only
+# ctrl-o and ctrl-q are unbound in fish, so ctrl-g displaces a preset binding on
+# purpose: branch checkout, over `cancel` — escape and ctrl-c both do that too.
 #
-#   ctrl-g  branch checkout, over `cancel` — escape and ctrl-c both do that too
-#   ctrl-p  pr checkout, over `up-line` — up and ctrl-r still search history
+# ctrl-p is deliberately *not* taken. It is fish's `up-line`, and on a one-line
+# prompt that is how people walk back through history: `up` falls through to
+# history search, ctrl-p does not, so replacing it costs a key that gets pressed
+# all day for a picker that gets pressed a few times an hour.
 #
-# The two function keys displace nothing: fish binds none of f1-f12 itself, and
-# f1 and f3 are the low end that users' own tools tend to leave alone — f4 and f5
-# upwards are commonly taken already. They carry the two pickers that are reached
-# least often, since a function key is a longer reach than a ctrl chord.
+# The function keys displace nothing: fish binds none of f1-f12 itself. f1 and f3
+# sit at the low end that users' own tools tend to leave alone; f4 and f5 are
+# where those tools cluster (awsvault, editors), so the third one skips past them
+# to f7. They carry the pickers reached least often, since a function key is a
+# longer reach than a ctrl chord.
 #
 # Rebind any of them by calling `bind` yourself after `scriv_key_bindings`; the
 # last binding for a key wins. alt-<letter> is left alone on purpose — it looks
@@ -106,7 +110,7 @@ function scriv_key_bindings --description "Bind scriv pickers to keys"
     bind f1     "scriv-repo-open; commandline -f repaint"
     bind f3     "scriv-file-edit; commandline -f repaint"
     bind ctrl-g "scriv-branch-checkout; commandline -f repaint"
-    bind ctrl-p "scriv-pr-checkout; commandline -f repaint"
+    bind f7     "scriv-pr-checkout; commandline -f repaint"
 end
 "#;
 
@@ -140,8 +144,8 @@ mod tests {
         assert!(out.contains("bind ctrl-q"));
         assert!(out.contains("bind f1"));
         assert!(out.contains("bind f3"));
+        assert!(out.contains("bind f7"));
         assert!(out.contains("bind ctrl-g"));
-        assert!(out.contains("bind ctrl-p"));
     }
 
     /// fish binds most of alt-<letter> itself — alt-b is backward-word, alt-e
@@ -218,13 +222,23 @@ mod tests {
         }
     }
 
-    /// f4 and f5 are common in user configs (awsvault, editors), so f3 is as far
-    /// up the function keys as scriv reaches.
+    /// f4 and f5 are where users' own tools cluster (awsvault, editors), so scriv
+    /// steps over them rather than reaching for the next free key upwards.
     #[test]
-    fn fish_avoids_function_keys_beyond_f3() {
+    fn fish_avoids_the_crowded_function_keys() {
         let out = integration(Shell::Fish, &mut dummy());
         assert!(!out.contains("bind f4"));
         assert!(!out.contains("bind f5"));
+    }
+
+    /// ctrl-p is fish's `up-line`, and unlike `up` it does not fall through to
+    /// history search — so a shell where scriv took it loses the way people walk
+    /// back through history on a one-line prompt.
+    #[test]
+    fn fish_leaves_history_navigation_alone() {
+        let out = integration(Shell::Fish, &mut dummy());
+        assert!(!out.contains("bind ctrl-p"), "ctrl-p is up-line");
+        assert!(!out.contains("bind ctrl-n"), "ctrl-n is down-line");
     }
 
     #[test]


### PR DESCRIPTION
`ctrl-p` is fish's `up-line`. Unlike `up` it does not fall through to history search, so scriv binding it costs a key that gets pressed all day for a picker that gets pressed a few times an hour. The PR picker moves to `f7`.

`f7` rather than the free `f2`: it stays clear of `f4`/`f5`, where users' own tools cluster, and puts the least-reached picker on the longest reach.

**Trade-off:** this loosens a rule the repo had written down — `f3` was previously as far up the function keys as scriv reached, on the argument that everything above is commonly taken. `f4`/`f5` are still off-limits and still tested; `f7` is a bet that the crowding thins out above them. If it collides with something, `bind` after `scriv_key_bindings` wins.

The old test `fish_avoids_function_keys_beyond_f3` becomes `fish_avoids_the_crowded_function_keys` (same f4/f5 assertions, narrower claim), and a new `fish_leaves_history_navigation_alone` pins the actual guarantee: scriv binds neither `ctrl-p` nor `ctrl-n`.

### The three docs
- **CLI help text** — untouched. No command or flag changed; bindings live in `scriv init fish` output, not in clap.
- **README.md** — key-binding table updated (rows reordered so ctrl chords and function keys group), and the paragraph under it rewritten to explain why `ctrl-p` is now deliberately left alone.
- **docs/demo.gif** — no re-record needed. Key bindings appear in no picker's rows, and `demo/demo.tape` drives `scriv` by command, not by keystroke.

`CLAUDE.md`'s key-binding rule is updated too, since it stated the `f3` ceiling.

`make` green: fmt, clippy `-D warnings`, 181 tests, release build.