### PR TITLE
Release 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,7 +1679,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scriv"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scriv"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "Pick, don't type: repositories, files, branches and pull requests from one fuzzy picker."
 license = "MIT"


### PR DESCRIPTION
`v0.1.0` is the Go program this replaced. Everything since is a rewrite in Rust plus the surface that grew on top of it:

- `scriv repo clone` and `scriv repo open`
- `scriv edit`, with a streamed `.gitignore`-aware walk
- `scriv pr open` / `pr merge`, with checks in every pull request listing
- in-place picker refresh on `ctrl-r`, and a spinner for the waits before a picker can open
- fish key bindings, moved from alt to ctrl and the function keys
- config regrouped under the command that reads each key

Minor rather than major: the config layout changed twice in that span and the key bindings moved, so this is not yet a surface to promise stability for. Pre-1.0, that is what the minor is for.

Tagging `v0.2.0` after this lands runs the release workflow, which builds the four targets, attests them, and publishes the release with generated notes.

### The three docs

1. **CLI help** — no surface change; `--version` picks the number up from the crate.
2. **README** — no version is written into it; install is `mise use -g github:joakimen/scriv` and `cargo install --path .`, both unpinned.
3. **`docs/demo.gif`** — untouched, and nothing in the recording shows a version.