### PR TITLE
Build the Intel macOS binary on the arm64 runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,16 @@ permissions:
   contents: read
 
 jobs:
+  # Each target names the runner it is built on. Linux builds natively on both
+  # architectures, because a cross-linker would have to be installed first.
+  # Both macOS targets build on the arm64 runner: Apple's linker produces
+  # x86_64 binaries without help, and `rust-toolchain.toml` already installs the
+  # std for every target here, so nothing is needed beyond `--target`.
+  #
+  # Do not add a `macos-13` runner back. GitHub keeps only the latest two macOS
+  # versions and retired that label, so a job asking for it does not fail — it
+  # queues until it expires, which held the v0.2.1 release for hours without
+  # ever reporting an error.
   build:
     strategy:
       matrix:
@@ -20,7 +30,7 @@ jobs:
           - target: aarch64-apple-darwin
             runner: macos-latest
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-latest
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -28,9 +38,19 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # `rustup show` installs the pinned toolchain; the target is added
+      # explicitly rather than trusted to rust-toolchain.toml's `targets`, which
+      # is honoured only when the toolchain is first installed from that file.
+      # `target add` is idempotent, so saying it twice costs nothing.
       - name: Install toolchain (pinned by rust-toolchain.toml)
-        run: rustup show
+        run: |
+          rustup show
+          rustup target add ${{ matrix.target }}
+      # Keyed by target: two of these jobs share a runner, and a cache entry
+      # holding another architecture's artifacts is worse than a cold cache.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: ${{ matrix.target }}
       - run: cargo build --release --target ${{ matrix.target }}
       - name: Package
         run: |


### PR DESCRIPTION
`v0.2.1` never published. Three targets built green; `x86_64-apple-darwin` sat **queued for 30+ minutes with zero steps started**, so the `publish` job waited on it and the release was never created.

Cause: GitHub keeps hosted images for the latest two macOS versions only, and `macos-13` is not one of them — [the runner-images table](https://github.com/actions/runner-images) lists macOS 26 and 15 as GA, 14 as deprecated, and 13 not at all. The label is retired. Crucially a retired label does not *fail* — the job queues silently until it expires, so this looks like a slow runner rather than a broken workflow. The `v0.2.0` run hit the same wall; fail-fast cancelled that job, which is why it read as collateral damage from the arm64 Linux failure instead of a second, independent bug.

**The fix.** Both Apple targets build on `macos-latest`. Apple's linker emits x86_64 from an arm64 host with no cross-linker, so `--target` is the entire change. Verified locally rather than assumed:

```
$ cargo build --release --target x86_64-apple-darwin
$ file target/x86_64-apple-darwin/release/scriv
target/x86_64-apple-darwin/release/scriv: Mach-O 64-bit executable x86_64
```

Two consequences handled:

- **The target is installed explicitly.** `rust-toolchain.toml`'s `targets` list applies when the toolchain is first installed from that file, which a runner's preinstalled toolchain does not guarantee — on my machine that file lists four targets and `rustup target list --installed` shows only the native one. `rustup target add` is idempotent.
- **The cache is keyed by target.** Two jobs now share a runner, and an entry holding the other architecture's artifacts is worse than a cold cache.

The workflow still cannot be exercised by CI — it only runs on a `v*` tag — so the first real evidence is the next release run. The eight-asset guard from #41 is what turns a missing target into a loud failure rather than a short release.

### The three docs

1. **CLI help** — untouched; no command, flag or description changed.
2. **README** — untouched. The install paths are unpinned and name no platform.
3. **`docs/demo.gif`** — untouched; no picker output changed.