### PR TITLE
Cut the README down to what a reader needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,21 @@
 
 ![A candle burning above an open book](docs/art/seal.svg)
 
-Fuzzy navigation and management of common local and remote resources.
+One fuzzy picker for your Git repositories, files, branches, pull requests and
+shell history.
 
 ![scriv: check out a remote branch, find and open a file, list pull requests](docs/demo.gif)
 
 | | |
 | --- | --- |
-| **repos** | pick one of your repositories and `cd` into it, open it on GitHub, or clone new ones |
+| **repos** | pick one and `cd` into it, open it on GitHub, or clone new ones |
 | **files** | keep a list of files you return to, and open one |
 | **editing** | fuzzy-find a file where you are standing and open it in `$EDITOR` |
 | **branches** | switch to a local branch, or check out a remote one |
 | **pull requests** | see what is green, then check one out, open it, or merge it |
 | **shell history** | fuzzy-search what you have run before, on `ctrl-r` and `up` |
 
-It is one binary and nothing else: the fuzzy finder
+One binary and nothing else: the fuzzy finder
 ([skim](https://github.com/skim-rs/skim)) and the file walker (the
 [`ignore`](https://docs.rs/ignore) crate behind
 [fd](https://github.com/sharkdp/fd)) are compiled in. Branches come from `git`,
@@ -39,6 +40,9 @@ From source:
 ```sh
 cargo install --path .
 ```
+
+macOS and Linux, with `git`. `gh` is needed only for pull requests and
+`repo clone`/`open`; the fish integration only for the key bindings.
 
 ## Getting started
 
@@ -68,52 +72,16 @@ Some verbs belong to one noun only:
   at `<root>/<owner>/<repo>`, so a clone is in `repo pick` the moment it
   finishes. `scriv repo clone owner/repo` skips both pickers.
 - **`scriv repo open`** — opens the repository you are standing in, or picks one
-  when you are not standing in any. `--pick` asks even from inside one.
+  when you are not. `--pick` asks even from inside one.
 - **`scriv pr open` / `scriv pr merge`** — put a pull request in the browser, or
   merge it. Both fuzzy-pick when given no number; `merge` takes `--squash`,
   `--auto`, `-d` and the rest of `gh`'s vocabulary.
 - **`scriv file add` / `remove`** — maintain the tracked list.
 
-`scriv config` and `scriv init` handle setup. `branch` abbreviates to `br`,
-`history` to `hist`, `edit` to `e`, `checkout` to `co`, and `ls` to `list`. Any command takes
-`--help` for its flags.
-
-`scriv history` searches what you have already run, reading fish's own history
-file — newest first, repeats of a command collapsed onto one row. `pick` prints
-the command rather than running it; the fish integration puts it back on the
-command line, to be read before you press enter.
-
-```fish
-scriv history pick          # fuzzy-pick a past command, print it
-scriv history ls --status   # every command, dated with when you last ran it
-```
-
-Every row is dated with when you last ran that command, in local time:
-
-```
-2026-07-30 13:58  gh pr merge --squash --auto
-2026-07-30 13:57  git log --oneline -3
-2026-07-29 09:11  cargo test --lib
-```
-
-The date is shown but never searched — it is digits at the front of every row,
-and matching it would put four thousand timestamps ahead of the command you were
-reaching for. `--status` prints the same column, fixed-width and sortable, so
-`sort` and `cut` work on it.
-
-fish records *when* a command ran and nothing else — there is no duration or
-exit status in its history file, so scriv cannot show what it was never told.
-
-A command spanning several lines is folded onto its one row with a `⏎` where
-each break was, so it cannot be mistaken for a command you never ran; selecting
-it yields the real multi-line text. The history picker has no preview pane —
-the pane would only repeat the row beside it, and the command lands back on the
-command line to be read before it runs. This one is fish-only: it is fish's
-history format, and only a shell can write to its own command line.
-
-`scriv edit` is the one verb rather than a noun: it searches the directory you
-are standing in — not a list scriv keeps — and opens what you choose in
-`$VISUAL`, then `$EDITOR`.
+`scriv edit` is a verb rather than a noun: it searches the directory you are
+standing in — not a list scriv keeps — and opens what you choose in `$VISUAL`,
+then `$EDITOR`. The walk honours `.gitignore`, `.ignore` and `.fdignore` and
+streams into the picker as it goes, so a huge tree is typeable immediately.
 
 ```fish
 scriv edit              # pick a file below $PWD, open it in your editor
@@ -121,17 +89,14 @@ scriv edit --tracked    # pick from your tracked files instead
 scriv edit src/main.rs  # skip the picker
 ```
 
-The walk honours `.gitignore`, `.ignore` and `.fdignore`, and streams into the
-picker as it goes, so a huge tree is typeable immediately rather than once the
-last file is found. `tab` selects several and they open together.
+`scriv config` and `scriv init` handle setup. `branch` abbreviates to `br`,
+`history` to `hist`, `edit` to `e`, `checkout` to `co`, and `ls` to `list`. Any
+command takes `--help` for its flags.
 
-Every list bar history previews the highlighted row, so you can tell candidates
-apart without leaving the picker: commits and working-tree state for
-repositories and branches, description and failing checks for pull requests,
-contents for files.
-
-Pull request listings carry their CI, so what is green is visible before you
-pick anything:
+Every list bar history previews the highlighted row: commits and working-tree
+state for repositories and branches, description and failing checks for pull
+requests, contents for files. Pull request listings carry their CI, so what is
+green is visible before you pick anything:
 
 ```
 #128  ✓    Add a token bucket per API key  @ada
@@ -140,10 +105,9 @@ pick anything:
 ```
 
 `✓` passed, `✗` failed, `⧗` still running, `⊘` conflicts with the base branch —
-shapes rather than colours alone, so a piped or `NO_COLOR` listing says exactly
-as much. Branch and pull request lists go stale while you read them, so `ctrl-r`
-refetches and swaps the rows in underneath your query without closing the
-picker.
+shapes rather than colours alone, so a piped or `NO_COLOR` listing says as much.
+Branch and pull request lists go stale while you read them; `ctrl-r` refetches
+without closing the picker.
 
 Every `pick` prints one line and nothing else, so it composes:
 
@@ -169,24 +133,19 @@ end
 | `ctrl-o` | pick a repository and `cd` into it |
 | `ctrl-g` | pick a branch and check it out |
 | `ctrl-q` | pick a file below `$PWD` and open it in `$EDITOR` |
-| `f1` | open this repository on GitHub, or pick one when you are not in one |
+| `f1` | open this repository on GitHub, or pick one |
 | `f3` | pick a tracked file and open it in `$EDITOR` |
 | `f7` | pick a pull request and check it out |
 
 `ctrl-r` and `up` take over fish's history keys, searching the same history
-fuzzily instead of by prefix and starting from whatever you have already typed.
-`up` hands back to fish wherever a picker would be wrong — in the completion
-pager, and on any line of a multi-line command but the first, where it still
-moves the cursor — and `ctrl-p`/`ctrl-n` are untouched, so stepping through
-history one entry at a time is still there. Of the rest only `ctrl-g` displaces
-anything fish had bound (`cancel`, which `escape` and `ctrl-c` also do); the
-function keys and the others were free. To use your own keys, bind them after
-`scriv_key_bindings` — the last binding for a key wins.
+fuzzily rather than by prefix and starting from whatever you have already typed.
+`up` still moves the cursor wherever a picker would be wrong — in the completion
+pager, and past the first line of a multi-line command. To use your own keys,
+bind them after `scriv_key_bindings`; the last binding for a key wins.
 
-The integration also defines `fe` — find, fuzzy-pick, edit — as a short alias
-for `scriv edit`, arguments and all. That is the only unprefixed name scriv
-defines. For other shells, `scriv init bash`/`zsh`/`powershell`/`elvish` emit
-completions.
+`fe` — find, fuzzy-pick, edit — is a short alias for `scriv edit`, arguments and
+all, and the only unprefixed name scriv defines. For other shells,
+`scriv init bash`/`zsh`/`powershell`/`elvish` emit completions.
 
 ## Configuration
 
@@ -194,39 +153,27 @@ completions.
 grouped by the command that reads them:
 
 ```toml
-# `scriv repo`: where your repositories are, and how they are labelled.
 [repo]
-
 # One root, laid out as <owner>/<repo> — the same shape as GitHub itself, which
 # is how `repo clone` knows where a repository belongs without being told.
 root = "~/dev/github.com"
-
-# Repositories outside the root, listed one at a time.
-extra = ["~/bin"]
-
-# Directory names to skip while searching.
-ignore = ["node_modules", "target"]
-
-# Repo path rendering: relative | tilde | full
-display = "relative"
+extra = ["~/bin"]                   # repositories outside the root
+ignore = ["node_modules", "target"] # directory names to skip
+display = "relative"                # relative | tilde | full
 
 # Labels name owners, one label to many, so everything you touch for work
 # colours as one group however many orgs it spans.
 labels = { personal = ["joakimen"], work = ["capralifecycle", "nsbno"] }
 
-# `scriv history`: which shell history to search.
 [history]
-
-# fish's history file. Defaults to $XDG_DATA_HOME/fish/fish_history, falling
-# back to ~/.local/share/fish/fish_history. Only worth setting if you have named
-# your session — `set -U fish_history work` reads `work_history` instead — since
-# fish does not export that variable for scriv to find.
+# fish's history file. Defaults to $XDG_DATA_HOME/fish/fish_history. Worth
+# setting only for a named session — `set -U fish_history work` reads
+# `work_history`, and fish does not export that variable for scriv to find.
 file = "~/.local/share/fish/work_history"
 
-# The built-in fuzzy picker, shared by every command that opens one.
 [picker]
 height = "50%"                # finder height
-preview = true                # show a preview pane for the highlighted row
+preview = true                # preview pane for the highlighted row
 preview_window = "right:50%"  # preview layout
 ```
 
@@ -243,8 +190,6 @@ make demo           # re-record docs/demo.gif
 make demo-fixture   # build the demo sandbox and poke at it by hand
 ```
 
-The demo is generated, not captured: `demo/fixture.sh` builds a throwaway
-sandbox of fictional repositories, branches and pull requests, applied entirely
-from outside through `HOME`, `XDG_CONFIG_HOME` and a stub `gh` earlier on
-`PATH`. Nothing in scriv knows it is being demoed. Recording needs
-[VHS](https://github.com/charmbracelet/vhs).
+The demo is generated, not captured — `demo/fixture.sh` builds a throwaway
+sandbox of fictional repositories, branches and pull requests, and recording it
+needs [VHS](https://github.com/charmbracelet/vhs).


### PR DESCRIPTION
250 lines, and most of the second half was design rationale rather than
documentation: why the history date is shown but never searched, why the history
picker has no preview pane, why fish records a timestamp and nothing else, why
`ctrl-g` was worth displacing, how the demo sandbox is applied from outside.

Every one of those is a real reason, and every one already lives where it
belongs — in `CLAUDE.md`, or in the comment above the code it explains. In the
README they were answers to questions nobody reading it had yet, sitting between
the reader and the parts they came for.

**195 lines now.** What stayed is what someone actually needs: what it does, how
to install it, the command table, what a listing looks like, the key bindings,
the config file. What went is every paragraph defending a decision rather than
describing behaviour.

Two things gained rather than lost:

- **Install** now says which platforms are supported and which external tools
  are needed for what — `git` always, `gh` only for pull requests and
  `repo clone`/`open`, fish only for the key bindings. That was not stated
  anywhere before.
- **The config sample** carries one comment per key instead of a paragraph.

## Repository metadata

Same treatment, applied live:

- **Description** — was "Fuzzy navigation and management of common local and
  remote resources", which describes a category rather than a tool. Now the same
  sentence as `scriv --help` and the crate metadata, so the three cannot drift.
- **Topics** — was `cli`, `rust`, `fuzzy-finder`: only what it is built in. Now
  also `git`, `github`, `fish`, `skim`, `terminal`, `developer-tools` — what it
  actually works with, which is what someone searching would type.

## The three docs

1. **CLI help text** — untouched; no command or flag changed.
2. **README** — this is the change. The command table, the abbreviations
   sentence, the key-binding table and the config sample were each walked
   against the code and still agree with `scriv --help` and `shell.rs`.
3. **`docs/demo.gif`** — no re-record. Nothing changed what a picker draws.