### PR TITLE
Drop the preview pane from the history picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,17 +99,17 @@ Every row is dated with when you last ran that command, in local time:
 The date is shown but never searched — it is digits at the front of every row,
 and matching it would put four thousand timestamps ahead of the command you were
 reaching for. `--status` prints the same column, fixed-width and sortable, so
-`sort` and `cut` work on it. The preview adds the exact second and the age:
-`last run 2026-07-30 13:58:20 (4h ago)`.
+`sort` and `cut` work on it.
 
 fish records *when* a command ran and nothing else — there is no duration or
 exit status in its history file, so scriv cannot show what it was never told.
 
 A command spanning several lines is folded onto its one row with a `⏎` where
-each break was, so it cannot be mistaken for a command you never ran; the
-preview shows it in full and selecting it yields the real multi-line text. This
-one is fish-only: it is fish's history format, and only a shell can write to its
-own command line.
+each break was, so it cannot be mistaken for a command you never ran; selecting
+it yields the real multi-line text. The history picker has no preview pane —
+the pane would only repeat the row beside it, and the command lands back on the
+command line to be read before it runs. This one is fish-only: it is fish's
+history format, and only a shell can write to its own command line.
 
 `scriv edit` is the one verb rather than a noun: it searches the directory you
 are standing in — not a list scriv keeps — and opens what you choose in
@@ -125,9 +125,10 @@ The walk honours `.gitignore`, `.ignore` and `.fdignore`, and streams into the
 picker as it goes, so a huge tree is typeable immediately rather than once the
 last file is found. `tab` selects several and they open together.
 
-Every list previews the highlighted row, so you can tell candidates apart
-without leaving the picker: commits and working-tree state for repositories and
-branches, description and failing checks for pull requests, contents for files.
+Every list bar history previews the highlighted row, so you can tell candidates
+apart without leaving the picker: commits and working-tree state for
+repositories and branches, description and failing checks for pull requests,
+contents for files.
 
 Pull request listings carry their CI, so what is green is visible before you
 pick anything:

--- a/src/cmd/history.rs
+++ b/src/cmd/history.rs
@@ -11,18 +11,9 @@ use std::io::Write;
 use anyhow::{Context, Result};
 
 use crate::history::{self, Entry};
-use crate::pick::{PickItem, Preview};
+use crate::pick::PickItem;
 use crate::term;
 use crate::{Ctx, pick};
