### PR TITLE
Publish release assets in the call that creates the release, and ship 0.2.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,10 @@ on:
       - "v*"
 
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 jobs:
-  release:
+  build:
     strategy:
       matrix:
         include:
@@ -24,6 +22,10 @@ jobs:
           - target: x86_64-apple-darwin
             runner: macos-13
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install toolchain (pinned by rust-toolchain.toml)
@@ -39,11 +41,47 @@ jobs:
       - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: ${{ env.ASSET }}
-      - name: Publish
+      # Handed to `publish` rather than uploaded to the release from here: the
+      # release is created once with everything attached, and an artifact is the
+      # only way a job on another runner can contribute to that one call.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ env.ASSET }}
+          path: |
+            ${{ env.ASSET }}
+            ${{ env.ASSET }}.sha256
+          if-no-files-found: error
+
+  # One job, one `gh release create`, every asset in that single call.
+  #
+  # Releases here are immutable, which means one is sealed the moment it is
+  # published: a later `gh release upload` fails with "Cannot upload assets to an
+  # immutable release". Creating the release from inside the build matrix
+  # therefore cannot work however the race is resolved — the first target to
+  # finish publishes an empty release and locks the other three out. So the
+  # matrix only builds, and publishing waits for all of it.
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+      - name: Publish the release with every asset attached
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "$GITHUB_REF_NAME" --generate-notes || true
-      - name: Upload assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release upload "$GITHUB_REF_NAME" "$ASSET" "$ASSET.sha256" --clobber
+        run: |
+          set -eu
+          mapfile -t assets < <(find dist -type f | sort)
+          # Eight files: a tarball and a checksum for each of the four targets.
+          # Fewer means a target dropped out without failing the matrix, and a
+          # release missing a platform is worse than a release that did not
+          # happen — it cannot be fixed afterwards.
+          [ "${#assets[@]}" -eq 8 ] || {
+            printf 'expected 8 assets, found %d:\n' "${#assets[@]}" >&2
+            printf '  %s\n' "${assets[@]}" >&2
+            exit 1
+          }
+          gh release create "$GITHUB_REF_NAME" --generate-notes "${assets[@]}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,7 +1679,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scriv"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scriv"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "Pick, don't type: repositories, files, branches, pull requests and shell history from one fuzzy picker."
 license = "MIT"


### PR DESCRIPTION
`v0.2.0` published with no binaries attached. Releases on this repository are immutable, so publishing one seals it and the workflow's second step — `gh release upload` — failed with:

```
HTTP 422: Cannot upload assets to an immutable release.
```

The arm64 Linux job hit it first and fail-fast cancelled the other three, which is why the release has zero of the eight expected files. It is not a race that can be tuned: whichever target finishes first creates an empty release and locks the other three out permanently.

**The fix.** The matrix now only builds, packages and attests, handing each tarball and checksum to a `publish` job as an artifact. `publish` runs a single `gh release create` with all eight files, which is the only shape an immutable release permits. It refuses to publish unless all eight are present — a release missing a platform cannot be repaired afterwards, so failing loudly is the cheaper outcome. Permissions moved to the jobs that need them: `id-token`/`attestations` on the build, `contents: write` only on `publish`.

**The version.** `v0.2.0` is spent — the tag and its notes are real, the binaries can never be added. So this ships `0.2.1` with an identical tree plus the working workflow, rather than deleting a published release. `v0.2.0` stays in the list as an empty entry; anyone who pinned it gets nothing, which is already true and cannot be undone.

Note that CI cannot exercise this path: the workflow only runs on a `v*` tag, so the first real evidence is the `v0.2.1` run. The YAML was checked for job graph and syntax locally, and `mapfile`/`find` are the only new shell.

### The three docs

1. **CLI help** — untouched. `--version` reads the number from the crate.
2. **README** — untouched. No version is written into it; both install paths are unpinned.
3. **`docs/demo.gif`** — untouched; no picker output changed.