### PR TITLE
Add --color auto|always|never

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,8 +188,12 @@ test that allocated a pty would be testing skim.
   an editor needs no such help: `scriv edit` spawns it directly and skim restores
   the terminal on its way out. Add a fish wrapper only for what genuinely cannot
   work from a child process.
-- **Colour is dropped when stdout is not a terminal**, and `NO_COLOR` is
-  honoured — `ls` output has to stay pipe-safe. Use `term::stdout_color()`.
+- **Colour is decided once, on `Ctx`.** `--color auto|always|never` wins, then
+  `NO_COLOR`, then whether stdout is a terminal — so `ls` output stays pipe-safe
+  by default and `--color always` can still feed `less -R`. Printing code reads
+  `ctx.color()` and never asks the terminal itself; one run must not colour one
+  command's output and not another's. The picker is out of scope: it is a
+  terminal UI that only ever draws on a terminal.
 - **Key bindings prefer `ctrl-<letter>`, and never use `alt-`.** ctrl is the
   modifier people put under a pinky, so it is where a picker worth a keystroke
   belongs. fish leaves only `ctrl-o` and `ctrl-q` unbound, so anything further

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ shapes rather than colours alone, so a piped or `NO_COLOR` listing says as much.
 Branch and pull request lists go stale while you read them; `ctrl-r` refetches
 without closing the picker.
 
