### PR TITLE
Date every history row with when you last ran it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,6 +1692,7 @@ dependencies = [
  "serde_json",
  "skim",
  "tempfile",
+ "time",
  "toml",
  "unicode-width",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,11 @@ serde_json = "1"
 # Library use only — skip the `cli`, `image`, and `listen` features and the
 # heavy deps (image stack, IPC server, duplicate clap) they pull in.
 skim = { version = "5", default-features = false }
+# Turning `history`'s stored Unix seconds into a local date. Already in the
+# tree via ratatui, so this compiles nothing new; `local-offset` is the one
+# feature added, and only `Ctx` uses it — see the note there about why the
+# offset is read before anything spawns a thread.
+time = { version = "0.3", features = ["local-offset"] }
 toml = { version = "1.1.3", features = ["preserve_order"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -89,8 +89,25 @@ command line, to be read before you press enter.
 
 ```fish
 scriv history pick          # fuzzy-pick a past command, print it
-scriv history ls --status   # every command, with how long ago you last ran it
+scriv history ls --status   # every command, dated with when you last ran it
 ```
+
+Every row is dated with when you last ran that command, in local time:
+
+```
+2026-07-30 13:58  gh pr merge --squash --auto
+2026-07-30 13:57  git log --oneline -3
+2026-07-29 09:11  cargo test --lib
+```
+
+The date is shown but never searched — it is digits at the front of every row,
+and matching it would put four thousand timestamps ahead of the command you were
+reaching for. `--status` prints the same column, fixed-width and sortable, so
+`sort` and `cut` work on it. The preview adds the exact second and the age:
+`last run 2026-07-30 13:58:20 (4h ago)`.
+
+fish records *when* a command ran and nothing else — there is no duration or
+exit status in its history file, so scriv cannot show what it was never told.
 
 A command spanning several lines is folded onto its one row with a `⏎` where
 each break was, so it cannot be mistaken for a command you never ran; the

--- a/src/cmd/history.rs
+++ b/src/cmd/history.rs
@@ -56,69 +56,60 @@ fn load(ctx: &Ctx) -> Result<Vec<Entry>> {
 /// The row only has one line, so this is where a command longer than the
 /// terminal is wide — or one that spans several lines — is actually readable.
 /// Built from the entry already in hand, so scrolling the list spawns nothing.
-fn preview(entry: &Entry, now: i64) -> String {
-    match entry.when {
-        Some(when) => format!(
-            "last run {}\n\n{}",
-            history::relative_time(now, when),
-            entry.cmd
-        ),
-        None => entry.cmd.clone(),
+fn preview(entry: &Entry, now: i64, offset: time::UtcOffset) -> String {
+    let Some(when) = entry.when else {
+        return entry.cmd.clone();
+    };
+    let exact = history::stamp_precise(when, offset);
+    if exact.is_empty() {
+        return entry.cmd.clone();
     }
+    // Both readings, because they answer different questions: the date says
+    // which run this was, the age says whether it is still how you do it.
+    format!(
+        "last run {exact} ({})\n\n{}",
+        history::relative_time(now, when),
+        entry.cmd
+    )
 }
 
-/// Build picker rows: the command folded onto one line, returning the command
-/// as it was really typed.
-fn items(entries: &[Entry], now: i64) -> Vec<PickItem> {
+/// Build picker rows: the local date it was last run, then the command folded
+/// onto one line, returning the command as it was really typed.
+///
+/// The date is a [`PickItem::prefix`] rather than part of the label, so it is
+/// shown without being searched. A date is digits at the front of every row;
+/// matched, a query of `3` would rank thousands of timestamps above the command
+/// being reached for.
+fn items(entries: &[Entry], now: i64, offset: time::UtcOffset) -> Vec<PickItem> {
     entries
         .iter()
         .map(|entry| {
             PickItem::new(history::one_line(&entry.cmd), entry.cmd.clone())
-                .preview(Preview::Text(preview(entry, now)))
+                .prefix(format!("{}  ", history::stamp(entry.when, offset)))
+                .preview(Preview::Text(preview(entry, now, offset)))
         })
         .collect()
-}
-
-/// Width of the widest age, for column alignment in `--status` output.
-fn age_width(ages: &[String]) -> usize {
-    ages.iter()
-        .map(|age| age.chars().count())
-        .max()
-        .unwrap_or(0)
 }
 
 /// `scriv history ls` — print past commands, newest first, one per line.
 ///
 /// A multi-line command is folded onto its one line like everywhere else, so
 /// the output stays one entry per line and pipes into `wc -l` or `grep`
-/// meaning what it looks like it means. `--status` prefixes how long ago each
-/// was last run.
+/// meaning what it looks like it means. `--status` prefixes the local date and
+/// time each was last run — the same column the picker shows, in a fixed-width
+/// sortable form, so `awk` and `grep` can both work on it.
 pub fn ls(ctx: &Ctx, status: bool) -> Result<()> {
     let entries = load(ctx)?;
-    let now = now();
+    let offset = ctx.utc_offset();
 
     let mut out = term::Listing::stdout();
-    if !status {
-        for entry in &entries {
-            if !out.line(&history::one_line(&entry.cmd))? {
-                break;
-            }
-        }
-        return Ok(());
-    }
-
-    let ages: Vec<String> = entries
-        .iter()
-        .map(|entry| {
-            entry
-                .when
-                .map(|when| history::relative_time(now, when))
-                .unwrap_or_default()
-        })
-        .collect();
-    let width = age_width(&ages);
-    for (entry, age) in entries.iter().zip(&ages) {
-        let row = format!("{age:<width$}  {}", history::one_line(&entry.cmd));
+    for entry in &entries {
+        let command = history::one_line(&entry.cmd);
+        let row = if status {
+            format!("{}  {command}", history::stamp(entry.when, offset))
+        } else {
+            command
+        };
         if !out.line(&row)? {
             break;
         }
@@ -135,9 +126,8 @@ pub fn ls(ctx: &Ctx, status: bool) -> Result<()> {
 /// this where one command ends.
 pub fn pick(ctx: &Ctx, query: Option<&str>, print0: bool) -> Result<()> {
     let entries = load(ctx)?;
-    let now = now();
     let chosen = pick::pick_one_queried(
-        items(&entries, now),
+        items(&entries, now(), ctx.utc_offset()),
         "Pick a command",
         query.unwrap_or_default(),
         &ctx.config.picker,
@@ -171,21 +161,50 @@ mod tests {
         ]
     }
 
+    fn utc() -> time::UtcOffset {
+        time::UtcOffset::UTC
+    }
+
     /// The row is folded onto one line; selecting it has to yield the command
     /// as it was actually typed, newlines and all, or a multi-line command
     /// comes back as something the user never ran.
     #[test]
     fn rows_fold_onto_one_line_but_return_the_real_command() {
-        let items = items(&entries(), 1000);
+        let items = items(&entries(), 1000, utc());
         assert_eq!(items[1].label, "git commit -m 'a ⏎ b'");
         assert_eq!(items[1].value(), "git commit -m 'a\nb'");
+    }
+
+    /// The date is shown but never searched. It lives in the prefix, so the
+    /// label — which is what skim matches the query against — is the command
+    /// and nothing else. Fold the date into the label instead and a query of
+    /// `3` ranks four thousand timestamps above the command being reached for.
+    #[test]
+    fn the_date_is_shown_beside_the_command_but_not_matched() {
+        let items = items(&entries(), 1000, utc());
+        assert_eq!(items[0].prefix.as_deref(), Some("1970-01-01 00:15  "));
+        assert_eq!(items[0].label, "git status");
+        assert!(!items[0].label.contains("1970"), "the date is searchable");
+    }
+
+    /// Undated rows keep the column open, so every command starts in the same
+    /// place whatever fish recorded.
+    #[test]
+    fn an_undated_row_holds_the_date_column_open() {
+        let items = items(&entries(), 1000, utc());
+        let (dated, undated) = (
+            items[0].prefix.as_deref().unwrap(),
+            items[1].prefix.as_deref().unwrap(),
+        );
+        assert_eq!(dated.len(), undated.len());
+        assert!(undated.trim().is_empty(), "{undated:?}");
     }
 
     /// Previews are built from data already in hand — a command preview would
     /// be spawned again on every keypress that moves the cursor.
     #[test]
     fn previews_are_text_rather_than_commands() {
-        for item in items(&entries(), 1000) {
+        for item in items(&entries(), 1000, utc()) {
             assert!(
                 matches!(item.preview, Some(Preview::Text(_))),
                 "a history row spawns a process to preview itself"
@@ -193,10 +212,13 @@ mod tests {
         }
     }
 
+    /// The preview carries both readings: the exact moment says which run this
+    /// was, the age says whether it is still how you do things.
     #[test]
     fn the_preview_dates_the_command_and_shows_it_in_full() {
-        let text = preview(&entries()[0], 1000);
-        assert!(text.starts_with("last run 1m ago"), "{text}");
+        let text = preview(&entries()[0], 1000, utc());
+        assert!(text.starts_with("last run 1970-01-01 00:15:00 ("), "{text}");
+        assert!(text.contains("1m ago"), "{text}");
         assert!(text.ends_with("git status"), "{text}");
     }
 
@@ -204,14 +226,6 @@ mod tests {
     /// no date to put above it.
     #[test]
     fn an_undated_command_previews_without_a_date() {
-        assert_eq!(preview(&entries()[1], 1000), "git commit -m 'a\nb'");
-    }
-
-    /// `{:<width$}` pads by character count, so a byte width would ragged the
-    /// column the moment an age is rendered in a non-ASCII locale.
-    #[test]
-    fn the_age_column_is_as_wide_as_its_widest_entry() {
-        assert_eq!(age_width(&["3d ago".into(), "just now".into()]), 8);
-        assert_eq!(age_width(&[]), 0);
+        assert_eq!(preview(&entries()[1], 1000, utc()), "git commit -m 'a\nb'");
     }
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -141,6 +141,62 @@ pub fn one_line(cmd: &str) -> String {
         .join(&joiner)
 }
 
+/// Width of a [`stamp`], so an entry fish recorded without a `when:` can hold
+/// the column open rather than shunting its command left of every other row.
+pub const STAMP_WIDTH: usize = "2026-07-30 13:57".len();
+
+/// When a command was last run, as a local date and time: `2026-07-30 13:57`.
+///
+/// Blank — but still [`STAMP_WIDTH`] wide — for an entry carrying no timestamp,
+/// so the commands stay in one column whatever fish did or did not record.
+///
+/// `offset` is passed in rather than looked up: the local offset is an
+/// environment fact, read once by [`Ctx`](crate::Ctx), which is also what keeps
+/// this a pure function with an exactly reproducible answer.
+pub fn stamp(when: Option<i64>, offset: time::UtcOffset) -> String {
+    match when.and_then(|w| local(w, offset)) {
+        Some(dt) => render(&dt, false),
+        None => " ".repeat(STAMP_WIDTH),
+    }
+}
+
+/// [`stamp`] down to the second, for the preview — where there is room for the
+/// exact moment, and where "was this the run before or after the one that
+/// worked" is a question minutes alone cannot always answer.
+///
+/// Empty for a timestamp that cannot be rendered, so the caller can leave the
+/// line out rather than print a half-formed date.
+pub fn stamp_precise(when: i64, offset: time::UtcOffset) -> String {
+    local(when, offset).map_or_else(String::new, |dt| render(&dt, true))
+}
+
+/// The one place the layout of a rendered timestamp is written down.
+fn render(dt: &time::OffsetDateTime, seconds: bool) -> String {
+    let date = format!(
+        "{:04}-{:02}-{:02} {:02}:{:02}",
+        dt.year(),
+        dt.month() as u8,
+        dt.day(),
+        dt.hour(),
+        dt.minute(),
+    );
+    if seconds {
+        format!("{date}:{:02}", dt.second())
+    } else {
+        date
+    }
+}
+
+/// The stored Unix seconds as a local date and time.
+///
+/// `None` for a timestamp outside the range a date can represent — a corrupt or
+/// absurd `when:` is one unreadable row, not a panic partway through a listing.
+fn local(when: i64, offset: time::UtcOffset) -> Option<time::OffsetDateTime> {
+    time::OffsetDateTime::from_unix_timestamp(when)
+        .ok()
+        .map(|dt| dt.to_offset(offset))
+}
+
 const MINUTE: i64 = 60;
 const HOUR: i64 = 60 * MINUTE;
 const DAY: i64 = 24 * HOUR;
@@ -323,5 +379,51 @@ mod tests {
     #[test]
     fn a_future_timestamp_reads_as_just_now() {
         assert_eq!(relative_time(1000, 9999), "just now");
+    }
+
+    /// Seven hours east of UTC, the reference moment is 1785394626.
+    fn bangkok() -> time::UtcOffset {
+        time::UtcOffset::from_hms(7, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn a_stamp_is_the_local_date_and_time() {
+        assert_eq!(stamp(Some(1785394626), bangkok()), "2026-07-30 13:57");
+    }
+
+    /// The offset is the whole point of passing one: the same instant is a
+    /// different wall clock — here a different *day* — depending on where you
+    /// are, and a history listing that showed UTC would be quietly wrong for
+    /// everyone not on it.
+    #[test]
+    fn the_offset_moves_the_wall_clock() {
+        let instant = Some(1785394626);
+        assert_eq!(stamp(instant, time::UtcOffset::UTC), "2026-07-30 06:57");
+        let west = time::UtcOffset::from_hms(-8, 0, 0).unwrap();
+        assert_eq!(stamp(instant, west), "2026-07-29 22:57");
+    }
+
+    /// Rows line up in one column, so an entry fish recorded without a `when:`
+    /// holds the space open rather than sliding its command left of every
+    /// other row.
+    #[test]
+    fn an_undated_entry_still_fills_the_column() {
+        let blank = stamp(None, bangkok());
+        assert_eq!(blank.len(), STAMP_WIDTH);
+        assert!(blank.trim().is_empty(), "{blank:?}");
+        assert_eq!(stamp(Some(1785394626), bangkok()).len(), STAMP_WIDTH);
+    }
+
+    #[test]
+    fn the_preview_stamp_carries_the_second() {
+        assert_eq!(stamp_precise(1785394626, bangkok()), "2026-07-30 13:57:06");
+    }
+
+    /// A `when:` far outside the range a date can hold is one unreadable row,
+    /// not a panic partway through five thousand of them.
+    #[test]
+    fn an_absurd_timestamp_renders_blank_rather_than_panicking() {
+        assert!(stamp(Some(i64::MAX), bangkok()).trim().is_empty());
+        assert!(stamp_precise(i64::MIN, bangkok()).is_empty());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,9 @@ pub struct Ctx {
     pub legacy_kf_path: PathBuf,
     /// fish's history file, which `scriv history` reads.
     pub history_path: PathBuf,
+    /// This machine's offset from UTC, for dating history entries. See
+    /// [`Ctx::load`] for why it is read here and not where it is used.
+    utc_offset: time::UtcOffset,
     /// The editor `scriv edit` launches, from the environment.
     editor: Option<String>,
     pub config: Config,
@@ -99,6 +102,17 @@ impl Ctx {
             &home,
         );
 
+        // Read here, at the top of the process, because it cannot be read
+        // later: determining the local offset reads the environment, which is
+        // unsound once another thread might be changing it, so `time` refuses
+        // to answer at all in a multi-threaded process on Unix. By the time a
+        // history row wants dating, skim has threads running. Resolving it once
+        // and carrying it is also simply what `Ctx` is for.
+        //
+        // UTC is the fallback if it cannot be determined — a listing an hour
+        // out beats a listing that refuses to open.
+        let utc_offset = time::UtcOffset::current_local_offset().unwrap_or(time::UtcOffset::UTC);
+
         let editor = config::resolve_editor(
             std::env::var("VISUAL").ok().as_deref(),
             std::env::var("EDITOR").ok().as_deref(),
@@ -112,6 +126,7 @@ impl Ctx {
             files_path,
             legacy_kf_path,
             history_path,
+            utc_offset,
             editor,
             config,
             log: Logger::new(verbose),
@@ -138,6 +153,11 @@ impl Ctx {
             anyhow::bail!("the configured editor is empty");
         }
         Ok(parts)
+    }
+
+    /// This machine's offset from UTC, resolved once at startup.
+    pub fn utc_offset(&self) -> time::UtcOffset {
+        self.utc_offset
     }
 
     pub fn home(&self) -> &Path {

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,9 +114,13 @@ enum Command {
     /// Search the commands you have already run (fish)
     ///
     /// Reads fish's history file directly — newest first, with repeats of a
-    /// command collapsed onto the one row. `history pick` prints the command
-    /// rather than running it; the fish integration puts it back on the command
-    /// line, bound to ctrl-r and to `up` on the first line of a prompt.
+    /// command collapsed onto the one row and dated with when it was last run.
+    /// `history pick` prints the command rather than running it; the fish
+    /// integration puts it back on the command line, bound to ctrl-r and to
+    /// `up` on the first line of a prompt.
+    ///
+    /// The date is shown but never searched: it is digits at the front of every
+    /// row, and matching it would rank timestamps above commands.
     #[command(alias = "hist")]
     History {
         #[command(subcommand)]
@@ -357,7 +361,9 @@ enum HistoryCmd {
     /// List past commands, most recent first
     #[command(alias = "list")]
     Ls {
-        /// Show how long ago each command was last run
+        /// Prefix each command with the local date and time it was last run
+        ///
+        /// Fixed width and `YYYY-MM-DD HH:MM`, so the column sorts and cuts.
         #[arg(long)]
         status: bool,
     },

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -17,8 +17,8 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use anyhow::{Result, anyhow};
-use ratatui::style::Color;
-use ratatui::text::Line;
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
 use skim::prelude::*;
 
 use crate::config::PickerConfig;
@@ -89,6 +89,14 @@ fn file_preview_cmd(path: &str) -> String {
 /// theme), and `preview` fills the preview pane while the row is highlighted.
 pub struct PickItem {
     pub label: String,
+    /// Drawn dim, ahead of the label, and *not* matched against.
+    ///
+    /// For a column that identifies a row without being what you search for —
+    /// the date on a history entry. Putting it in the label instead would make
+    /// it searchable, and since a date is digits at the start of every row,
+    /// typing a `3` would rank four thousand timestamps above the command you
+    /// were reaching for.
+    pub prefix: Option<String>,
     /// `None` when the value is the label itself, which is the common case for
     /// path rows — worth not storing twice when a walk streams in a million of
     /// them. Read it through [`PickItem::value`].
@@ -102,6 +110,7 @@ impl PickItem {
     pub fn plain(text: impl Into<String>) -> Self {
         Self {
             label: text.into(),
+            prefix: None,
             value: None,
             color: None,
             preview: None,
@@ -112,10 +121,17 @@ impl PickItem {
     pub fn new(label: impl Into<String>, value: impl Into<String>) -> Self {
         Self {
             label: label.into(),
+            prefix: None,
             value: Some(value.into()),
             color: None,
             preview: None,
         }
+    }
+
+    /// Draw `prefix` dim, ahead of the label, outside what the query matches.
+    pub fn prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.prefix = Some(prefix.into());
+        self
     }
 
     /// What selecting this row yields — the label unless one was set apart.
@@ -135,6 +151,10 @@ impl PickItem {
         self
     }
 }
+
+/// Colour of a [`PickItem::prefix`]: ANSI 8, the terminal's own grey, so the
+/// column reads as context beside the command rather than competing with it.
+const PREFIX_COLOR: u8 = 8;
 
 /// Bridges a [`PickItem`] to skim: `text()` drives display and matching,
 /// `output()` is what a selection yields, `display()` tints the row, and
@@ -158,7 +178,22 @@ impl SkimItem for SkItem {
         if let Some(idx) = self.item.color {
             context.base_style = context.base_style.fg(Color::Indexed(idx));
         }
-        context.to_line(self.text())
+
+        let Some(prefix) = &self.item.prefix else {
+            return context.to_line(self.text());
+        };
+
+        // The prefix is drawn here rather than folded into the label because
+        // `to_line`'s highlight positions are indices into the matched text.
+        // Prepending a span leaves those indices — and so the highlighting —
+        // exactly where they belong, over the label alone.
+        let mut line = Line::default();
+        line.push_span(Span::styled(
+            prefix.clone(),
+            Style::default().fg(Color::Indexed(PREFIX_COLOR)),
+        ));
+        line.spans.extend(context.to_line(self.text()).spans);
+        line
     }
 
     fn preview(&self, _context: PreviewContext) -> ItemPreview {
@@ -654,6 +689,69 @@ fn refresh_binds() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Render an item the way skim would, with `matches` standing in for a
+    /// query that hit the given characters of the *label*.
+    fn rendered(item: PickItem, matches: Vec<usize>) -> Line<'static> {
+        let sk = SkItem { item };
+        let context = DisplayContext {
+            score: 0,
+            matches: Matches::CharIndices(matches),
+            container_width: 80,
+            base_style: Style::default(),
+            matched_style: Style::default().fg(Color::Indexed(1)),
+        };
+        let line = sk.display(context);
+        Line::from(
+            line.spans
+                .into_iter()
+                .map(|s| Span::styled(s.content.into_owned(), s.style))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    fn text_of(line: &Line) -> String {
+        line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    /// The prefix is drawn ahead of the label in the terminal's grey, so a date
+    /// reads as context beside the command rather than competing with it.
+    #[test]
+    fn a_prefix_is_drawn_dim_before_the_label() {
+        let item = PickItem::plain("git status").prefix("2026-07-30 13:57  ");
+        let line = rendered(item, vec![]);
+        assert_eq!(text_of(&line), "2026-07-30 13:57  git status");
+        assert_eq!(line.spans[0].content, "2026-07-30 13:57  ");
+        assert_eq!(line.spans[0].style.fg, Some(Color::Indexed(PREFIX_COLOR)));
+    }
+
+    /// Match highlighting has to land on the label. skim reports match
+    /// positions as indices into the text it matched — the label — so folding
+    /// the prefix into that text instead would shift every highlight right by
+    /// the width of the date.
+    #[test]
+    fn highlighting_lands_on_the_label_not_the_prefix() {
+        // Character 0 of the label: the `g` of `git`.
+        let matched = Style::default().fg(Color::Indexed(1));
+        let with = rendered(
+            PickItem::plain("git status").prefix("2026-07-30 13:57  "),
+            vec![0],
+        );
+        let hit: String = with
+            .spans
+            .iter()
+            .filter(|s| s.style.fg == matched.fg)
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert_eq!(hit, "g", "highlight slid off the label: {with:?}");
+    }
+
+    /// A row with no prefix renders exactly as it did before there was one.
+    #[test]
+    fn an_item_without_a_prefix_is_unchanged() {
+        let line = rendered(PickItem::plain("git status"), vec![]);
+        assert_eq!(text_of(&line), "git status");
+    }
 
     #[test]
     fn quotes_plain_values() {


### PR DESCRIPTION
Rows and `history ls --status` now carry the local date and time a command was
last run, from the `when:` fish already stores:

```
2026-07-30 13:58  gh pr merge --squash --auto
2026-07-30 13:57  git log --oneline -3
2026-07-29 09:11  cargo test --lib
```

The preview adds the exact second and the age — `last run 2026-07-30 13:58:20
(4h ago)` — since the two answer different questions: the date says *which* run
this was, the age says whether it is still how you do things.

## The date is shown but not searched

It is a `PickItem::prefix` rather than part of the label. A date is digits at
the front of every row; matched, a query of `3` would rank four thousand
timestamps above the command being reached for. Verified in a real terminal —
with four rows whose dates all contain a `3`, typing `3` narrows to **1/4**, the
one command containing `-3`.

Drawing it as its own span ahead of the label also keeps skim's match
highlighting where it belongs: those positions are indices into the matched
text, so folding the date into that text would slide every highlight right by
the width of the date. There is a test for exactly that.

## Why the offset lives in `Ctx`

Local time needs a UTC offset, and determining one reads the environment — which
is unsound while another thread might be changing it, so `time` refuses to
answer at all in a multi-threaded process on Unix. By the time a row wants
dating, skim has threads running. `Ctx` reads it once at the top of the process
and carries it, which is what `Ctx` is for anyway, and leaves the formatting a
pure function with an exactly reproducible answer. UTC is the fallback if it
cannot be determined: a listing an hour out beats one that refuses to open.

## What this costs

- **A dependency line, and no new compiled code.** `time` was already in the
  binary via ratatui; `local-offset` is the one feature added.
- **One fixed offset for the whole listing.** An entry from the other side of a
  DST change renders an hour off. Invisible at +07; visible in Oslo. Getting it
  right for every historical entry means a tz database — `jiff` — which is a
  genuinely new dependency, and the trade was made deliberately.
- **`history ls --status` shows the date instead of the relative age** it showed
  before. It is the same column the picker shows, fixed width, and it sorts and
  cuts. The age is still in the preview.
- **`age_width` and its test are deleted**, not weakened: a fixed-width stamp
  needs no width computed, and the column alignment that test protected is now
  covered by `an_undated_row_holds_the_date_column_open`.

## What is not here

fish records **no duration and no exit status** — the only per-entry fields in
its history file are `when:`, `added_when:` and `paths:`. Atuin has duration
because it hooks `preexec`/`postexec` into its own database. scriv would need
the same to show it, which is a different architecture from reading fish's file,
so it is out of scope here and now stated in the README rather than left to be
discovered.

## The three docs that go stale silently

1. **CLI help — `src/main.rs`.** `--status` re-described (it is a date now, not
   an age); the `history` doc comment says rows are dated and that the date is
   not searched.
2. **README.md.** The history section gains the dated-rows example, the
   not-searched note, the `--status` column, and the sentence about duration.
3. **`docs/demo.gif`.** Not re-recorded. This does change what a picker draws —
   but the history picker is not in `demo/demo.tape`, which covers repo, branch,
   edit and pull requests, so no frame of the recording is affected.
   `make demo-check` passes. Adding history to the tape is worth doing on its
   own; the tape is deliberately kept under ~25 seconds.

`make` green: fmt check, clippy `-D warnings`, 221 tests, release build.