### PR TITLE
Fix main: `config check` still called the removed `stdout_color`

### DIFF
--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -476,7 +476,7 @@ fn collect(ctx: &Ctx) -> Vec<Check> {
 /// still leaves scriv working.
 pub fn check(ctx: &Ctx) -> Result<()> {
     let checks = collect(ctx);
-    let color = term::stdout_color();
+    let color = ctx.color();
     let width = checks
         .iter()
         .map(|c| c.name.chars().count())

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -349,6 +349,26 @@ fn config_check_fails_on_a_missing_root() {
     assert!(!run.stdout.contains('\x1b'), "colour through a pipe");
 }
 
+/// The report goes through the same colour plumbing as every other listing.
+///
+/// This is the case that was missed: `config check` and `--color` were written
+/// in parallel, each green on its own branch, and the merge did not compile
+/// because the report was still calling the function the flag had replaced.
+/// Nothing tied the two together, so nothing noticed.
+#[test]
+fn config_check_honours_the_color_flag() {
+    let sandbox = Sandbox::new();
+    sandbox.write_config("[repo]\nroot = \"~/not/here\"\n");
+
+    let forced = sandbox.run(&["--color", "always", "config", "check"]);
+    forced.code(1);
+    assert!(
+        forced.stdout.contains('\x1b'),
+        "the report ignored --color always: {:?}",
+        forced.stdout
+    );
+}
+
 /// One problem, one line. Discovery treats a missing search path as a hard
 /// error, so running it anyway would report the same thing twice in vaguer
 /// words and inflate the failure count.


### PR DESCRIPTION
**main does not compile.** `make` on `c8d4177`:

```
479 |     let color = term::stdout_color();
    |                       ^^^^^^^^^^^^ not found in `term`
```

#52 replaced `term::stdout_color()` with `ctx.color()`. #53 was written in
parallel and its report still called the old one. Both were green on their own
branch and both merged cleanly — git had nothing to conflict on, because the two
changes touch different files. It is the merged result that does not build, and
CI never tested the merged result.

Two changes:

- `cmd/config.rs` now reads `ctx.color()`, like every other listing.
- A test ties the two together: `config check --color always` has to colour. The
  coupling is now pinned rather than left to whoever next touches either side.

`make` green: 232 unit tests, 34 end-to-end, clippy clean, release build.

## The actual cause

Neither branch was up to date with `main` when it merged. The `default` ruleset
requires `build` and `demo` to pass, but does not require the branch to be
current, so auto-merge landed a commit whose CI ran against a `main` that no
longer existed. Turning on "require branches to be up to date before merging"
turns this class of failure from a broken `main` into a blocked pull request,
which is where it belongs. Worth doing separately, and deliberately — it makes
every parallel pull request need a rebase before it can land.

## The three docs

None. No command, flag, wording or picker output changed; this restores what
#52 and #53 already documented.