+Colour follows `--color auto|always|never`, on any command: `auto` colours a
+terminal and honours `NO_COLOR`, `always` colours a pipe too so `scriv pr ls
+--color always | less -R` keeps its greens and reds.
+
 Every `pick` prints one line and nothing else, so it composes:
 
 ```fish

--- a/src/cmd/branch.rs
+++ b/src/cmd/branch.rs
@@ -26,7 +26,7 @@ use crate::{Ctx, pick};
 fn load(ctx: &Ctx, fetch: bool) -> Result<Vec<Branch>> {
     git::ensure_repo()?;
     if fetch {
-        let _spinner = term::spinner("fetching");
+        let _spinner = term::spinner("fetching", ctx.color());
         git::fetch()?;
     }
     let branches = git::branches()?;
@@ -82,7 +82,7 @@ fn date_width(branches: &[Branch]) -> usize {
 /// stdout is not a terminal.
 pub fn ls(ctx: &Ctx, filter: Filter, status: bool, fetch: bool) -> Result<()> {
     let branches = collect(ctx, filter, fetch)?;
-    let color = term::stdout_color();
+    let color = ctx.color();
 
     let mut out = term::Listing::stdout();
     if !status {

--- a/src/cmd/file.rs
+++ b/src/cmd/file.rs
@@ -26,7 +26,7 @@ pub fn ls(ctx: &Ctx, status: bool, missing: bool, exists: bool) -> Result<()> {
         return Ok(());
     }
 
-    let use_color = status && term::stdout_color();
+    let use_color = status && ctx.color();
 
     for line in &lines {
         let expanded = expand_tilde(line, ctx.home_str());

--- a/src/cmd/pr.rs
+++ b/src/cmd/pr.rs
@@ -21,7 +21,7 @@ use crate::term;
 /// `gh pr view (scriv pr pick)` are untouched by it.
 fn collect(ctx: &Ctx, state: &str, limit: usize) -> Result<Vec<PullRequest>> {
     let prs = {
-        let _spinner = term::spinner("loading pull requests");
+        let _spinner = term::spinner("loading pull requests", ctx.color());
         gh::list(state, limit)?
     };
     ctx.log.info(&format!("found {} pull requests", prs.len()));
@@ -115,7 +115,7 @@ impl StatusColumns {
 /// still says everything a coloured one does.
 pub fn ls(ctx: &Ctx, state: &str, limit: usize, status: bool) -> Result<()> {
     let prs = collect(ctx, state, limit)?;
-    let color = term::stdout_color();
+    let color = ctx.color();
     let width = number_width(&prs);
     let columns = StatusColumns::of(&prs);
     let mut out = term::Listing::stdout();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,13 +67,20 @@ pub struct Ctx {
     utc_offset: time::UtcOffset,
     /// The editor `scriv edit` launches, from the environment.
     editor: Option<String>,
+    /// Whether printed output carries colour, resolved once from `--color`,
+    /// `NO_COLOR` and whether stdout is a terminal.
+    color: bool,
     pub config: Config,
     pub log: Logger,
 }
 
 impl Ctx {
     /// Resolve the environment and load configuration.
-    pub fn load(config_flag: Option<&str>, verbose: bool) -> Result<Self> {
+    pub fn load(
+        config_flag: Option<&str>,
+        verbose: bool,
+        color: term::ColorChoice,
+    ) -> Result<Self> {
         let home = dirs::home_dir().context("determining home directory")?;
         let cwd = std::env::current_dir().context("determining working directory")?;
         // `$PWD` keeps the symlinks the user walked through, which `getcwd`
@@ -136,9 +143,21 @@ impl Ctx {
             history_path,
             utc_offset,
             editor,
+            // Resolved here rather than at each listing, so one run cannot
+            // colour one command's output and not another's.
+            color: color.for_stdout(),
             config,
             log: Logger::new(verbose),
         })
+    }
+
+    /// Whether printed output should carry ANSI colour.
+    ///
+    /// The picker is not governed by this: it is a full terminal UI that only
+    /// ever draws on a terminal, and `--color` is about what scriv *prints* —
+    /// the same scope ripgrep and fd give it.
+    pub fn color(&self) -> bool {
+        self.color
     }
 
     /// The resolved editor command, or `None` when nothing is set. For

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use clap_complete::Shell;
 use scriv::gh::MergeMethod;
 use scriv::git::Filter;
 use scriv::pick::Cancelled;
+use scriv::term::ColorChoice;
 use scriv::{Ctx, Reported, cmd, shell};
 
 /// Usage examples appended to the top-level help.
@@ -60,6 +61,15 @@ struct Cli {
     /// Path to the config file
     #[arg(short, long, global = true, value_name = "FILE")]
     config: Option<String>,
+
+    /// When to colour printed output
+    ///
+    /// `auto` colours a terminal and honours `NO_COLOR`. `always` colours a
+    /// pipe or a file too, for a pager such as `less -R`. Either explicit
+    /// value overrides `NO_COLOR`. The picker is unaffected — it only ever
+    /// draws on a terminal.
+    #[arg(long, global = true, value_name = "WHEN", default_value = "auto")]
+    color: ColorChoice,
 
     #[command(subcommand)]
     command: Command,
@@ -423,7 +433,7 @@ fn main() -> ExitCode {
 }
 
 fn run(cli: Cli) -> anyhow::Result<()> {
-    let ctx = Ctx::load(cli.config.as_deref(), cli.verbose)?;
+    let ctx = Ctx::load(cli.config.as_deref(), cli.verbose, cli.color)?;
 
     match cli.command {
         Command::Repo { command } => match command {

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,9 +1,10 @@
 //! Terminal capability checks shared by the printing commands.
 //!
-//! Colour is opt-out per the `NO_COLOR` convention and is never emitted when
-//! stdout is redirected, so `scriv … ls` stays pipe-safe by default. The same
-//! rule governs [`Spinner`] and [`ScratchRow`]: they touch the display only
-//! when there is one to touch.
+//! Colour is decided once, at startup, by [`ColorChoice::resolve`] and carried
+//! on [`Ctx`](crate::Ctx) — `--color` if the user said, else the `NO_COLOR`
+//! convention, else whether stdout is a terminal, so `scriv … ls` stays
+//! pipe-safe by default. [`Spinner`] and [`ScratchRow`] follow the same rule
+//! from the other side: they touch the display only when there is one to touch.
 
 use std::io::{IsTerminal, Write};
 use std::sync::Arc;
@@ -11,9 +12,43 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-/// Whether stdout should carry ANSI colour: a terminal, and `NO_COLOR` unset.
-pub fn stdout_color() -> bool {
-    std::io::stdout().is_terminal() && !no_color()
+/// When to colour printed output, as `--color` states it.
+///
+/// The three names every other tool of this kind uses — ripgrep, fd, `ls`,
+/// `git` — so the flag needs no explaining to anyone who has met one of them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
+#[clap(rename_all = "lower")]
+pub enum ColorChoice {
+    /// Colour when stdout is a terminal and `NO_COLOR` is unset.
+    #[default]
+    Auto,
+    /// Always colour, terminal or not — for a pager (`less -R`) or a recording.
+    Always,
+    /// Never colour.
+    Never,
+}
+
+impl ColorChoice {
+    /// Whether printed output should carry ANSI colour.
+    ///
+    /// `is_tty` is passed in rather than looked up so the rule is a pure
+    /// function with a test; [`ColorChoice::for_stdout`] is what callers use.
+    ///
+    /// An explicit `always`/`never` outranks `NO_COLOR`: the environment states
+    /// a default, and a flag on the command line is the user overriding their
+    /// own default for this one run. `auto` is where `NO_COLOR` applies.
+    pub fn resolve(self, is_tty: bool, no_color: bool) -> bool {
+        match self {
+            Self::Always => true,
+            Self::Never => false,
+            Self::Auto => is_tty && !no_color,
+        }
+    }
+
+    /// [`ColorChoice::resolve`] against this process's stdout and environment.
+    pub fn for_stdout(self) -> bool {
+        self.resolve(std::io::stdout().is_terminal(), no_color())
+    }
 }
 
 /// Honour the `NO_COLOR` convention: colour is disabled when the variable is
@@ -202,11 +237,15 @@ pub struct Spinner {
 /// Start a spinner labelled `label` (e.g. `fetching`), running until it is
 /// dropped.
 ///
+/// `color` is the resolved [`ColorChoice`], so `--color never` gives a plain
+/// spinner rather than a cyan one — the flag means the same thing everywhere
+/// scriv draws.
+///
 /// Bind it to a name — `let _spinner = term::spinner(…)` — for as long as the
 /// wait lasts. A bare `term::spinner(…)` statement drops it immediately and
 /// spins for nothing.
 #[must_use]
-pub fn spinner(label: &str) -> Spinner {
+pub fn spinner(label: &str, color: bool) -> Spinner {
     let stop = Arc::new(AtomicBool::new(false));
     if !std::io::stderr().is_terminal() {
         return Spinner {
@@ -218,7 +257,6 @@ pub fn spinner(label: &str) -> Spinner {
     let row = ScratchRow::take();
 
     let label = label.to_string();
-    let color = !no_color();
     let flag = Arc::clone(&stop);
     let thread = std::thread::spawn(move || {
         let mut frames = FRAMES.iter().cycle();
@@ -345,6 +383,37 @@ mod tests {
 
     use super::*;
 
+    /// `auto` is the rule that was there before there was a flag: a terminal,
+    /// and `NO_COLOR` unset.
+    #[test]
+    fn auto_colours_only_a_terminal_without_no_color() {
+        assert!(ColorChoice::Auto.resolve(true, false));
+        assert!(!ColorChoice::Auto.resolve(false, false), "coloured a pipe");
+        assert!(!ColorChoice::Auto.resolve(true, true), "ignored NO_COLOR");
+    }
+
+    /// The point of `always` is a destination that is not a terminal — a pager
+    /// reading through `less -R`, a recording, a file to be replayed. A rule
+    /// that still checked for a tty would make the flag do nothing at all in
+    /// exactly the case it exists for.
+    #[test]
+    fn always_colours_a_pipe_too() {
+        assert!(ColorChoice::Always.resolve(false, false));
+        assert!(!ColorChoice::Never.resolve(false, false));
+    }
+
+    /// `NO_COLOR` states a default for the environment; a flag on the command
+    /// line is the user overriding their own default for this one run, so it
+    /// has to win in both directions.
+    #[test]
+    fn an_explicit_choice_outranks_no_color() {
+        assert!(
+            ColorChoice::Always.resolve(true, true),
+            "NO_COLOR beat --color always"
+        );
+        assert!(!ColorChoice::Never.resolve(true, false));
+    }
+
     #[test]
     fn paint_is_identity_when_off() {
         assert_eq!(paint("main", 2, false), "main");
@@ -390,7 +459,7 @@ mod tests {
     #[test]
     fn no_terminal_means_no_animation() {
         // The test harness captures stderr, so this is the redirected case.
-        let spinner = spinner("fetching");
+        let spinner = spinner("fetching", true);
         assert!(spinner.thread.is_none(), "spun without a terminal");
     }
 
@@ -399,7 +468,7 @@ mod tests {
     /// nothing but a blank line behind once it stopped.
     #[test]
     fn the_spinner_draws_on_a_row_of_its_own() {
-        let spinner = spinner("fetching");
+        let spinner = spinner("fetching", true);
         assert_eq!(
             spinner._row.is_taken(),
             spinner.thread.is_some(),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -106,8 +106,22 @@ impl Sandbox {
     /// or `EDITOR` would quietly change what is being tested, and an inherited
     /// `HOME` would point the run at the developer's own config.
     fn run_in(&self, cwd: &Path, args: &[&str]) -> Run {
-        let out = Command::new(BIN)
-            .args(args)
+        self.run_full(cwd, args, &[])
+    }
+
+    fn run(&self, args: &[&str]) -> Run {
+        self.run_full(self.home(), args, &[])
+    }
+
+    /// [`Sandbox::run`] with `env` set on top — for the variables scriv is
+    /// meant to react to, such as `NO_COLOR`.
+    fn run_with_env(&self, args: &[&str], env: &[(&str, &str)]) -> Run {
+        self.run_full(self.home(), args, env)
+    }
+
+    fn run_full(&self, cwd: &Path, args: &[&str], env: &[(&str, &str)]) -> Run {
+        let mut cmd = Command::new(BIN);
+        cmd.args(args)
             .current_dir(cwd)
             .env_clear()
             .env("HOME", self.home())
@@ -116,19 +130,17 @@ impl Sandbox {
             .env("XDG_DATA_HOME", self.home().join(".local/share"))
             // `gh`, `git` and the editor are looked up on PATH; keep the real
             // one so the tests that reach them behave as they would in a shell.
-            .env("PATH", std::env::var("PATH").unwrap_or_default())
-            .output()
-            .expect("running scriv");
+            .env("PATH", std::env::var("PATH").unwrap_or_default());
+        for (key, value) in env {
+            cmd.env(key, value);
+        }
 
+        let out = cmd.output().expect("running scriv");
         Run {
             code: out.status.code(),
             stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
             stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
         }
-    }
-
-    fn run(&self, args: &[&str]) -> Run {
-        self.run_in(self.home(), args)
     }
 }
 
@@ -473,6 +485,86 @@ fn file_add_resolves_a_relative_path_against_the_working_directory() {
     sandbox.run_in(&project, &["file", "add", "main.rs"]).ok();
     let stored = std::fs::read_to_string(sandbox.files_path()).unwrap();
     assert_eq!(stored.trim(), "~/project/main.rs");
+}
+
+// --- colour -----------------------------------------------------------------
+
+/// A sandbox with one present and one missing tracked file, so `file ls
+/// --status` has both a green row and a red one to colour.
+fn coloured_listing(sandbox: &Sandbox) {
+    let here = sandbox.home().join("here.md");
+    std::fs::write(&here, "").unwrap();
+    sandbox.run(&["file", "add", here.to_str().unwrap()]).ok();
+    sandbox
+        .run(&[
+            "file",
+            "add",
+            sandbox.home().join("gone.md").to_str().unwrap(),
+        ])
+        .ok();
+}
+
+/// Every run in this file writes to a pipe, which is the case `--color always`
+/// exists for: `scriv pr ls --color always | less -R` is a listing whose whole
+/// point is the colour, and `auto` drops it because a pipe is not a terminal.
+#[test]
+fn color_always_colours_a_pipe_and_never_does_not() {
+    let sandbox = Sandbox::new();
+    coloured_listing(&sandbox);
+
+    let always = sandbox.run(&["--color", "always", "file", "ls", "--status"]);
+    always.ok();
+    assert!(
+        always.stdout.contains('\x1b'),
+        "no colour through a pipe: {:?}",
+        always.stdout
+    );
+
+    for args in [
+        &["--color", "never", "file", "ls", "--status"][..],
+        // The default through a pipe: unchanged from before there was a flag.
+        &["file", "ls", "--status"][..],
+    ] {
+        let run = sandbox.run(args);
+        run.ok();
+        assert!(
+            !run.stdout.contains('\x1b'),
+            "{args:?} coloured: {:?}",
+            run.stdout
+        );
+        // The glyphs are shapes, so the listing says as much either way.
+        assert!(run.stdout.contains("✓ "), "{:?}", run.stdout);
+        assert!(run.stdout.contains("✗ "), "{:?}", run.stdout);
+    }
+}
+
+/// `NO_COLOR` states a default for the environment; a flag on the command line
+/// is the user overriding their own default for this one run, so it wins in
+/// both directions.
+#[test]
+fn an_explicit_color_choice_outranks_no_color() {
+    let sandbox = Sandbox::new();
+    coloured_listing(&sandbox);
+
+    let forced = sandbox.run_with_env(
+        &["--color", "always", "file", "ls", "--status"],
+        &[("NO_COLOR", "1")],
+    );
+    forced.ok();
+    assert!(
+        forced.stdout.contains('\x1b'),
+        "NO_COLOR beat `--color always`: {:?}",
+        forced.stdout
+    );
+}
+
+/// The three values are the ones every comparable tool takes, and nothing else
+/// is accepted — a typo is a usage error rather than a silent fallback to the
+/// default, which would leave the user thinking they had asked for something.
+#[test]
+fn color_takes_only_the_three_conventional_values() {
+    let sandbox = Sandbox::new();
+    sandbox.run(&["--color", "sometimes", "file", "ls"]).code(2);
 }
 
 // --- fish history -----------------------------------------------------------