-
-/// The clock, read once per command so every row is dated against the same
-/// instant.
-fn now() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|since| since.as_secs() as i64)
-        .unwrap_or(0)
-}
 
 /// Every command in fish's history, newest first and deduplicated.
 fn load(ctx: &Ctx) -> Result<Vec<Entry>> {
@@ -51,28 +42,6 @@ fn load(ctx: &Ctx) -> Result<Vec<Entry>> {
     Ok(entries)
 }
 
-/// The preview for a command: when it was last run, then the command in full.
-///
-/// The row only has one line, so this is where a command longer than the
-/// terminal is wide — or one that spans several lines — is actually readable.
-/// Built from the entry already in hand, so scrolling the list spawns nothing.
-fn preview(entry: &Entry, now: i64, offset: time::UtcOffset) -> String {
-    let Some(when) = entry.when else {
-        return entry.cmd.clone();
-    };
-    let exact = history::stamp_precise(when, offset);
-    if exact.is_empty() {
-        return entry.cmd.clone();
-    }
-    // Both readings, because they answer different questions: the date says
-    // which run this was, the age says whether it is still how you do it.
-    format!(
-        "last run {exact} ({})\n\n{}",
-        history::relative_time(now, when),
-        entry.cmd
-    )
-}
-
 /// Build picker rows: the local date it was last run, then the command folded
 /// onto one line, returning the command as it was really typed.
 ///
@@ -80,13 +49,16 @@ fn preview(entry: &Entry, now: i64, offset: time::UtcOffset) -> String {
 /// shown without being searched. A date is digits at the front of every row;
 /// matched, a query of `3` would rank thousands of timestamps above the command
 /// being reached for.
-fn items(entries: &[Entry], now: i64, offset: time::UtcOffset) -> Vec<PickItem> {
+///
+/// No row carries a preview, so the picker keeps the full width for the
+/// commands: a preview pane would only repeat the row it is beside, and the
+/// selected command goes back on the command line to be read before it runs.
+fn items(entries: &[Entry], offset: time::UtcOffset) -> Vec<PickItem> {
     entries
         .iter()
         .map(|entry| {
             PickItem::new(history::one_line(&entry.cmd), entry.cmd.clone())
                 .prefix(format!("{}  ", history::stamp(entry.when, offset)))
-                .preview(Preview::Text(preview(entry, now, offset)))
         })
         .collect()
 }
@@ -127,7 +99,7 @@ pub fn ls(ctx: &Ctx, status: bool) -> Result<()> {
 pub fn pick(ctx: &Ctx, query: Option<&str>, print0: bool) -> Result<()> {
     let entries = load(ctx)?;
     let chosen = pick::pick_one_queried(
-        items(&entries, now(), ctx.utc_offset()),
+        items(&entries, ctx.utc_offset()),
         "Pick a command",
         query.unwrap_or_default(),
         &ctx.config.picker,
@@ -170,7 +142,7 @@ mod tests {
     /// comes back as something the user never ran.
     #[test]
     fn rows_fold_onto_one_line_but_return_the_real_command() {
-        let items = items(&entries(), 1000, utc());
+        let items = items(&entries(), utc());
         assert_eq!(items[1].label, "git commit -m 'a ⏎ b'");
         assert_eq!(items[1].value(), "git commit -m 'a\nb'");
     }
@@ -181,7 +153,7 @@ mod tests {
     /// `3` ranks four thousand timestamps above the command being reached for.
     #[test]
     fn the_date_is_shown_beside_the_command_but_not_matched() {
-        let items = items(&entries(), 1000, utc());
+        let items = items(&entries(), utc());
         assert_eq!(items[0].prefix.as_deref(), Some("1970-01-01 00:15  "));
         assert_eq!(items[0].label, "git status");
         assert!(!items[0].label.contains("1970"), "the date is searchable");
@@ -191,7 +163,7 @@ mod tests {
     /// place whatever fish recorded.
     #[test]
     fn an_undated_row_holds_the_date_column_open() {
-        let items = items(&entries(), 1000, utc());
+        let items = items(&entries(), utc());
         let (dated, undated) = (
             items[0].prefix.as_deref().unwrap(),
             items[1].prefix.as_deref().unwrap(),
@@ -200,32 +172,13 @@ mod tests {
         assert!(undated.trim().is_empty(), "{undated:?}");
     }
 
-    /// Previews are built from data already in hand — a command preview would
-    /// be spawned again on every keypress that moves the cursor.
+    /// No history row previews. The pane exists only when some row asks for
+    /// one, so this is what keeps the full terminal width on the commands
+    /// rather than on a pane repeating the highlighted row back.
     #[test]
-    fn previews_are_text_rather_than_commands() {
-        for item in items(&entries(), 1000, utc()) {
-            assert!(
-                matches!(item.preview, Some(Preview::Text(_))),
-                "a history row spawns a process to preview itself"
-            );
+    fn no_row_opens_a_preview_pane() {
+        for item in items(&entries(), utc()) {
+            assert!(item.preview.is_none(), "a history row previews itself");
         }
-    }
-
-    /// The preview carries both readings: the exact moment says which run this
-    /// was, the age says whether it is still how you do things.
-    #[test]
-    fn the_preview_dates_the_command_and_shows_it_in_full() {
-        let text = preview(&entries()[0], 1000, utc());
-        assert!(text.starts_with("last run 1970-01-01 00:15:00 ("), "{text}");
-        assert!(text.contains("1m ago"), "{text}");
-        assert!(text.ends_with("git status"), "{text}");
-    }
-
-    /// An entry fish recorded without a `when:` still previews; there is simply
-    /// no date to put above it.
-    #[test]
-    fn an_undated_command_previews_without_a_date() {
-        assert_eq!(preview(&entries()[1], 1000, utc()), "git commit -m 'a\nb'");
     }
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -108,7 +108,7 @@ fn unescape(text: &str) -> String {
 /// wants: the command from a moment ago is the first row offered. Dropping
 /// repeats is what keeps a command run twenty times a day to one row instead of
 /// a screenful of identical ones, and keeping the *newest* of each is what lets
-/// the preview say when it was last used.
+/// the row say when it was last used.
 pub fn recent_first(entries: Vec<Entry>) -> Vec<Entry> {
     let mut seen: HashSet<String> = HashSet::with_capacity(entries.len());
     let mut out = Vec::with_capacity(entries.len());
@@ -155,36 +155,21 @@ pub const STAMP_WIDTH: usize = "2026-07-30 13:57".len();
 /// this a pure function with an exactly reproducible answer.
 pub fn stamp(when: Option<i64>, offset: time::UtcOffset) -> String {
     match when.and_then(|w| local(w, offset)) {
-        Some(dt) => render(&dt, false),
+        Some(dt) => render(&dt),
         None => " ".repeat(STAMP_WIDTH),
     }
 }
 
-/// [`stamp`] down to the second, for the preview — where there is room for the
-/// exact moment, and where "was this the run before or after the one that
-/// worked" is a question minutes alone cannot always answer.
-///
-/// Empty for a timestamp that cannot be rendered, so the caller can leave the
-/// line out rather than print a half-formed date.
-pub fn stamp_precise(when: i64, offset: time::UtcOffset) -> String {
-    local(when, offset).map_or_else(String::new, |dt| render(&dt, true))
-}
-
 /// The one place the layout of a rendered timestamp is written down.
-fn render(dt: &time::OffsetDateTime, seconds: bool) -> String {
-    let date = format!(
+fn render(dt: &time::OffsetDateTime) -> String {
+    format!(
         "{:04}-{:02}-{:02} {:02}:{:02}",
         dt.year(),
         dt.month() as u8,
         dt.day(),
         dt.hour(),
         dt.minute(),
-    );
-    if seconds {
-        format!("{date}:{:02}", dt.second())
-    } else {
-        date
-    }
+    )
 }
 
 /// The stored Unix seconds as a local date and time.
@@ -195,30 +180,6 @@ fn local(when: i64, offset: time::UtcOffset) -> Option<time::OffsetDateTime> {
     time::OffsetDateTime::from_unix_timestamp(when)
         .ok()
         .map(|dt| dt.to_offset(offset))
-}
-
-const MINUTE: i64 = 60;
-const HOUR: i64 = 60 * MINUTE;
-const DAY: i64 = 24 * HOUR;
-const MONTH: i64 = 30 * DAY;
-const YEAR: i64 = 365 * DAY;
-
-/// How long ago `then` was, seen from `now` — both Unix seconds.
-///
-/// Coarse on purpose: a history entry answers "was this today or last spring",
-/// and the second it happened is never the question. A `then` in the future is
-/// a clock that has been put back, not a command from tomorrow, so it reads as
-/// having just happened rather than as a negative age.
-pub fn relative_time(now: i64, then: i64) -> String {
-    let secs = now.saturating_sub(then).max(0);
-    match secs {
-        s if s < MINUTE => "just now".to_string(),
-        s if s < HOUR => format!("{}m ago", s / MINUTE),
-        s if s < DAY => format!("{}h ago", s / HOUR),
-        s if s < MONTH => format!("{}d ago", s / DAY),
-        s if s < YEAR => format!("{}mo ago", s / MONTH),
-        s => format!("{}y ago", s / YEAR),
-    }
 }
 
 #[cfg(test)]
@@ -337,8 +298,8 @@ mod tests {
             recent.iter().map(|e| e.cmd.as_str()).collect::<Vec<_>>(),
             vec!["ls", "git status"]
         );
-        // The surviving `ls` is the one from the most recent run, so the
-        // preview dates it by when it was last used rather than first.
+        // The surviving `ls` is the one from the most recent run, so its row
+        // is dated by when it was last used rather than first.
         assert_eq!(recent[0].when, Some(3));
     }
 
@@ -361,24 +322,6 @@ mod tests {
     fn control_characters_never_reach_a_row() {
         assert_eq!(one_line("echo \x1b[31mred\x07"), "echo [31mred");
         assert_eq!(one_line("a\tb"), "a b");
-    }
-
-    #[test]
-    fn ages_read_from_seconds_to_years() {
-        let now = 10 * YEAR;
-        assert_eq!(relative_time(now, now - 5), "just now");
-        assert_eq!(relative_time(now, now - 5 * MINUTE), "5m ago");
-        assert_eq!(relative_time(now, now - 3 * HOUR), "3h ago");
-        assert_eq!(relative_time(now, now - 2 * DAY), "2d ago");
-        assert_eq!(relative_time(now, now - 4 * MONTH), "4mo ago");
-        assert_eq!(relative_time(now, now - 3 * YEAR), "3y ago");
-    }
-
-    /// A history file written before the clock was corrected has entries dated
-    /// in the future; "in -3h" is not a thing a listing should ever say.
-    #[test]
-    fn a_future_timestamp_reads_as_just_now() {
-        assert_eq!(relative_time(1000, 9999), "just now");
     }
 
     /// Seven hours east of UTC, the reference moment is 1785394626.
@@ -414,16 +357,11 @@ mod tests {
         assert_eq!(stamp(Some(1785394626), bangkok()).len(), STAMP_WIDTH);
     }
 
-    #[test]
-    fn the_preview_stamp_carries_the_second() {
-        assert_eq!(stamp_precise(1785394626, bangkok()), "2026-07-30 13:57:06");
-    }
-
     /// A `when:` far outside the range a date can hold is one unreadable row,
     /// not a panic partway through five thousand of them.
     #[test]
     fn an_absurd_timestamp_renders_blank_rather_than_panicking() {
         assert!(stamp(Some(i64::MAX), bangkok()).trim().is_empty());
-        assert!(stamp_precise(i64::MIN, bangkok()).is_empty());
+        assert!(stamp(Some(i64::MIN), bangkok()).trim().is_empty());
     }
 }


### PR DESCRIPTION
The history preview repeated the row it sat beside — the same command, the same date to the second, plus an age nobody reads — while costing half the terminal width on the one list whose rows are long enough to want it. A multi-line command is read on the command line anyway, which is where the picker puts it before it runs.

The pane only opens when some row asks for one (`Feed::batch`), so dropping `.preview(...)` from history rows closes it for `scriv history pick`, ctrl-r and up. `history::stamp_precise` and `history::relative_time` had no other caller and go with it, along with their tests; the preview tests are replaced by one asserting no row opens a pane.

Trade-off named out loud: a command wider than the terminal is now truncated in the picker with no way to see the tail before selecting. Selecting it still yields the exact text, and fish puts it on the command line rather than running it, so the full command is readable before enter — that is the reason this is acceptable rather than a gap.

### The three docs

- **CLI help (`src/main.rs`)** — untouched: no command, flag or example describes the preview.
- **README.md** — updated. Removed the `last run … (4h ago)` preview line from the history section, reworded the multi-line-command paragraph to say the command is read on the command line rather than in a preview, and narrowed "Every list previews the highlighted row" to "Every list bar history". Command table, key bindings and sample `config.toml` are unaffected — `[picker] preview` still governs every other picker.
- **`docs/demo.gif`** — no re-record. `demo/demo.tape` never opens the history picker; it records branch checkout, `scriv edit` and `scriv pr ls`, none of which change.

`make` green: fmt, clippy `-D warnings`, 216 tests, release build.