### PR TITLE
Rewrite the README as a page rather than a manual

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,12 +25,18 @@ done until the old wording is gone. `EXAMPLES` covers the common entry point
 of each command group — add a line when you add a group, not when you add
 every flag.
 
-**2. README.md.** Check each of these in turn, since a change rarely touches
-just one: the feature table under the demo, the `Commands` section (including
-the abbreviations sentence), the key-binding table when `shell.rs` bindings
-change, and the sample `config.toml` when a config key is added or renamed.
-The README's command table and `scriv --help` describe the same surface and
-must not disagree.
+**2. README.md.** It is deliberately short — a page, not a manual — and it stays
+that way. Three things in it can go stale: the command table, which must list
+the same subcommands `scriv <group> --help` does; the fish key-binding sentence,
+when `scriv_key_bindings` changes; and the `Install` line naming the platforms
+and the external tools each command group needs.
+
+Resist adding to it. The README's job is to get someone from nothing to a
+working setup and then hand off — to `scriv --help` for flags, to the generated
+`config.toml` for settings, to `CLAUDE.md` for why anything is the way it is.
+Every one of those is closer to the code and cannot drift from it the way a
+paragraph here can. A new flag does not belong in the README; a new *command
+group* does, as one table row.
 
 **3. `docs/demo.gif`.** If anything changed what a picker shows on screen —
 row layout, colours, preview contents, the commands or flags in

--- a/README.md
+++ b/README.md
@@ -7,201 +7,46 @@
 ![A candle burning above an open book](docs/art/seal.svg)
 
 One fuzzy picker for your Git repositories, files, branches, pull requests and
-shell history.
+shell history. The finder is compiled in; there is nothing to install alongside
+it.
 
 ![scriv: check out a remote branch, find and open a file, list pull requests](docs/demo.gif)
 
