### PR TITLE
Open the repository you are standing in with `repo open`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,11 @@ reference, so command implementations do no environment lookups of their own.
   `repo`/`file`/`branch`/`pr` are each a set scriv knows about, with `ls`/`pick`
   and a verb over that set. `edit` acts on the directory the user is standing
   in, so it is a verb at the top level rather than a fifth noun — and it has no
-  `ls`. Resist filing ambient-directory work under a noun group.
+  `ls`. Resist filing ambient-directory work under a noun group. `repo open` is
+  the one place a registry verb reads the ambient directory, and only to skip a
+  question it can already answer: in a repository it opens that one, `--pick`
+  asks anyway, and outside one it is the ordinary picker. The set it picks over
+  is unchanged.
 - **Anything drawn inline takes a `term::ScratchRow` first.** The picker and the
   spinner both start on the row the cursor is on, which from a key binding is
   the last row of the shell's prompt — the picker draws over it, the spinner

--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ scriv repo clone capralifecycle # scope to one owner (any owner, not just yours)
 scriv repo clone tailscale/tailscale   # skip both pickers
 ```
 
-`scriv repo open` picks from that same list and opens the repository's GitHub
-page, via `gh repo view --web` — which reads the page from that checkout's git
-remotes, so a directory renamed on clone and a fork both land where they should.
-It picks over every repository you have rather than acting on the one you are
-standing in; for that one, `gh repo view --web` is already the whole answer.
+`scriv repo open` opens a repository's GitHub page. Standing in one, that is the
+one it opens — there is nothing to ask. Anywhere else it picks from that same
+list, and `--pick` asks even from inside a repository, for when you want
+somebody else's. Either way it goes through `gh repo view --web`, which reads
+the page from that checkout's git remotes, so a directory renamed on clone and a
+fork both land where they should.
 
 `scriv file add`/`remove` maintain the tracked list, and `scriv config` /
 `scriv init` handle setup. `branch` abbreviates to `br`, `checkout` to `co`,
@@ -186,7 +187,7 @@ end
 | `ctrl-o` | pick a repository and `cd` into it |
 | `ctrl-g` | pick a branch and check it out |
 | `ctrl-q` | pick a file below `$PWD` and open it in `$EDITOR` |
-| `f1` | pick a repository and open it on GitHub |
+| `f1` | open this repository on GitHub, or pick one when you are not in one |
 | `f3` | pick a tracked file and open it in `$EDITOR` |
 | `f7` | pick a pull request and check it out |
 

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -13,7 +13,7 @@ use crate::gh::{self, Repo};
 use crate::path::{display_path, expand_home_dir, relative_label};
 use crate::pick::{Choice, PickItem, Preview};
 use crate::repo::FoundRepo;
-use crate::{Ctx, pick, repo, term};
+use crate::{Ctx, git, pick, repo, term};
 
 /// Discover repositories, label-tagged and sorted by path.
 fn discover(ctx: &Ctx) -> Result<Vec<FoundRepo>> {
@@ -179,14 +179,39 @@ pub fn pick(ctx: &Ctx) -> Result<()> {
     Ok(())
 }
 
-/// `scriv repo open` — fuzzy-select one repository and open its GitHub page.
+/// Which repository `repo open` acts on.
+#[derive(Debug, PartialEq, Eq)]
+enum Target {
+    /// The repository the shell is standing in.
+    Here(PathBuf),
+    /// Whichever one the user picks.
+    Pick,
+}
+
+/// Decide what `repo open` opens.
 ///
-/// A verb over the same set `ls` and `pick` cover, so it picks from every
-/// repository scriv found rather than acting on the one the shell happens to be
-/// standing in. That case is already `gh repo view --web`, which needs no fuzzy
-/// finder to do it; choosing among the hundred you are *not* standing in is the
-/// part worth a command.
-pub fn open(ctx: &Ctx) -> Result<()> {
+/// Standing in a repository is already a statement of which one you mean, so it
+/// wins over the picker — a key binding pressed in a checkout should not ask a
+/// question it can answer. `--pick` is how you say you meant a different one.
+fn target(root: Option<PathBuf>, force_pick: bool) -> Target {
+    match root {
+        Some(root) if !force_pick => Target::Here(root),
+        _ => Target::Pick,
+    }
+}
+
+/// `scriv repo open` — open a repository's GitHub page in the browser.
+///
+/// Inside a repository that is this one, with nothing to choose. Anywhere else,
+/// or with `--pick`, it is a verb over the same set `ls` and `pick` cover and
+/// fuzzy-selects from every repository scriv found.
+pub fn open(ctx: &Ctx, force_pick: bool) -> Result<()> {
+    if let Target::Here(root) = target(git::repo_root(), force_pick) {
+        ctx.log
+            .info(&format!("opening the repository at {}", root.display()));
+        return gh::view_repo_web(&root);
+    }
+
     let repos = discover(ctx)?;
     let rows = repo_rows(ctx, &repos);
     let choice = pick::pick_one(rows, "Open a repository on GitHub", &ctx.config.picker)?;
@@ -556,6 +581,25 @@ mod tests {
         assigned.sort_unstable();
         assigned.dedup();
         assert_eq!(assigned.len(), 4, "two labels share a colour: {colors:?}");
+    }
+
+    /// The repository you are standing in is the one you mean: `repo open`
+    /// there opens it rather than asking which of a hundred you wanted.
+    #[test]
+    fn open_acts_on_the_repository_you_are_in() {
+        let here = PathBuf::from("/home/u/dev/github.com/acme/billing-api");
+        assert_eq!(target(Some(here.clone()), false), Target::Here(here));
+    }
+
+    /// Outside a repository there is nothing ambient to open, so the picker is
+    /// the only answer — and `--pick` asks for it from inside one, which is how
+    /// you reach a repository other than the one you are working in.
+    #[test]
+    fn open_picks_outside_a_repository_or_on_request() {
+        assert_eq!(target(None, false), Target::Pick);
+        assert_eq!(target(None, true), Target::Pick);
+        let here = PathBuf::from("/home/u/dev/github.com/acme/billing-api");
+        assert_eq!(target(Some(here), true), Target::Pick);
     }
 
     /// A clone must land exactly where discovery looks for it, or cloning

--- a/src/git.rs
+++ b/src/git.rs
@@ -12,6 +12,7 @@
 
 use std::collections::HashSet;
 use std::io::ErrorKind;
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -367,6 +368,25 @@ pub fn ensure_repo() -> Result<()> {
         bail!("not inside a git repository");
     }
     Ok(())
+}
+
+/// The root of the repository the working directory is in, if it is in one.
+///
+/// Absence is an answer here rather than an error: a command that adapts to
+/// where you are standing needs to know whether you are standing anywhere, and
+/// "not in a repository" is an ordinary case with its own behaviour.
+pub fn repo_root() -> Option<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let root = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!root.is_empty()).then(|| PathBuf::from(root))
 }
 
 /// Every branch in the repository, ordered by [`by_relevance`]: the current

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,13 +136,17 @@ enum RepoCmd {
     },
     /// Fuzzy-select a repository and print its absolute path
     Pick,
-    /// Fuzzy-select a repository and open its GitHub page in the browser
+    /// Open a repository's GitHub page in the browser
     ///
-    /// Picks from every repository under your search paths, then hands off to
+    /// Inside a repository, opens that one. Anywhere else, fuzzy-selects from
+    /// every repository under your search paths. Either way it hands off to
     /// `gh repo view --web`, which resolves the page from that checkout's git
-    /// remotes. To open the repository you are already standing in, run
-    /// `gh repo view --web` directly — there is nothing to pick.
-    Open,
+    /// remotes.
+    Open {
+        /// Pick a repository even when standing in one
+        #[arg(short, long)]
+        pick: bool,
+    },
     /// Clone repositories from GitHub into your root
     ///
     /// With no argument, pick an owner — suggested from your config, the owners
@@ -383,7 +387,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
         Command::Repo { command } => match command {
             RepoCmd::Ls { absolute_paths } => cmd::repo::ls(&ctx, absolute_paths),
             RepoCmd::Pick => cmd::repo::pick(&ctx),
-            RepoCmd::Open => cmd::repo::open(&ctx),
+            RepoCmd::Open { pick } => cmd::repo::open(&ctx, pick),
             RepoCmd::Clone { target, limit } => cmd::repo::clone(&ctx, target.as_deref(), limit),
         },
         Command::File { command } => match command {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -46,7 +46,7 @@ end
 
 # Unlike cd, opening a browser needs no shell help — this is a thin wrapper kept
 # only to hang a key binding off.
-function scriv-repo-open --description "Pick a repository and open it on GitHub"
+function scriv-repo-open --description "Open this repository on GitHub, or pick one"
     command scriv repo open
 end
 


### PR DESCRIPTION
`repo open` picked from every repository scriv knows about even when run from inside one, so `f1` — pressed from a checkout nearly every time — asked a question it could already answer.

In a repository it now opens that one. Outside a repository, and with `--pick` from inside one, it is the picker as before; the set it picks over is unchanged. `--pick` is what keeps a colleague's repository reachable without leaving your own.

The decision is a pure `target()` over "is there a repo root here" and the flag, covered by tests rather than by running git. `git::repo_root()` returns `Option` rather than erroring, since "not in a repository" is an ordinary case here.

This is the one place a registry verb reads the ambient directory — the trade-off `CLAUDE.md` warns about. It buys a keystroke that no longer opens a picker to answer a question with one obvious answer; `--pick` is the cost, one flag for the case that used to be free. The rule is amended rather than quietly broken.

### The three docs

1. **CLI help** — `RepoCmd::Open` doc comment rewritten, `--pick` documented. `EXAMPLES` unchanged: no new command group.
2. **README** — the `repo open` paragraph and the `f1` row of the key-binding table. Also `shell.rs`, whose fish function description is user-visible.
3. **`docs/demo.gif`** — no re-record. Nothing changed what any picker draws, and the tape does not run `repo open`.