### PR TITLE
Require branches to be up to date, and say what that costs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,10 @@ gh pr merge --squash --auto
 existing history, with no poll loop in between. It is load-bearing that `build`
 and `demo` are *required* status checks on `main` (the `default` ruleset):
 auto-merge only queues behind checks that are required, so if that rule is ever
-removed, `--auto` stops waiting and merges on the spot.
+removed, `--auto` stops waiting and merges on the spot. They are also `strict`,
+which is what stops a pull request merging against a `main` its CI never saw.
 
-Two things auto-merge does not do for you:
+Three things auto-merge does not do for you:
 
 - **The local branch survives.** `gh` exits the moment auto-merge is armed, so
   `--delete-branch` never gets to run — and the squash rewrites the commit, so
@@ -76,6 +77,32 @@ Two things auto-merge does not do for you:
   indefinitely. Say in the reply that auto-merge is armed, and check back —
   with a backgrounded wait on `gh pr view <n> --json state`, or on the next
   turn — so a failure gets fixed rather than silently parked.
+- **It does not rebase.** The ruleset requires branches to be up to date, so a
+  pull request whose base has moved *blocks* rather than merging, and stays
+  blocked until someone rebases it. See below.
+
+### Parallel pull requests land one at a time
+
+Required checks are `strict`: a pull request cannot merge while `main` has
+commits it does not have. That is not tidiness — it is the only thing that makes
+CI's answer mean anything. Without it, `build` passing says two commits were
+each fine on their own, which is not the question; a pull request that removed a
+function and one written in parallel that still called it were both green and
+the merge did not compile.
+
+So several pull requests in flight merge in sequence, not at once:
+
+1. Arm auto-merge on the one that should land first.
+2. Wait for it (`gh pr view <n> --json state`).
+3. `git checkout main && git pull`, then `git rebase main` in each remaining
+   worktree, resolve, `make`, force-push with `--force-with-lease`, and arm the
+   next.
+
+Order them so the one touching the most files goes first — everything after it
+rebases onto a base that is already settled. When two changes couple across
+files git cannot conflict on, that is what the rebase is for: pin the coupling
+with a test at that point, rather than leaving it for whoever next touches
+either side.
 
 Never commit straight to `main`. The pull request is what leaves a reviewable
 record of work nobody watched happen — which matters more when there is no


### PR DESCRIPTION
Follow-up to #54, which fixed a `main` that did not compile.

Five pull requests merged in parallel. #52 removed `term::stdout_color()`; #53,
written alongside it, still called it. Both were green, because `build` tested
two commits neither of which was the one that landed. git had nothing to
conflict on — the changes were in different files.

The `default` ruleset now marks its required checks **strict**
(`strict_required_status_checks_policy: true`, applied live). A pull request
whose base has moved blocks until it is rebased, so CI's answer means what it
looks like it means.

**The cost is real**, so `CLAUDE.md` states it rather than leaving it to be
discovered: pull requests in flight now land one at a time, each rebased onto
the one before it. The workflow section gains the sequence — arm, wait, pull,
rebase each remaining worktree, `make`, force-push with `--force-with-lease`,
arm the next — and the ordering heuristic: put the change touching the most
files first, so everything after it rebases onto a base that is already settled.

It also notes what the rebase is *for* in the case that caused this. When two
changes couple across files git cannot conflict on, the rebase is the moment to
pin the coupling with a test, rather than leaving it for whoever next touches
either side. That is what #54 did with `config check --color always`.

## The three docs

None. `CLAUDE.md` is the only file changed; no command, flag, wording or picker
output is different.