-| | |
-| --- | --- |
-| **repos** | pick one and `cd` into it, open it on GitHub, or clone new ones |
-| **files** | keep a list of files you return to, and open one |
-| **editing** | fuzzy-find a file where you are standing and open it in `$EDITOR` |
-| **branches** | switch to a local branch, or check out a remote one |
-| **pull requests** | see what is green, then check one out, open it, or merge it |
-| **shell history** | fuzzy-search what you have run before, on `ctrl-r` and `up` |
-
-One binary and nothing else: the fuzzy finder
-([skim](https://github.com/skim-rs/skim)) and the file walker (the
-[`ignore`](https://docs.rs/ignore) crate behind
-[fd](https://github.com/sharkdp/fd)) are compiled in. Branches come from `git`,
-pull requests from [`gh`](https://cli.github.com) — reusing the login
-`gh auth login` already set up, so scriv stores no tokens of its own.
-
 ## Install
 
-With [mise](https://mise.jdx.dev):
-
 ```sh
-mise use -g github:joakimen/scriv
+mise use -g github:joakimen/scriv    # or: cargo install --path .
 ```
 
-From source:
+macOS and Linux. Needs `git`; `gh` for pull requests and `repo clone`/`open`.
+
+## Setup
 
 ```sh
-cargo install --path .
-```
-
-macOS and Linux, with `git`. `gh` is needed only for pull requests and
-`repo clone`/`open`; the fish integration only for the key bindings.
-
-## Getting started
-
-```sh
-scriv config init          # write ~/.config/scriv/config.toml
-scriv config check         # set your root, then check the whole setup
-scriv repo ls              # see what scriv finds under it
+scriv config init          # write ~/.config/scriv/config.toml, then set `root`
 scriv init fish | source   # helpers, key bindings, completions
+scriv config check         # confirm it all resolves
 ```
-
-`scriv config check` looks at everything scriv depends on in one pass — the
-config file, the paths it names, how many repositories discovery actually
-finds, your editor, `git`, `gh`, fish's history file and the tracked list — and
-reports each with what to do about it:
-
-```
-✓ config         ~/.config/scriv/config.toml
-✗ repo root      ~/dev/github.com is not a directory
-✓ editor         nvim (/opt/homebrew/bin/nvim)
-! gh             not on PATH — only `pr` and `repo clone`/`open` need it
-```
-
-It exits non-zero only when something is genuinely broken, so it works in a
-setup script; a `!` is worth knowing about but still leaves scriv working.
 
 ## Commands
 
-Five nouns, the same few verbs:
-
-| | `ls` lists | `pick` prints | `checkout` |
-| --- | --- | --- | --- |
-| `scriv repo` | your repositories | an absolute path | — |
-| `scriv file` | your tracked files | an absolute path | — |
-| `scriv branch` | local and remote branches | a branch name | switches, tracking the remote |
-| `scriv pr` | pull requests | a PR number | hands off to `gh pr checkout` |
-| `scriv history` | commands you have run | a past command | — |
-
-Some verbs belong to one noun only:
-
-- **`scriv repo clone`** — pick a GitHub owner, then one or more of their
-  repositories; `tab` selects several and they clone at once. Everything lands
-  at `<root>/<owner>/<repo>`, so a clone is in `repo pick` the moment it
-  finishes. `scriv repo clone owner/repo` skips both pickers.
-- **`scriv repo open`** — opens the repository you are standing in, or picks one
-  when you are not. `--pick` asks even from inside one.
-- **`scriv pr open` / `scriv pr merge`** — put a pull request in the browser, or
-  merge it. Both fuzzy-pick when given no number; `merge` takes `--squash`,
-  `--auto`, `-d` and the rest of `gh`'s vocabulary.
-- **`scriv file add` / `remove`** — maintain the tracked list.
-
-`scriv edit` is a verb rather than a noun: it searches the directory you are
-standing in — not a list scriv keeps — and opens what you choose in `$VISUAL`,
-then `$EDITOR`. The walk honours `.gitignore`, `.ignore` and `.fdignore` and
-streams into the picker as it goes, so a huge tree is typeable immediately.
-
-```fish
-scriv edit              # pick a file below $PWD, open it in your editor
-scriv edit --tracked    # pick from your tracked files instead
-scriv edit src/main.rs  # skip the picker
-```
-
-`scriv config` and `scriv init` handle setup — `config init` writes a starter
-file, `config print` shows what was resolved, `config path` names it, and
-`config check` tests the lot. `branch` abbreviates to `br`, `history` to `hist`,
-`edit` to `e`, `checkout` to `co`, and `ls` to `list`. Any command takes
-`--help` for its flags.
-
-Every list bar history previews the highlighted row: commits and working-tree
-state for repositories and branches, description and failing checks for pull
-requests, contents for files. Pull request listings carry their CI, so what is
-green is visible before you pick anything:
-
-```
-#128  ✓    Add a token bucket per API key  @ada
-#127  ✗    Round partial usage up  @grace
-#126  ⧗ ⊘  Cache quotas in redis  @ada
-```
-
-`✓` passed, `✗` failed, `⧗` still running, `⊘` conflicts with the base branch —
-shapes rather than colours alone, so a piped or `NO_COLOR` listing says as much.
-Branch and pull request lists go stale while you read them; `ctrl-r` refetches
-without closing the picker.
-
-Colour follows `--color auto|always|never`, on any command: `auto` colours a
-terminal and honours `NO_COLOR`, `always` colours a pipe too so `scriv pr ls
---color always | less -R` keeps its greens and reds.
-
-Every `pick` prints one line and nothing else, so it composes:
-
-```fish
-cd (scriv repo pick)
-gh pr view (scriv pr pick)
-```
-
-## Shell integration (fish)
-
-```fish
-scriv init fish | source
-
-function fish_user_key_bindings
-    scriv_key_bindings
-end
-```
-
-| Key | Does |
+| | |
 | --- | --- |
-| `ctrl-r` | search shell history, onto the command line |
-| `up` | the same, on the first line of a prompt |
-| `ctrl-o` | pick a repository and `cd` into it |
-| `ctrl-g` | pick a branch and check it out |
-| `ctrl-q` | pick a file below `$PWD` and open it in `$EDITOR` |
-| `f1` | open this repository on GitHub, or pick one |
-| `f3` | pick a tracked file and open it in `$EDITOR` |
-| `f7` | pick a pull request and check it out |
+| `scriv repo` | `ls` `pick` `open` `clone` |
+| `scriv file` | `ls` `pick` `add` `remove` |
+| `scriv branch` | `ls` `pick` `checkout` |
+| `scriv pr` | `ls` `pick` `checkout` `open` `merge` |
+| `scriv history` | `ls` `pick` |
+| `scriv edit` | a file below `$PWD`, opened in `$EDITOR` |
 
-`ctrl-r` and `up` take over fish's history keys, searching the same history
-fuzzily rather than by prefix and starting from whatever you have already typed.
-`up` still moves the cursor wherever a picker would be wrong — in the completion
-pager, and past the first line of a multi-line command. To use your own keys,
-bind them after `scriv_key_bindings`; the last binding for a key wins.
+`ls` prints the set, `pick` fuzzy-selects one line of it, and the other verbs
+act. Every `pick` composes: `cd (scriv repo pick)`.
 
-`fe` — find, fuzzy-pick, edit — is a short alias for `scriv edit`, arguments and
-all, and the only unprefixed name scriv defines. For other shells,
-`scriv init bash`/`zsh`/`powershell`/`elvish` emit completions.
+In fish, `ctrl-r` searches history, `ctrl-o` jumps to a repository, `ctrl-g`
+checks out a branch and `ctrl-q` edits a file; `f1`, `f3` and `f7` open a
+repository, a tracked file and a pull request.
 
-## Configuration
-
-`scriv config init` writes `~/.config/scriv/config.toml`, where settings are
-grouped by the command that reads them:
-
-```toml
-[repo]
-# One root, laid out as <owner>/<repo> — the same shape as GitHub itself, which
-# is how `repo clone` knows where a repository belongs without being told.
-root = "~/dev/github.com"
-extra = ["~/bin"]                   # repositories outside the root
-ignore = ["node_modules", "target"] # directory names to skip
-display = "relative"                # relative | tilde | full
-
-# Labels name owners, one label to many, so everything you touch for work
-# colours as one group however many orgs it spans.
-labels = { personal = ["joakimen"], work = ["capralifecycle", "nsbno"] }
-
-[history]
-# fish's history file. Defaults to $XDG_DATA_HOME/fish/fish_history. Worth
-# setting only for a named session — `set -U fish_history work` reads
-# `work_history`, and fish does not export that variable for scriv to find.
-file = "~/.local/share/fish/work_history"
-
-[picker]
-height = "50%"                # finder height
-preview = true                # preview pane for the highlighted row
-preview_window = "right:50%"  # preview layout
-```
-
-The tracked-files list sits beside it in `~/.config/scriv/files`, one path per
-line, managed by `scriv file add`/`remove`. There is no key for the editor:
-`$VISUAL` and `$EDITOR` are where every other terminal tool reads it. A config
-still using an older layout is refused with the replacement written out for you.
+`scriv --help` covers the flags, the generated `config.toml` the settings.
 
 ## Development
 
@@ -210,7 +55,3 @@ make                # fmt check, clippy, tests, release build
 make demo           # re-record docs/demo.gif
 make demo-fixture   # build the demo sandbox and poke at it by hand
 ```
-
-The demo is generated, not captured — `demo/fixture.sh` builds a throwaway
-sandbox of fictional repositories, branches and pull requests, and recording it
-needs [VHS](https://github.com/charmbracelet/vhs).


### PR DESCRIPTION
**216 lines → 57.**

#49 cut the design rationale. What was left still read as documentation someone
had to get through: a feature table restating the command table, a paragraph on
what `edit` searches, a key-binding table plus a paragraph defending it, a copy
of the config file with its comments, a paragraph on how the demo sandbox works.

None of it was wrong. All of it was a **second copy of something closer to the
code** — `scriv --help` for the flags, the generated `config.toml` for the
settings, `CLAUDE.md` for why anything is the way it is. A second copy is a thing
that can disagree with the first.

What is left gets someone from nothing to a working setup and then hands off:
what it is, install, three setup commands, a table of the command groups, one
sentence of key bindings, the `make` targets.

## Verified rather than assumed

- The command table was generated from `scriv <group> --help`, not from memory.
- The key-binding sentence was checked line by line against
  `scriv_key_bindings` in `shell.rs`.
- The `Install` note names the platforms and which command groups need `gh`.

## CLAUDE.md

Rule 2 of "the three docs that go stale silently" named the feature table, the
abbreviations sentence, the key-binding table and the sample `config.toml` —
none of which exist any more, so the rule was itself stale.

It now names the three things that remain and states the README's job: hand off
rather than explain. A new flag does not belong in it; a new command *group*
does, as one table row. That is what keeps this from growing back.

## The three docs

1. **CLI help text** — untouched. Nothing about the surface changed; the README
   now defers to it rather than duplicating it.
2. **README** — this is the change.
3. **`docs/demo.gif`** — no re-record. Nothing changed what a picker draws.