### PR TITLE
Describe what scriv does, without the slogan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "scriv"
 version = "0.2.1"
 edition = "2024"
-description = "Pick, don't type: repositories, files, branches, pull requests and shell history from one fuzzy picker."
+description = "One fuzzy picker for your Git repositories, files, branches, pull requests and shell history."
 license = "MIT"
 repository = "https://github.com/joakimen/scriv"
 # Artwork, the demo recording and CI config belong to the repository, not the

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # scriv
 
 [![ci](https://github.com/joakimen/scriv/actions/workflows/ci.yml/badge.svg)](https://github.com/joakimen/scriv/actions/workflows/ci.yml)
+[![release](https://img.shields.io/github/v/release/joakimen/scriv?logo=github&color=blue)](https://github.com/joakimen/scriv/releases/latest)
+[![license](https://img.shields.io/github/license/joakimen/scriv?color=blue)](LICENSE)
 
 ![A candle burning above an open book](docs/art/seal.svg)
 
-**Pick, don't type.** [Scriv](https://kingkiller.fandom.com/wiki/Scriv) puts the
-things you move between — your repositories, the files you keep returning to,
-git branches, GitHub pull requests, the commands you have already run — behind
-one fuzzy picker. Getting somewhere costs a few characters and a keystroke,
-rather than a path you half-remember, a branch name you have to look up, or a
-command you ran last Tuesday.
+[Scriv](https://kingkiller.fandom.com/wiki/Scriv) is one fuzzy picker for your
+Git repositories, the files you keep returning to, git branches, GitHub pull
+requests and shell history, so you pick from a list instead of typing a path you
+half-remember, a branch name you have to look up, or a command you ran last
+Tuesday.
 
 ![scriv: check out a remote branch, find and open a file, list pull requests](docs/demo.gif)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ const STYLES: Styles = Styles::styled()
 #[command(
     name = "scriv",
     version,
-    about = "Pick, don't type: repositories, files, branches, pull requests and shell history from one fuzzy picker.",
+    about = "One fuzzy picker for your Git repositories, files, branches, pull requests and shell history.",
     after_help = EXAMPLES,
     styles = STYLES,
     disable_help_subcommand = true


### PR DESCRIPTION
"Pick, don't type" is a pitch, not a description — someone scanning a repository list learns the tone before they learn what the tool is for. uv manages Python packages; ripgrep searches directories for a regex while respecting your gitignore. Both say the thing and stop.

> One fuzzy picker for your Git repositories, files, branches, pull requests and shell history.

That goes in `--help` and `Cargo.toml`, and I will set the GitHub repository description to match once this lands. The README's opening paragraph now names the problem instead of opening on a slogan: a path you half-remember, a branch name you have to look up, a command you ran last Tuesday.

Two badges join the CI one — latest release and licence:

```
[![release](https://img.shields.io/github/v/release/joakimen/scriv?logo=github&color=blue)](…/releases/latest)
[![license](https://img.shields.io/github/license/joakimen/scriv?color=blue)](LICENSE)
```

**No crates.io badge**, because there is no crates.io release: `GET /api/v1/crates/scriv` returns nothing, so the crate was never published and the name is still free. Worth knowing if you ever want it — `exclude` in `Cargo.toml` is already set up for a clean `cargo package`.

### The three docs

1. **CLI help** — `about` replaced; no command or flag changed, so every other doc comment stands.
2. **README** — opening paragraph and the badge row. The feature table, command table, key bindings and sample config are untouched and still accurate.
3. **`docs/demo.gif`** — no re-record. Nothing changed what a picker draws, and the tape never shows `--help`.

Note that the `v0.2.1` binaries being built right now carry the old `about` string; the new one ships with whatever comes next.