### PR TITLE
Add `scriv config check`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,14 @@ test that allocated a pty would be testing skim.
   the user was never standing in. `Ctx::load` takes it only when it resolves to
   the same directory scriv is actually in. Anything else reading the environment
   for a location it will then write down owes the same check.
+- **A new dependency on the outside world gets a `config check` row.** Every
+  path scriv reads, tool it spawns, or environment variable it needs is
+  something a user can have wrong, and `scriv config check` is the one place
+  that says so without them having to trip over it one command at a time. Add
+  the row in `cmd/config.rs`, and pick the status honestly: `Fail` only when
+  scriv is genuinely broken without it, since the exit status is what makes the
+  command usable in a setup script. A check that repeats what an earlier one
+  already said is not a second problem — skip it, as `discovery_check` does.
 - **Anything drawn inline takes a `term::ScratchRow` first.** The picker and the
   spinner both start on the row the cursor is on, which from a key binding is
   the last row of the shell's prompt — the picker draws over it, the spinner

--- a/README.md
+++ b/README.md
@@ -48,10 +48,25 @@ macOS and Linux, with `git`. `gh` is needed only for pull requests and
 
 ```sh
 scriv config init          # write ~/.config/scriv/config.toml
-scriv config print         # set your root, then check it
+scriv config check         # set your root, then check the whole setup
 scriv repo ls              # see what scriv finds under it
 scriv init fish | source   # helpers, key bindings, completions
 ```
+
+`scriv config check` looks at everything scriv depends on in one pass — the
+config file, the paths it names, how many repositories discovery actually
+finds, your editor, `git`, `gh`, fish's history file and the tracked list — and
+reports each with what to do about it:
+
+```
+✓ config         ~/.config/scriv/config.toml
+✗ repo root      ~/dev/github.com is not a directory
+✓ editor         nvim (/opt/homebrew/bin/nvim)
+! gh             not on PATH — only `pr` and `repo clone`/`open` need it
+```
+
+It exits non-zero only when something is genuinely broken, so it works in a
+setup script; a `!` is worth knowing about but still leaves scriv working.
 
 ## Commands
 
