### PR TITLE
Fix a duplicated repository, a stale $PWD, and a copy of the history

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,14 @@ reference, so command implementations do no environment lookups of their own.
   only to skip a question it can already answer: in a repository it opens that
   one, `--pick` asks anyway, and outside one it is the ordinary picker. The set
   it picks over is unchanged.
+- **`$PWD` is preferred over `getcwd`, but only when it is still true.** A shell
+  sets `$PWD` to the path the user walked, symlinks intact, which is what they
+  expect to see back; `getcwd` resolves those away. But nothing keeps the
+  variable current — a `chdir` in a parent process leaves it behind, and it can
+  simply be set wrong — and a stale one silently records a path for a directory
+  the user was never standing in. `Ctx::load` takes it only when it resolves to
+  the same directory scriv is actually in. Anything else reading the environment
+  for a location it will then write down owes the same check.
 - **Anything drawn inline takes a `term::ScratchRow` first.** The picker and the
   spinner both start on the row the cursor is on, which from a key binding is
   the last row of the shell's prompt — the picker draws over it, the spinner

--- a/src/history.rs
+++ b/src/history.rs
@@ -109,14 +109,31 @@ fn unescape(text: &str) -> String {
 /// repeats is what keeps a command run twenty times a day to one row instead of
 /// a screenful of identical ones, and keeping the *newest* of each is what lets
 /// the row say when it was last used.
+///
+/// The set holds borrowed commands rather than copies of them. A history file
+/// is tens of thousands of entries and this runs on every ctrl-r, so cloning
+/// each command into the set — only to throw the clone away — was a second copy
+/// of the whole history built and dropped on the path where the user is waiting
+/// for a picker to open.
 pub fn recent_first(entries: Vec<Entry>) -> Vec<Entry> {
-    let mut seen: HashSet<String> = HashSet::with_capacity(entries.len());
-    let mut out = Vec::with_capacity(entries.len());
-    for entry in entries.into_iter().rev() {
-        if seen.insert(entry.cmd.clone()) {
-            out.push(entry);
+    // Scoped so the borrows end before the entries are consumed below.
+    let keep = {
+        let mut seen: HashSet<&str> = HashSet::with_capacity(entries.len());
+        let mut keep = vec![false; entries.len()];
+        // Backwards, so the *newest* run of each command is the one kept and
+        // its row can say when it was last used.
+        for (index, entry) in entries.iter().enumerate().rev() {
+            keep[index] = seen.insert(entry.cmd.as_str());
         }
-    }
+        keep
+    };
+
+    let mut out: Vec<Entry> = entries
+        .into_iter()
+        .zip(keep)
+        .filter_map(|(entry, keep)| keep.then_some(entry))
+        .collect();
+    out.reverse();
     out
 }
 
@@ -301,6 +318,38 @@ mod tests {
         // The surviving `ls` is the one from the most recent run, so its row
         // is dated by when it was last used rather than first.
         assert_eq!(recent[0].when, Some(3));
+    }
+
+    /// Order and dedup have to survive the rewrite that stopped cloning every
+    /// command into the set: newest run first, one row per distinct command,
+    /// and every distinct command still present.
+    #[test]
+    fn dedup_keeps_every_distinct_command_in_recency_order() {
+        let entries: Vec<Entry> = ["a", "b", "a", "c", "b", "a"]
+            .iter()
+            .enumerate()
+            .map(|(i, cmd)| Entry {
+                cmd: (*cmd).to_string(),
+                when: Some(i as i64),
+            })
+            .collect();
+
+        let got = recent_first(entries);
+        assert_eq!(
+            got.iter().map(|e| e.cmd.as_str()).collect::<Vec<_>>(),
+            vec!["a", "b", "c"],
+            "not ordered by the most recent run of each command"
+        );
+        // Each surviving row is dated by the *last* time it was run.
+        assert_eq!(
+            got.iter().map(|e| e.when).collect::<Vec<_>>(),
+            vec![Some(5), Some(4), Some(3)]
+        );
+    }
+
+    #[test]
+    fn an_empty_history_dedups_to_nothing() {
+        assert!(recent_first(Vec::new()).is_empty());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,10 +75,18 @@ impl Ctx {
     /// Resolve the environment and load configuration.
     pub fn load(config_flag: Option<&str>, verbose: bool) -> Result<Self> {
         let home = dirs::home_dir().context("determining home directory")?;
-        let pwd = std::env::var("PWD")
-            .map(PathBuf::from)
-            .or_else(|_| std::env::current_dir())
-            .context("determining working directory")?;
+        let cwd = std::env::current_dir().context("determining working directory")?;
+        // `$PWD` keeps the symlinks the user walked through, which `getcwd`
+        // resolves away — but only when it is still current. See
+        // [`path::resolve_pwd`].
+        let pwd = path::resolve_pwd(
+            std::env::var("PWD").ok().as_deref(),
+            cwd,
+            |claimed, actual| match (claimed.canonicalize(), actual.canonicalize()) {
+                (Ok(a), Ok(b)) => a == b,
+                _ => false,
+            },
+        );
 
         let scriv_env = std::env::var(config::CONFIG_ENV_VAR).ok();
         let xdg_env = std::env::var(config::XDG_ENV_VAR).ok();

--- a/src/path.rs
+++ b/src/path.rs
@@ -32,6 +32,35 @@ pub fn expand_tilde(path: &str, home: &str) -> String {
     format!("{}{}", home, &path[1..])
 }
 
+/// Decide which of `$PWD` and the real working directory to work from.
+///
+/// `$PWD` is preferred, and worth preferring: a shell sets it to the path the
+/// user actually walked, symlinks intact, while `getcwd` reports the resolved
+/// one. Somebody who works in `~/dev` where `dev` is a symlink expects to see
+/// `~/dev/…`, not the volume it really lives on.
+///
+/// But `$PWD` is only *usually* right. It is an ordinary exported variable and
+/// nothing keeps it current: `os.chdir` in Python leaves it behind, so does a
+/// `chdir` in any program that spawns scriv, and it can simply be set to
+/// something wrong. Trusted blindly, a stale one silently records the wrong
+/// path — `scriv file add notes.md` writes an entry for a directory the user
+/// was not standing in, and nothing about the output looks unusual.
+///
+/// So it is taken only when it names the directory scriv is genuinely in.
+/// `same_dir` is what decides that — passed in so the rule is testable, and
+/// resolving symlinks on both sides in the real implementation, which is
+/// exactly what makes a symlinked-but-correct `$PWD` still win.
+pub fn resolve_pwd(
+    pwd_env: Option<&str>,
+    cwd: PathBuf,
+    same_dir: impl Fn(&Path, &Path) -> bool,
+) -> PathBuf {
+    match pwd_env.filter(|p| !p.is_empty()).map(PathBuf::from) {
+        Some(pwd) if same_dir(&pwd, &cwd) => pwd,
+        _ => cwd,
+    }
+}
+
 /// Render a repository path relative to the search `root` it was found under,
 /// so a shared base is not repeated on every row.
 ///
@@ -319,5 +348,41 @@ mod tests {
     #[test]
     fn clean_empty_is_dot() {
         assert_eq!(clean(""), ".");
+    }
+
+    /// The reason `$PWD` is preferred at all: a shell reports the path the user
+    /// walked, symlinks intact, and `getcwd` reports the resolved one. Somebody
+    /// working in `~/dev` where `dev` is a symlink expects to see `~/dev/…`.
+    #[test]
+    fn a_current_pwd_wins_even_when_it_is_a_symlinked_spelling() {
+        let got = resolve_pwd(
+            Some("/home/u/dev"),
+            PathBuf::from("/Volumes/work/dev"),
+            |_, _| true,
+        );
+        assert_eq!(got, PathBuf::from("/home/u/dev"));
+    }
+
+    /// A stale `$PWD` is the whole hazard: nothing keeps the variable current —
+    /// `os.chdir` in a Python parent leaves it behind, and it can simply be set
+    /// wrong — and trusting it would silently record a path for a directory the
+    /// user was never standing in.
+    #[test]
+    fn a_pwd_naming_somewhere_else_is_discarded() {
+        let got = resolve_pwd(
+            Some("/somewhere/stale"),
+            PathBuf::from("/real/cwd"),
+            |_, _| false,
+        );
+        assert_eq!(got, PathBuf::from("/real/cwd"));
+    }
+
+    /// Unset or empty is not an answer, and neither is a reason to fail — the
+    /// real working directory is always there to fall back on.
+    #[test]
+    fn a_missing_pwd_falls_back_to_the_real_directory() {
+        let cwd = PathBuf::from("/real/cwd");
+        assert_eq!(resolve_pwd(None, cwd.clone(), |_, _| true), cwd);
+        assert_eq!(resolve_pwd(Some(""), cwd.clone(), |_, _| true), cwd);
     }
 }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -3,6 +3,7 @@
 //! covered by tests that run against temporary directories.
 
 use anyhow::{Context, Result};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::thread;
 
@@ -119,7 +120,26 @@ pub fn find_all_repos(cfg: &Config, home: &Path, log: &Logger) -> Result<Vec<Fou
     for result in results {
         repos.extend(result?);
     }
-    Ok(repos)
+    Ok(dedup_by_path(repos))
+}
+
+/// Drop repositories found more than once, keeping the first.
+///
+/// The searches are independent, so nothing stops two of them from reaching the
+/// same checkout: an `extra` path that also sits under the root, the same path
+/// listed twice, or two spellings of one directory. Every one of those used to
+/// put the repository in the list twice, which in a picker is two identical
+/// rows where selecting either does the same thing.
+///
+/// The first occurrence wins because the jobs are ordered root-first, and only
+/// the root search knows a repository's owner and therefore its label. Keeping
+/// the later one would leave a labelled repository showing up unlabelled.
+fn dedup_by_path(repos: Vec<FoundRepo>) -> Vec<FoundRepo> {
+    let mut seen = HashSet::with_capacity(repos.len());
+    repos
+        .into_iter()
+        .filter(|repo| seen.insert(repo.path.clone()))
+        .collect()
 }
 
 /// Find directories containing a `.git` entry under `root`, descending at most
@@ -387,6 +407,47 @@ mod tests {
 
         let got = find_repos(root.path(), 2, &[], &quiet()).unwrap();
         assert_eq!(sorted(got), expected);
+    }
+
+    fn found(path: &str, label: &str, owner: Option<&str>) -> FoundRepo {
+        FoundRepo {
+            label: label.to_string(),
+            owner: owner.map(str::to_string),
+            root: PathBuf::from("/root"),
+            path: PathBuf::from(path),
+        }
+    }
+
+    /// The root search and each `extra` path run independently, so nothing
+    /// stops two of them reaching the same checkout — an `extra` entry that is
+    /// also under the root is the ordinary way it happens. Two identical picker
+    /// rows, where selecting either does the same thing, is not a list.
+    #[test]
+    fn a_repository_found_twice_is_listed_once() {
+        let got = dedup_by_path(vec![
+            found("/root/me/foo", "personal", Some("me")),
+            found("/root/me/bar", "personal", Some("me")),
+            found("/root/me/foo", "-", None),
+        ]);
+        assert_eq!(
+            got.iter().map(|r| r.path.clone()).collect::<Vec<_>>(),
+            vec![PathBuf::from("/root/me/foo"), PathBuf::from("/root/me/bar")]
+        );
+    }
+
+    /// The first occurrence is the one kept, and it has to be: the jobs run
+    /// root-first, and only the root search knows a repository's owner and
+    /// therefore its label. Keep the later copy and a labelled repository turns
+    /// up unlabelled.
+    #[test]
+    fn deduping_keeps_the_labelled_copy() {
+        let got = dedup_by_path(vec![
+            found("/root/me/foo", "personal", Some("me")),
+            found("/root/me/foo", "-", None),
+        ]);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].label, "personal");
+        assert_eq!(got[0].owner.as_deref(), Some("me"));
     }
 
     #[test]


### PR DESCRIPTION
Three things found reading the code rather than by hitting them. Each has a
regression test, and the first was reproduced against the built binary before
and after.

### A repository found twice was listed twice

The root search and each `extra` path run as independent jobs and their results
were concatenated with no dedup. Nothing stops two of them reaching the same
checkout — an `extra` entry that also sits under the root is the ordinary way it
happens, the same path listed twice is the other. The picker showed two
identical rows where selecting either did the same thing.

Before:

```
~/dev/github.com/me/bar
~/dev/github.com/me/foo
~/dev/github.com/me/foo     <- extra = ["~/dev/github.com/me/foo"]
```

Deduped by path, keeping the **first**: the jobs run root-first and only the
root search knows a repository's owner, so keeping the later copy would turn a
labelled repository unlabelled.

### A stale `$PWD` was trusted

`$PWD` is preferred over `getcwd` for a good reason — a shell reports the path
the user walked, symlinks intact, where `getcwd` reports the resolved one, and
somebody working in `~/dev` where `dev` is a symlink expects to see `~/dev/…`.

But nothing keeps `$PWD` current. A `chdir` in a parent process leaves it behind
(Python's `os.chdir` does exactly this), and it can simply be set wrong. Taken
at face value it silently recorded the wrong path: `scriv file add notes.md`
writing an entry for a directory the user was never standing in, with nothing
about the output looking unusual.

It is now taken only when it resolves to the directory scriv is genuinely in —
which still lets a symlinked-but-correct spelling win, since both sides are
canonicalised before comparing. The rule is a pure function in `path.rs` with
the comparison injected, so it is tested rather than only reasoned about.

### `history::recent_first` copied the whole history to throw it away

The dedup set held cloned command strings. Opening the history picker therefore
built and dropped a second copy of every command in the file — tens of thousands
of allocations on the one path where the user is sitting there waiting for a
picker to appear. The set now borrows; the ordering and dedup semantics are
pinned by a new test rather than left to inspection.

## The three docs

1. **CLI help text** — untouched. No command, flag or wording changed.
2. **README** — untouched. None of this is user-visible surface; the behaviour
   the README describes is what these fix it to actually do.
3. **`docs/demo.gif`** — no re-record. The dedup changes what a picker shows
   only for a config whose `extra` overlaps its root, which the demo fixture
   does not have.