### PR TITLE
Tell gh which repository to publish to

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,9 +89,13 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
+      # `GH_REPO` because this job has no checkout — it only needs the artifacts
+      # — and `gh` otherwise resolves the repository by asking git for a remote,
+      # failing with "not a git repository" before it reaches the API.
       - name: Publish the release with every asset attached
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -eu
           mapfile -t assets < <(find dist -type f | sort)


### PR DESCRIPTION
All four builds passed on the re-tagged `v0.2.1` run — including the Intel Mac cross-build, so #43 did its job. `publish` then failed:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The job deliberately has no checkout — it needs the artifacts, not the source — but `gh` resolves the target repository by asking git for a remote, so it never reached the API. The eight-asset guard passed first, meaning all eight files were present and correct; only the publish call itself failed. No release object was created, so `v0.2.1` is still free.

`GH_REPO` is the documented way to name the repository outright and is read by every `gh` subcommand. Verified from a directory that is explicitly not a repository:

```
$ git rev-parse --is-inside-work-tree
fatal: not a git repository (or any of the parent directories): .git
$ GH_REPO=joakimen/scriv gh release list -L 2
v0.2.0  Latest  v0.2.0  2026-07-30T07:45:53Z
v0.1.0          v0.1.0  2026-04-03T14:46:42Z
```

The alternative was adding `actions/checkout` to the job, which downloads the whole tree so that `gh` can read one string out of `.git/config`. One env var is the smaller answer.

This is the third failure in this workflow and they were genuinely independent: immutable releases (#41), a retired runner label (#43), and now repo resolution. Each was only observable on a tag push, which is why they surfaced one at a time rather than together.

### The three docs

1. **CLI help** — untouched.
2. **README** — untouched.
3. **`docs/demo.gif`** — untouched.