@@ -89,9 +104,11 @@ scriv edit --tracked    # pick from your tracked files instead
 scriv edit src/main.rs  # skip the picker
 ```
 
-`scriv config` and `scriv init` handle setup. `branch` abbreviates to `br`,
-`history` to `hist`, `edit` to `e`, `checkout` to `co`, and `ls` to `list`. Any
-command takes `--help` for its flags.
+`scriv config` and `scriv init` handle setup — `config init` writes a starter
+file, `config print` shows what was resolved, `config path` names it, and
+`config check` tests the lot. `branch` abbreviates to `br`, `history` to `hist`,
+`edit` to `e`, `checkout` to `co`, and `ls` to `list`. Any command takes
+`--help` for its flags.
 
 Every list bar history previews the highlighted row: commits and working-tree
 state for repositories and branches, description and failing checks for pull

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -1,11 +1,13 @@
-//! `scriv config` — inspect and generate the configuration file.
+//! `scriv config` — inspect, generate, and check the configuration file.
 
 use std::os::unix::fs::DirBuilderExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result, bail};
 
-use crate::Ctx;
+use crate::path::expand_home_dir;
+use crate::{Ctx, files, history, repo, term};
 
 /// A commented starter config. Settings are grouped by the command that reads
 /// them; users edit it to taste.
@@ -134,6 +136,367 @@ pub fn path(ctx: &Ctx) -> Result<()> {
     Ok(())
 }
 
+// --- check ------------------------------------------------------------------
+
+/// How one check came out.
+///
+/// The distinction between [`Status::Warn`] and [`Status::Fail`] is what makes
+/// the command's exit status worth anything: only a failure means something is
+/// actually broken. A missing `gh` is a warning because five of the six command
+/// groups do not need it; a root that does not exist is a failure because
+/// nothing works without one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Status {
+    Ok,
+    Warn,
+    Fail,
+}
+
+impl Status {
+    /// A shape, not a colour alone — the same rule the pull request listings
+    /// follow, so a piped or `NO_COLOR` report says exactly as much.
+    fn glyph(self) -> &'static str {
+        match self {
+            Self::Ok => "✓",
+            Self::Warn => "!",
+            Self::Fail => "✗",
+        }
+    }
+
+    /// ANSI 256-colour index: green, yellow, red.
+    fn color(self) -> u8 {
+        match self {
+            Self::Ok => 2,
+            Self::Warn => 3,
+            Self::Fail => 1,
+        }
+    }
+}
+
+/// One thing that was looked at, and what was found.
+#[derive(Debug, Clone)]
+struct Check {
+    /// What was looked at, e.g. `repo root`.
+    name: &'static str,
+    status: Status,
+    /// What was found, and — when something is wrong — what to do about it.
+    detail: String,
+}
+
+impl Check {
+    fn new(name: &'static str, status: Status, detail: impl Into<String>) -> Self {
+        Self {
+            name,
+            status,
+            detail: detail.into(),
+        }
+    }
+
+    fn ok(name: &'static str, detail: impl Into<String>) -> Self {
+        Self::new(name, Status::Ok, detail)
+    }
+
+    fn warn(name: &'static str, detail: impl Into<String>) -> Self {
+        Self::new(name, Status::Warn, detail)
+    }
+
+    fn fail(name: &'static str, detail: impl Into<String>) -> Self {
+        Self::new(name, Status::Fail, detail)
+    }
+}
+
+/// Render one check as its row: glyph, aligned name, detail.
+///
+/// `width` is the widest name in the report, counted in characters rather than
+/// bytes so a non-ASCII name would not over-pad the column.
+fn render(check: &Check, width: usize, color: bool) -> String {
+    let row = format!(
+        "{glyph} {name:<width$}  {detail}",
+        glyph = check.status.glyph(),
+        name = check.name,
+        detail = check.detail,
+    );
+    term::paint(row.trim_end(), check.status.color(), color)
+}
+
+/// How many checks failed. Warnings are not failures: the command exits
+/// non-zero only when something is genuinely broken, so it is worth putting in
+/// a setup script.
+fn failures(checks: &[Check]) -> usize {
+    checks.iter().filter(|c| c.status == Status::Fail).count()
+}
+
+/// Resolve `program` against `path_env` the way a shell would.
+///
+/// A name containing a separator is a path already and is used as it stands;
+/// anything else is looked for in each `PATH` entry in order. `exists` is
+/// passed in so the rule is a pure function with a test rather than something
+/// that can only be exercised against whatever happens to be installed.
+///
+/// Executability is deliberately not checked: a file on `PATH` under the name
+/// the user configured is what they meant, and reporting "found but not
+/// executable" is a distinction the spawn itself makes better.
+fn resolve_on_path(
+    program: &str,
+    path_env: Option<&str>,
+    exists: impl Fn(&Path) -> bool,
+) -> Option<PathBuf> {
+    if program.contains(std::path::MAIN_SEPARATOR) {
+        let direct = PathBuf::from(program);
+        return exists(&direct).then_some(direct);
+    }
+    path_env?
+        .split(':')
+        .filter(|dir| !dir.is_empty())
+        .map(|dir| Path::new(dir).join(program))
+        .find(|candidate| exists(candidate))
+}
+
+/// [`resolve_on_path`] against this process's `PATH` and the filesystem.
+fn on_path(program: &str) -> Option<PathBuf> {
+    resolve_on_path(program, std::env::var("PATH").ok().as_deref(), |p| {
+        p.exists()
+    })
+}
+
+/// The first line of `program --version`, for reporting which one is installed.
+fn version_of(program: &str) -> Option<String> {
+    let output = Command::new(program)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    let text = String::from_utf8_lossy(&output.stdout);
+    text.lines().next().map(str::trim).map(str::to_string)
+}
+
+/// Whether a tool scriv shells out to is installed, and which version.
+fn tool_check(name: &'static str, program: &str, required: bool, note: &str) -> Check {
+    match on_path(program) {
+        Some(_) => Check::ok(name, version_of(program).unwrap_or_else(|| "found".into())),
+        None if required => Check::fail(name, format!("not on PATH — {note}")),
+        None => Check::warn(name, format!("not on PATH — {note}")),
+    }
+}
+
+/// The config file itself: whether there is one, and where.
+///
+/// Reaching this point at all means it parsed — [`Ctx::load`](crate::Ctx::load)
+/// refuses to build otherwise — so the only question left is whether one
+/// exists. Absent is a warning, not a failure: the known-files commands work
+/// without any config at all.
+fn config_check(ctx: &Ctx) -> Check {
+    let path = ctx.config_path.display().to_string();
+    if ctx.config_path.exists() {
+        Check::ok("config", path)
+    } else {
+        Check::warn(
+            "config",
+            format!("{path} not found — run `scriv config init`"),
+        )
+    }
+}
+
+/// The search root, and the `extra` paths beside it.
+fn root_checks(ctx: &Ctx) -> Vec<Check> {
+    let mut checks = Vec::new();
+
+    match &ctx.config.repo.root {
+        None if ctx.config.repo.extra.is_empty() => {
+            checks.push(Check::fail(
+                "repo root",
+                "not set — `repo`, `edit --tracked` and `repo clone` have nowhere to look",
+            ));
+        }
+        None => checks.push(Check::warn(
+            "repo root",
+            "not set; only `extra` is searched",
+        )),
+        Some(root) => {
+            let expanded = expand_home_dir(root, ctx.home());
+            let shown = expanded.display();
+            checks.push(if expanded.is_dir() {
+                Check::ok("repo root", format!("{shown}"))
+            } else {
+                Check::fail("repo root", format!("{shown} is not a directory"))
+            });
+        }
+    }
+
+    if !ctx.config.repo.extra.is_empty() {
+        let total = ctx.config.repo.extra.len();
+        let missing: Vec<&str> = ctx
+            .config
+            .repo
+            .extra
+            .iter()
+            .filter(|p| !expand_home_dir(p, ctx.home()).is_dir())
+            .map(String::as_str)
+            .collect();
+        checks.push(if missing.is_empty() {
+            Check::ok("repo extra", format!("{total} path(s), all present"))
+        } else {
+            // A hard error, because discovery treats a missing search path as
+            // one: the whole picker fails rather than quietly listing less.
+            Check::fail("repo extra", format!("missing: {}", missing.join(", ")))
+        });
+    }
+
+    checks
+}
+
+/// How many repositories discovery actually finds — the number the picker will
+/// show, which is the only figure that answers "is my root right".
+///
+/// Skipped when a search path has already been reported missing. Discovery
+/// treats that as a hard error, so running it anyway would report the same
+/// problem a second time in vaguer words, and the report is meant to be one
+/// line per thing wrong.
+fn discovery_check(ctx: &Ctx, paths_ok: bool) -> Option<Check> {
+    if !paths_ok || (ctx.config.repo.root.is_none() && ctx.config.repo.extra.is_empty()) {
+        return None;
+    }
+    Some(
+        match repo::find_all_repos(&ctx.config, ctx.home(), &ctx.log) {
+            Ok(repos) if repos.is_empty() => Check::warn(
+                "repositories",
+                "none found — check `root` and `ignore` in the config",
+            ),
+            Ok(repos) => Check::ok("repositories", format!("{} found", repos.len())),
+            Err(err) => Check::fail("repositories", format!("{err:#}")),
+        },
+    )
+}
+
+/// The editor `scriv edit` will launch, and whether it is actually there.
+fn editor_check(ctx: &Ctx) -> Check {
+    let Some(setting) = ctx.editor_setting() else {
+        return Check::warn(
+            "editor",
+            "no $VISUAL or $EDITOR — `scriv edit` has nothing to open files with",
+        );
+    };
+    // The setting may carry arguments (`code -w`); only the program is looked
+    // for, which is the same split the launch does.
+    let program = setting.split_whitespace().next().unwrap_or(setting);
+    match on_path(program) {
+        Some(found) => Check::ok("editor", format!("{setting} ({})", found.display())),
+        None => Check::fail("editor", format!("{setting} — `{program}` is not on PATH")),
+    }
+}
+
+/// fish's history file: whether it is where scriv looked, and how much is in
+/// it.
+fn history_check(ctx: &Ctx) -> Check {
+    let shown = ctx.history_path.display().to_string();
+    match std::fs::read(&ctx.history_path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Check::warn(
+            "fish history",
+            format!("{shown} not found — set `[history] file` if yours is elsewhere"),
+        ),
+        Err(e) => Check::fail("fish history", format!("{shown}: {e}")),
+        Ok(data) => {
+            let entries = history::recent_first(history::parse(&String::from_utf8_lossy(&data)));
+            Check::ok(
+                "fish history",
+                format!("{} unique command(s) in {shown}", entries.len()),
+            )
+        }
+    }
+}
+
+/// The known-files list, and how much of it still exists on disk.
+fn files_check(ctx: &Ctx) -> Check {
+    let lines = match files::read_lines(&ctx.files_path) {
+        Ok(lines) => lines,
+        Err(err) => return Check::fail("tracked files", format!("{err:#}")),
+    };
+    if lines.is_empty() {
+        return Check::ok("tracked files", "none yet — add one with `scriv file add`");
+    }
+    let missing = lines
+        .iter()
+        .filter(|line| !Path::new(&crate::path::expand_tilde(line, ctx.home_str())).exists())
+        .count();
+    if missing == 0 {
+        Check::ok("tracked files", format!("{} tracked", lines.len()))
+    } else {
+        // Not a failure: a list going stale is what happens to a list, and
+        // `file ls --missing` is the thing to run next.
+        Check::warn(
+            "tracked files",
+            format!(
+                "{} tracked, {missing} no longer on disk — see `scriv file ls --missing`",
+                lines.len()
+            ),
+        )
+    }
+}
+
+/// Everything `config check` looks at, in the order it is reported: the config
+/// first, then what it points at, then the tools scriv shells out to.
+fn collect(ctx: &Ctx) -> Vec<Check> {
+    let mut checks = vec![config_check(ctx)];
+
+    let paths = root_checks(ctx);
+    let paths_ok = failures(&paths) == 0;
+    checks.extend(paths);
+    checks.extend(discovery_check(ctx, paths_ok));
+
+    checks.push(editor_check(ctx));
+    checks.push(tool_check(
+        "git",
+        "git",
+        true,
+        "`branch` and `repo` cannot work without it",
+    ));
+    checks.push(tool_check(
+        "gh",
+        "gh",
+        false,
+        "only `pr` and `repo clone`/`open` need it (https://cli.github.com)",
+    ));
+    checks.push(history_check(ctx));
+    checks.push(files_check(ctx));
+    checks
+}
+
+/// `scriv config check` — look at everything scriv depends on and say what is
+/// wrong with it.
+///
+/// A tool that only reports the first thing it trips over makes fixing a setup
+/// a sequence of round trips: run it, read one error, fix it, run it again.
+/// This looks at all of it in one go — the config file, the paths it names, the
+/// repositories discovery actually finds, the editor, `git`, `gh`, the history
+/// file and the tracked list — and reports each with what to do about it.
+///
+/// The exit status is non-zero only when something is genuinely broken, so it
+/// is worth putting in a setup script; a warning is a thing worth knowing that
+/// still leaves scriv working.
+pub fn check(ctx: &Ctx) -> Result<()> {
+    let checks = collect(ctx);
+    let color = term::stdout_color();
+    let width = checks
+        .iter()
+        .map(|c| c.name.chars().count())
+        .max()
+        .unwrap_or(0);
+
+    let mut out = term::Listing::stdout();
+    for check in &checks {
+        if !out.line(&render(check, width, color))? {
+            return Ok(());
+        }
+    }
+
+    let failed = failures(&checks);
+    if failed > 0 {
+        bail!("{failed} of {} checks failed", checks.len());
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -192,5 +555,89 @@ mod tests {
         assert_eq!(cfg.repo.display, RepoDisplay::Relative);
         assert_eq!(cfg.repo.label_of("acme"), Some("work"));
         assert!(!cfg.picker.preview_window.is_empty());
+    }
+
+    // --- check ---
+
+    /// Only a failure is a failure. Getting this wrong in the other direction
+    /// makes the command useless in a setup script: a missing `gh`, which five
+    /// of the six command groups do not care about, would fail the run.
+    #[test]
+    fn warnings_do_not_fail_the_run() {
+        let checks = vec![
+            Check::ok("git", "git version 2.51.0"),
+            Check::warn("gh", "not on PATH"),
+        ];
+        assert_eq!(failures(&checks), 0);
+
+        let broken = vec![Check::fail("repo root", "not set"), checks[1].clone()];
+        assert_eq!(failures(&broken), 1);
+    }
+
+    /// The report has to be readable without colour — piped, redirected, or
+    /// under `NO_COLOR` — so each status carries a distinct shape of its own.
+    #[test]
+    fn every_status_is_a_distinct_shape_not_a_colour() {
+        let glyphs: Vec<&str> = [Status::Ok, Status::Warn, Status::Fail]
+            .iter()
+            .map(|s| s.glyph())
+            .collect();
+        let mut unique = glyphs.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(unique.len(), glyphs.len(), "two statuses look alike");
+
+        let plain = render(&Check::fail("repo root", "not set"), 9, false);
+        assert_eq!(plain, "✗ repo root  not set");
+        assert!(!plain.contains('\x1b'), "colour leaked into a plain report");
+    }
+
+    /// Names are padded into one column so the details line up; the padding is
+    /// what makes a report of ten rows scannable rather than ragged.
+    #[test]
+    fn names_are_padded_into_one_column() {
+        let rows = [
+            render(&Check::ok("gh", "found"), 9, false),
+            render(&Check::ok("repo root", "/tmp"), 9, false),
+        ];
+        let column = |row: &str| row.rfind("  ").map(|i| i + 2);
+        assert_eq!(column(&rows[0]), column(&rows[1]), "{rows:?}");
+    }
+
+    /// A program is looked for in each `PATH` entry in order, so the one that
+    /// would actually be spawned is the one reported.
+    #[test]
+    fn path_lookup_takes_the_first_match_in_order() {
+        let found = resolve_on_path("gh", Some("/a:/b:/c"), |p| {
+            p == Path::new("/b/gh") || p == Path::new("/c/gh")
+        });
+        assert_eq!(found, Some(PathBuf::from("/b/gh")));
+    }
+
+    #[test]
+    fn path_lookup_reports_nothing_when_it_is_not_there() {
+        assert_eq!(resolve_on_path("gh", Some("/a:/b"), |_| false), None);
+        // No PATH at all is not a panic; it is simply nothing found.
+        assert_eq!(resolve_on_path("gh", None, |_| true), None);
+        // Empty entries are skipped rather than turned into a bare filename.
+        assert_eq!(
+            resolve_on_path("gh", Some("::"), |p| p == Path::new("gh")),
+            None
+        );
+    }
+
+    /// An editor set to an absolute path — `EDITOR=/opt/bin/hx` — is a path,
+    /// not a name to search for.
+    #[test]
+    fn a_program_with_a_separator_is_used_as_it_stands() {
+        assert_eq!(
+            resolve_on_path("/opt/bin/hx", Some("/usr/bin"), |p| p
+                == Path::new("/opt/bin/hx")),
+            Some(PathBuf::from("/opt/bin/hx"))
+        );
+        assert_eq!(
+            resolve_on_path("/opt/bin/hx", Some("/usr/bin"), |_| false),
+            None
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use scriv::{Ctx, Reported, cmd, shell};
 /// Usage examples appended to the top-level help.
 const EXAMPLES: &str = "\x1b[1;92mExamples:\x1b[0m
   scriv config init            Write a starter configuration
+  scriv config check           Check your setup and report what is wrong
   scriv repo pick              Fuzzy-pick a repository, print its path
   cd (scriv repo pick)         Jump to a repository (fish)
   scriv repo clone             Pick an owner, then repositories to clone
@@ -394,6 +395,14 @@ enum ConfigCmd {
     Print,
     /// Print the configuration file path
     Path,
+    /// Check everything scriv depends on and report what is wrong
+    ///
+    /// Looks at the config file, the paths it names, the repositories
+    /// discovery actually finds, your editor, `git`, `gh`, fish's history file
+    /// and the tracked-file list — all in one pass, each with what to do about
+    /// it. Exits non-zero only when something is genuinely broken, so it is
+    /// worth putting in a setup script; a warning still leaves scriv working.
+    Check,
 }
 
 fn main() -> ExitCode {
@@ -485,6 +494,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             ConfigCmd::Init { force } => cmd::config::init(&ctx, force),
             ConfigCmd::Print => cmd::config::print(&ctx),
             ConfigCmd::Path => cmd::config::path(&ctx),
+            ConfigCmd::Check => cmd::config::check(&ctx),
         },
         Command::Init { .. } => unreachable!("init handled before Ctx"),
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -299,6 +299,67 @@ fn a_broken_config_names_the_file() {
     );
 }
 
+/// The exit status is the whole reason `config check` is worth putting in a
+/// setup script, so a sound setup has to come back 0 — even one with things
+/// worth knowing about, since the sandbox has no fish history and no tracked
+/// files and neither leaves scriv broken.
+#[test]
+fn config_check_passes_on_a_sound_setup() {
+    let sandbox = Sandbox::new();
+    mk_repo(&sandbox.home().join("dev/github.com"), "acme", "billing");
+    sandbox.write_config("[repo]\nroot = \"~/dev/github.com\"\n");
+
+    let run = sandbox.run(&["config", "check"]);
+    run.ok();
+    assert!(run.stdout.contains("repo root"), "{}", run.stdout);
+    // Discovery is really run: the count is what answers "is my root right".
+    assert!(run.stdout.contains("1 found"), "{}", run.stdout);
+    assert!(!run.stdout.contains('✗'), "{}", run.stdout);
+}
+
+/// A broken setup exits non-zero and says which line was the problem, and the
+/// report is still readable without colour — the statuses are shapes.
+#[test]
+fn config_check_fails_on_a_missing_root() {
+    let sandbox = Sandbox::new();
+    sandbox.write_config("[repo]\nroot = \"~/not/here\"\n");
+
+    let run = sandbox.run(&["config", "check"]);
+    run.code(1);
+    assert!(
+        run.stdout
+            .lines()
+            .any(|l| l.starts_with('✗') && l.contains("repo root")),
+        "{}",
+        run.stdout
+    );
+    assert!(run.stderr.contains("checks failed"), "{}", run.stderr);
+    assert!(!run.stdout.contains('\x1b'), "colour through a pipe");
+}
+
+/// One problem, one line. Discovery treats a missing search path as a hard
+/// error, so running it anyway would report the same thing twice in vaguer
+/// words and inflate the failure count.
+#[test]
+fn config_check_does_not_report_one_problem_twice() {
+    let sandbox = Sandbox::new();
+    sandbox.write_config("[repo]\nroot = \"~/not/here\"\n");
+
+    let run = sandbox.run(&["config", "check"]);
+    run.code(1);
+    assert_eq!(
+        run.stdout.lines().filter(|l| l.starts_with('✗')).count(),
+        1,
+        "{}",
+        run.stdout
+    );
+    assert!(
+        !run.stdout.contains("repositories"),
+        "the repository count repeated the root failure: {}",
+        run.stdout
+    );
+}
+
 // --- repo discovery ---------------------------------------------------------
 
 /// The core of `repo ls`: what is under the root, one per line, sorted, with


### PR DESCRIPTION
Finding out why scriv is not doing what you expect meant discovering one problem
at a time. The root is a typo, so `repo ls` fails. Fix that and `pr` says `gh` is
missing. Install that and the editor is unset. Each round trip only reveals the
next thing.

`config check` looks at all of it in one pass and reports each with what to do
about it:

```
$ scriv config check
✓ config         ~/.config/scriv/config.toml
✓ repo root      ~/dev/github.com
✓ repo extra     1 path(s), all present
✓ repositories   109 found
✓ editor         nvim (/opt/homebrew/bin/nvim)
✓ git            git version 2.55.0
✓ gh             gh version 2.96.0
✓ fish history   5510 unique command(s) in ~/.local/share/fish/fish_history
! tracked files  29 tracked, 4 no longer on disk — see `scriv file ls --missing`
```

```
$ scriv config check
✓ config         /tmp/c.toml
✗ repo root      /tmp/nope is not a directory
…
error: 1 of 7 checks failed
```

**Warn and Fail are distinguished on purpose**, because the exit status is what
makes the command worth putting in a setup script: it is non-zero only when
scriv is genuinely broken. A missing `gh` is a warning, since five of the six
command groups never call it; a root that is not a directory is a failure. A
tracked file that has since been deleted is a warning, because that is simply
what happens to a list.

**A check that would only repeat an earlier one is skipped rather than counted
twice.** Discovery treats a missing search path as a hard error, so with the
path already reported there is nothing left for the repository count to add —
one problem, one line.

**`repositories` runs real discovery** rather than checking that the root
exists. The number the picker will actually show is the only figure that answers
"is my root right", and it catches an `ignore` list that has swallowed
everything.

Statuses are shapes (`✓ ! ✗`) rather than colours alone, matching the pull
request listings, so a piped or `NO_COLOR` report says exactly as much. Rows go
through `term::Listing` like every other listing.

The verdict rollup, the row rendering and the `PATH` lookup are pure functions
with tests; only the probing touches the outside world.

It sits under `config` rather than at the top level because it is about scriv's
own setup, which is the set `config` covers — a top-level `doctor` would be a
sixth noun for something that is not a set of anything.

## The three docs

1. **CLI help text** — `Check` has a doc comment covering what it looks at and
   what its exit status means, and `EXAMPLES` gained a line, since this is the
   common entry point for "my setup is wrong".
2. **README** — `Getting started` now runs `config check` as the verify step
   instead of `config print`, with a short sample of the output, and the
   `config`/`init` sentence names all four subcommands.
3. **`docs/demo.gif`** — no re-record. This adds a command without altering any
   existing picker's output.

`CLAUDE.md` gained a rule: a new dependency on the outside world gets a row
here, with the status picked honestly.