### PR DESCRIPTION
Colour was auto-detected and nothing else: stdout is a terminal, and `NO_COLOR`
is unset. There was no way to ask for it and no way to refuse it.

That costs the case colour is most useful in. `scriv pr ls | less -R` — where
the check glyphs are the entire reason you are reading the list — arrived
uncoloured, because a pipe is not a terminal. And turning it off in a terminal
meant exporting `NO_COLOR` for the whole session.

ripgrep, fd, `ls` and `git` all take the same flag with the same three values,
so it needs no explaining to anyone who has met one of them.

```
$ scriv --color always branch ls --status | cat -v
^[[38;5;3m* main   local   2 hours ago  …^[[0m
```

**Precedence.** An explicit `always`/`never` outranks `NO_COLOR`: the
environment states a default, and a flag on the command line is the user
overriding their own default for this one run. `auto` is where `NO_COLOR`
applies, and is the old behaviour exactly.

**Resolved once, in `Ctx::load`**, rather than at each listing — one run must
not colour one command's output and not another's. The rule itself is a pure
function taking the tty answer as an argument, so it is tested rather than only
reasoned about, and the spinner takes the same resolved answer so `--color
never` gives a plain one.

**Scope is printed output**, which is what the flag means in ripgrep and fd. The
picker is not governed by it: it is a full terminal UI that only ever draws on a
terminal, so there is nothing for the flag to decide there. That is stated in
the flag's own help text rather than left to be discovered.

## The three docs

1. **CLI help text** — the flag has a doc comment covering all three values, the
   `NO_COLOR` interaction and the picker's exclusion.
2. **README** — a two-sentence note where the pull request glyphs are described,
   since that is the listing the flag exists for.
3. **`docs/demo.gif`** — no re-record. The default is unchanged, so nothing a
   picker or a listing draws is different without the flag.

`CLAUDE.md`'s colour rule was rewritten: it named `term::stdout_color()`, which
is gone.