### PR TITLE
End a listing when the reader stops reading

### DIFF
--- a/src/cmd/branch.rs
+++ b/src/cmd/branch.rs
@@ -84,9 +84,12 @@ pub fn ls(ctx: &Ctx, filter: Filter, status: bool, fetch: bool) -> Result<()> {
     let branches = collect(ctx, filter, fetch)?;
     let color = term::stdout_color();
 
+    let mut out = term::Listing::stdout();
     if !status {
         for branch in &branches {
-            println!("{}", term::paint(&branch.name, branch.kind.color(), color));
+            if !out.line(&term::paint(&branch.name, branch.kind.color(), color))? {
+                break;
+            }
         }
         return Ok(());
     }
@@ -102,10 +105,9 @@ pub fn ls(ctx: &Ctx, filter: Filter, status: bool, fetch: bool) -> Result<()> {
             date = branch.date,
             subject = branch.subject,
         );
-        println!(
-            "{}",
-            term::paint(row.trim_end(), branch.kind.color(), color)
-        );
+        if !out.line(&term::paint(row.trim_end(), branch.kind.color(), color))? {
+            break;
+        }
     }
     Ok(())
 }

--- a/src/cmd/file.rs
+++ b/src/cmd/file.rs
@@ -14,10 +14,14 @@ pub fn ls(ctx: &Ctx, status: bool, missing: bool, exists: bool) -> Result<()> {
     ctx.ensure_files_migrated()?;
     let lines = files::read_lines(&ctx.files_path)?;
 
+    let mut out = term::Listing::stdout();
+
     // Plain listing: expand `~` and print, nothing else.
     if !status && !missing && !exists {
         for line in &lines {
-            println!("{}", expand_tilde(line, ctx.home_str()));
+            if !out.line(&expand_tilde(line, ctx.home_str()))? {
+                break;
+            }
         }
         return Ok(());
     }
@@ -35,16 +39,15 @@ pub fn ls(ctx: &Ctx, status: bool, missing: bool, exists: bool) -> Result<()> {
             continue;
         }
 
-        if !status {
-            println!("{expanded}");
-            continue;
-        }
-
-        match (use_color, present) {
-            (true, true) => println!("\x1b[32m✓ {expanded}\x1b[0m"),
-            (true, false) => println!("\x1b[31m✗ {expanded}\x1b[0m"),
-            (false, true) => println!("✓ {expanded}"),
-            (false, false) => println!("✗ {expanded}"),
+        let row = match (status, use_color, present) {
+            (false, _, _) => expanded,
+            (true, true, true) => format!("\x1b[32m✓ {expanded}\x1b[0m"),
+            (true, true, false) => format!("\x1b[31m✗ {expanded}\x1b[0m"),
+            (true, false, true) => format!("✓ {expanded}"),
+            (true, false, false) => format!("✗ {expanded}"),
+        };
+        if !out.line(&row)? {
+            break;
         }
     }
     Ok(())

--- a/src/cmd/history.rs
+++ b/src/cmd/history.rs
@@ -12,6 +12,7 @@ use anyhow::{Context, Result};
 
 use crate::history::{self, Entry};
 use crate::pick::{PickItem, Preview};
+use crate::term;
 use crate::{Ctx, pick};
 
 /// The clock, read once per command so every row is dated against the same
@@ -96,9 +97,12 @@ pub fn ls(ctx: &Ctx, status: bool) -> Result<()> {
     let entries = load(ctx)?;
     let now = now();
 
+    let mut out = term::Listing::stdout();
     if !status {
         for entry in &entries {
-            println!("{}", history::one_line(&entry.cmd));
+            if !out.line(&history::one_line(&entry.cmd))? {
+                break;
+            }
         }
         return Ok(());
     }
@@ -114,7 +118,10 @@ pub fn ls(ctx: &Ctx, status: bool) -> Result<()> {
         .collect();
     let width = age_width(&ages);
     for (entry, age) in entries.iter().zip(&ages) {
-        println!("{age:<width$}  {}", history::one_line(&entry.cmd));
+        let row = format!("{age:<width$}  {}", history::one_line(&entry.cmd));
+        if !out.line(&row)? {
+            break;
+        }
     }
     Ok(())
 }

--- a/src/cmd/pr.rs
+++ b/src/cmd/pr.rs
@@ -118,6 +118,7 @@ pub fn ls(ctx: &Ctx, state: &str, limit: usize, status: bool) -> Result<()> {
     let color = term::stdout_color();
     let width = number_width(&prs);
     let columns = StatusColumns::of(&prs);
+    let mut out = term::Listing::stdout();
 
     for pr in &prs {
         let cells = columns.cells(pr, color.then(|| pr.color()));
@@ -139,7 +140,9 @@ pub fn ls(ctx: &Ctx, state: &str, limit: usize, status: bool) -> Result<()> {
                 author = pr.author_login(),
             )
         };
-        println!("{}", term::paint(&row, pr.color(), color));
+        if !out.line(&term::paint(&row, pr.color(), color))? {
+            break;
+        }
     }
     Ok(())
 }

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -47,9 +47,12 @@ pub fn ls(ctx: &Ctx, absolute: bool) -> Result<()> {
     let repos = discover(ctx)?;
     ctx.log
         .info(&format!("returning {} repositories", repos.len()));
+    let mut out = term::Listing::stdout();
     for repo in &repos {
         let path = repo.path.to_string_lossy();
-        println!("{}", display_path(&path, ctx.home_str(), absolute));
+        if !out.line(&display_path(&path, ctx.home_str(), absolute))? {
+            break;
+        }
     }
     Ok(())
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -22,6 +22,57 @@ pub fn no_color() -> bool {
     std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty())
 }
 
+/// Stdout for a listing, which ends quietly when the reader stops reading.
+///
+/// `println!` panics on a closed pipe, so `scriv history ls | head` — five
+/// thousand rows produced for a reader that wanted three — ends in a Rust
+/// stack trace where every other command-line tool would simply stop. Listings
+/// write through here instead.
+///
+/// Only the long ones ever noticed: a few hundred rows fit in the pipe buffer,
+/// so the write that fails never happens and the panic stayed hidden until a
+/// listing got big enough to outrun `head`.
+pub struct Listing<W: Write> {
+    out: W,
+    /// Cleared once the far end has gone, so the caller is told once and no
+    /// further write is attempted.
+    open: bool,
+}
+
+impl Listing<std::io::Stdout> {
+    /// The listing every `ls` command writes: stdout.
+    pub fn stdout() -> Self {
+        Self::new(std::io::stdout())
+    }
+}
+
+impl<W: Write> Listing<W> {
+    /// Wrap a writer. Taking one rather than reaching for stdout is what lets
+    /// the closed-pipe behaviour be tested against a writer that really fails.
+    pub fn new(out: W) -> Self {
+        Self { out, open: true }
+    }
+
+    /// Write one line, reporting whether there is still anyone reading.
+    ///
+    /// `Ok(false)` means the reader has closed the pipe: stop producing rows
+    /// that have nowhere to go. Any other write failure is a real error and is
+    /// returned as one — a full disk must not look like a `head`.
+    pub fn line(&mut self, text: &str) -> std::io::Result<bool> {
+        if !self.open {
+            return Ok(false);
+        }
+        match writeln!(self.out, "{text}") {
+            Ok(()) => Ok(true),
+            Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {
+                self.open = false;
+                Ok(false)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
 /// Wrap `text` in an ANSI 256-colour sequence when `on`, so the same colour
 /// indices the picker uses also drive plain listings.
 pub fn paint(text: &str, color: u8, on: bool) -> String {
@@ -215,6 +266,83 @@ impl Drop for Spinner {
 
 #[cfg(test)]
 mod tests {
+    /// A writer that takes `ok` complete lines and then fails with `kind`,
+    /// standing in for a `head` that has read its rows and gone.
+    ///
+    /// Counting newlines rather than calls is what makes it a stand-in at all:
+    /// `writeln!` reaches the writer more than once per line, so a stub that
+    /// counted calls would fail partway through a row instead of between them.
+    struct FailsAfter {
+        ok: usize,
+        kind: std::io::ErrorKind,
+        buf: String,
+    }
+
+    impl FailsAfter {
+        fn new(ok: usize, kind: std::io::ErrorKind) -> Self {
+            Self {
+                ok,
+                kind,
+                buf: String::new(),
+            }
+        }
+
+        fn lines(&self) -> Vec<&str> {
+            self.buf.lines().collect()
+        }
+    }
+
+    impl std::io::Write for FailsAfter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            if self.buf.matches('\n').count() >= self.ok {
+                return Err(std::io::Error::from(self.kind));
+            }
+            self.buf.push_str(&String::from_utf8_lossy(buf));
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// `scriv history ls | head` produces five thousand rows for a reader that
+    /// wants three, and `println!` answers the closed pipe with a panic. Short
+    /// listings hid it — a few hundred rows fit in the pipe buffer, so the
+    /// failing write never happened — which is why it only surfaced once a
+    /// listing got long enough to outrun `head`.
+    #[test]
+    fn a_reader_that_stops_reading_ends_the_listing_rather_than_failing_it() {
+        let mut listing = super::Listing::new(FailsAfter::new(2, std::io::ErrorKind::BrokenPipe));
+        assert!(listing.line("one").unwrap());
+        assert!(listing.line("two").unwrap());
+        assert!(
+            !listing.line("three").unwrap(),
+            "kept writing past the reader"
+        );
+        // Told once, then silent: no further write is even attempted.
+        assert!(!listing.line("four").unwrap());
+        assert_eq!(listing.out.lines(), vec!["one", "two"]);
+    }
+
+    /// A full disk must not be mistaken for a `head`. Everything other than the
+    /// reader leaving is a real failure, and a listing that swallowed it would
+    /// report success having printed half of what was asked for.
+    #[test]
+    fn other_write_failures_still_fail_the_listing() {
+        for kind in [
+            std::io::ErrorKind::StorageFull,
+            std::io::ErrorKind::PermissionDenied,
+        ] {
+            let mut listing = super::Listing::new(FailsAfter::new(1, kind));
+            assert!(listing.line("one").unwrap());
+            assert_eq!(
+                listing.line("two").unwrap_err().kind(),
+                kind,
+                "{kind:?} was treated as the reader going away"
+            );
+        }
+    }
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
`scriv history ls | head` panics:

```
thread 'main' panicked at library/std/src/io/stdio.rs:1166:9:
failed printing to stdout: Broken pipe (os error 32)
```

`println!` answers a closed pipe with a stack trace, where every other
command-line tool simply stops.

## Why now

The behaviour was always there; nothing was ever long enough to reach it. A few
hundred rows fit in the pipe buffer, so the write that fails never happens —
`repo ls` is 109 rows on my machine and has never panicked. Shell history is
5,482, which outruns `head` by two orders of magnitude and hits it every time.

So this is not a regression from #38 so much as a latent defect that #38 made
reachable — and `history ls | head` is about the most obvious thing to type at a
five-thousand-line listing. The README also claims that output pipes cleanly,
which right now it does not.

## The fix

`term::Listing` writes listing rows and reports `Ok(false)` once the far end has
gone, so the caller stops producing rows that have nowhere to go:

```rust
let mut out = term::Listing::stdout();
for entry in &entries {
    if !out.line(&history::one_line(&entry.cmd))? { break; }
}
```

Two things worth stating:

- **It takes its writer** rather than reaching for stdout internally. That is
  what lets the closed-pipe path be tested against a writer that really fails,
  instead of testing a private helper that merely classifies an error kind.
- **A failure that is not the reader leaving still propagates.** A full disk
  must not be mistaken for a `head` and reported as success having printed half
  the list.

Applied to every `ls` — repo, file, branch, pr, history. Only history is long
enough to have hit this today, but the others are one large config away from it,
and a listing that panics on a pipe is the same defect wherever it sits.

## Verification

Every listing, piped into `head -2`, no panic, correct content; full output
unchanged (`history ls` still 5,482 lines, `repo ls` still 109). The two new
tests drive a writer that fails after N complete lines — counting newlines
rather than calls, since `writeln!` reaches the writer more than once per row.

## The three docs that go stale silently

1. **CLI help.** No surface change: no command, flag, or wording moved.
2. **README.md.** No change needed — it already says `ls` output is pipe-safe;
   this is what makes that true.
3. **`docs/demo.gif`.** Not re-recorded. Nothing a picker draws changed, and the
   tape does not pipe a listing. `make demo-check` passes.

`make` green: fmt check, clippy `-D warnings`, 212 tests, release build.