### PR TITLE
Add `scriv file prune`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ scriv config check         # confirm it all resolves
 | | |
 | --- | --- |
 | `scriv repo` | `ls` `pick` `open` `clone` |
-| `scriv file` | `ls` `pick` `add` `remove` |
+| `scriv file` | `ls` `pick` `add` `remove` `prune` |
 | `scriv branch` | `ls` `pick` `checkout` |
 | `scriv pr` | `ls` `pick` `checkout` `open` `merge` |
 | `scriv proc` | `ls` `pick` `kill` |

--- a/src/cmd/file.rs
+++ b/src/cmd/file.rs
@@ -39,16 +39,89 @@ pub fn ls(ctx: &Ctx, status: bool, missing: bool, exists: bool) -> Result<()> {
             continue;
         }
 
-        let row = match (status, use_color, present) {
-            (false, _, _) => expanded,
-            (true, true, true) => format!("\x1b[32m✓ {expanded}\x1b[0m"),
-            (true, true, false) => format!("\x1b[31m✗ {expanded}\x1b[0m"),
-            (true, false, true) => format!("✓ {expanded}"),
-            (true, false, false) => format!("✗ {expanded}"),
+        let row = if status {
+            status_row(&expanded, present, use_color)
+        } else {
+            expanded
         };
         if !out.line(&row)? {
             break;
         }
+    }
+    Ok(())
+}
+
+/// A file with its existence marked: green tick for there, red cross for gone.
+///
+/// Shared by `file ls --status` and `file prune`, so the entries `prune` offers
+/// to drop look like the rows `ls` already draws them as.
+fn status_row(path: &str, present: bool, color: bool) -> String {
+    match (color, present) {
+        (true, true) => format!("\x1b[32m✓ {path}\x1b[0m"),
+        (true, false) => format!("\x1b[31m✗ {path}\x1b[0m"),
+        (false, true) => format!("✓ {path}"),
+        (false, false) => format!("✗ {path}"),
+    }
+}
+
+/// `scriv file prune` — drop the tracked files that are no longer there.
+///
+/// The list is what it is because files move: a repository is re-cloned, a note
+/// is renamed, a checkout is deleted. Each of those leaves an entry pointing at
+/// nothing, and until now the only way to clear them was to read
+/// `file ls --missing` and remove each one by hand.
+///
+/// What will go is printed before the question is asked, because a count is not
+/// enough to decide on — "remove 4 entries?" is answerable only by someone who
+/// already knows which four.
+pub fn prune(ctx: &Ctx, yes: bool) -> Result<()> {
+    ctx.ensure_files_migrated()?;
+    let lines = files::read_lines(&ctx.files_path)?;
+
+    let (kept, missing) = files::partition_missing(&lines, |line| {
+        Path::new(&expand_tilde(line, ctx.home_str())).exists()
+    });
+    if missing.is_empty() {
+        println!("Nothing to prune — every tracked file is still there");
+        return Ok(());
+    }
+
+    let mut out = term::Listing::stdout();
+    for line in &missing {
+        let expanded = expand_tilde(line, ctx.home_str());
+        if !out.line(&status_row(&expanded, false, ctx.color()))? {
+            return Ok(());
+        }
+    }
+
+    match term::Confirm::resolve(yes) {
+        term::Confirm::Assumed => {}
+        term::Confirm::Ask => {
+            let question = format!(
+                "Remove {} {} from the list?",
+                missing.len(),
+                if missing.len() == 1 {
+                    "entry"
+                } else {
+                    "entries"
+                }
+            );
+            if !term::confirm(&question)? {
+                println!("Nothing removed");
+                return Ok(());
+            }
+        }
+        // The files themselves are untouched either way — this only edits the
+        // list — but a command that deletes on an assumed yes is one nobody can
+        // safely put in a pipeline.
+        term::Confirm::Impossible => bail!(
+            "no terminal to ask for confirmation on — pass `--yes` to prune without being asked"
+        ),
+    }
+
+    files::write_lines(&ctx.files_path, &kept)?;
+    for line in &missing {
+        println!("Removed {line}");
     }
     Ok(())
 }

--- a/src/files.rs
+++ b/src/files.rs
@@ -107,6 +107,29 @@ pub fn partition_remove(lines: &[String], to_remove: &[String]) -> (Vec<String>,
     (kept, removed)
 }
 
+/// Split `lines` into the entries whose file is still there and the entries
+/// whose file has gone, preserving the original order of both.
+///
+/// `present` is passed in rather than reaching for the filesystem, which is
+/// what keeps this a decision with a test rather than something only observable
+/// against a real directory. It is given the raw stored line — expanding `~` is
+/// the caller's job, since only the caller knows the home directory.
+pub fn partition_missing(
+    lines: &[String],
+    present: impl Fn(&str) -> bool,
+) -> (Vec<String>, Vec<String>) {
+    let mut kept = Vec::new();
+    let mut missing = Vec::new();
+    for line in lines {
+        if present(line) {
+            kept.push(line.clone());
+        } else {
+            missing.push(line.clone());
+        }
+    }
+    (kept, missing)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -162,6 +185,26 @@ mod tests {
         let (kept, removed) = partition_remove(&lines, &owned(&["x"]));
         assert_eq!(kept, owned(&["a", "b"]));
         assert!(removed.is_empty());
+    }
+
+    /// Both halves keep the order the list was in, so what `prune` prints
+    /// reads in the same order as `file ls` — the list the user knows.
+    #[test]
+    fn partition_missing_splits_on_what_is_still_there() {
+        let lines = owned(&["a", "b", "c", "d"]);
+        let (kept, missing) = partition_missing(&lines, |line| line == "a" || line == "c");
+        assert_eq!(kept, owned(&["a", "c"]));
+        assert_eq!(missing, owned(&["b", "d"]));
+    }
+
+    /// A list where nothing is missing must come back untouched, so `prune` can
+    /// tell there is nothing to ask about.
+    #[test]
+    fn partition_missing_finds_nothing_when_every_file_is_there() {
+        let lines = owned(&["a", "b"]);
+        let (kept, missing) = partition_missing(&lines, |_| true);
+        assert_eq!(kept, lines);
+        assert!(missing.is_empty());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,6 +235,17 @@ enum FileCmd {
         /// File path to remove
         file: Option<String>,
     },
+    /// Remove tracked files that no longer exist
+    ///
+    /// Prints the entries pointing at nothing and asks before dropping them —
+    /// the files themselves are already gone, so this only edits the list.
+    /// `--yes` skips the question, which is also what a run with no terminal on
+    /// stdin needs.
+    Prune {
+        /// Prune without asking
+        #[arg(short, long)]
+        yes: bool,
+    },
 }
 
 /// Which branches a `branch` subcommand considers, shared by all three.
@@ -506,6 +517,7 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             FileCmd::Pick => cmd::file::pick(&ctx),
             FileCmd::Add { file } => cmd::file::add(&ctx, file.as_deref()),
             FileCmd::Remove { file } => cmd::file::remove(&ctx, file.as_deref()),
+            FileCmd::Prune { yes } => cmd::file::prune(&ctx, yes),
         },
         Command::Edit { files, tracked } => cmd::edit::run(&ctx, &files, tracked),
         Command::Branch { command } => match command {

--- a/src/term.rs
+++ b/src/term.rs
@@ -108,6 +108,72 @@ impl<W: Write> Listing<W> {
     }
 }
 
+/// Whether an answer read from a prompt means yes.
+///
+/// Only an explicit yes counts: anything else — a bare return, a stray
+/// keystroke, end of input — is no. A command that deletes something has to be
+/// harder to trigger by accident than by intent.
+pub fn is_yes(answer: &str) -> bool {
+    matches!(answer.trim().to_lowercase().as_str(), "y" | "yes")
+}
+
+/// Ask `question` on stderr and read the answer from stdin.
+///
+/// The question goes to stderr because stdout is a result: `scriv file prune`
+/// prints the entries it removed there, and a prompt mixed into that would be
+/// something a script had to parse around.
+///
+/// Whether there is anyone to answer is the caller's problem, not this
+/// function's — see [`Confirm`] for why that distinction matters.
+pub fn confirm(question: &str) -> std::io::Result<bool> {
+    let mut err = std::io::stderr().lock();
+    write!(err, "{question} [y/N] ")?;
+    err.flush()?;
+    drop(err);
+
+    let mut answer = String::new();
+    // End of input is not a yes: a closed stdin has said nothing, and the
+    // safe reading of nothing is no.
+    if std::io::stdin().read_line(&mut answer)? == 0 {
+        return Ok(false);
+    }
+    Ok(is_yes(&answer))
+}
+
+/// Whether a question can be asked at all.
+///
+/// A prompt written to a stdin nobody is typing at is not a safety check — it
+/// is a hang, or an instant "no" that looks like a refusal to work. A command
+/// that needs confirmation and cannot ask for it should say so and name the
+/// flag that skips the question, rather than guessing which answer was meant.
+pub enum Confirm {
+    /// There is a terminal on stdin: ask.
+    Ask,
+    /// `--yes` was given: do not ask.
+    Assumed,
+    /// stdin is a pipe or a file, and no `--yes`: refuse rather than guess.
+    Impossible,
+}
+
+impl Confirm {
+    /// Decide from the `--yes` flag and whether stdin is a terminal.
+    ///
+    /// Split from the check itself so the rule is a pure function with a test;
+    /// [`Confirm::resolve`] is what callers use.
+    pub fn decide(yes: bool, stdin_is_tty: bool) -> Self {
+        match (yes, stdin_is_tty) {
+            (true, _) => Self::Assumed,
+            (false, true) => Self::Ask,
+            (false, false) => Self::Impossible,
+        }
+    }
+
+    /// [`Confirm::decide`] against this process's stdin.
+    pub fn resolve(yes: bool) -> Self {
+        Self::decide(yes, std::io::stdin().is_terminal())
+    }
+}
+
 /// Wrap `text` in an ANSI 256-colour sequence when `on`, so the same colour
 /// indices the picker uses also drive plain listings.
 pub fn paint(text: &str, color: u8, on: bool) -> String {
@@ -412,6 +478,35 @@ mod tests {
             "NO_COLOR beat --color always"
         );
         assert!(!ColorChoice::Never.resolve(true, false));
+    }
+
+    /// Only an explicit yes deletes anything. A bare return is the answer
+    /// someone gives when they were not reading, and it has to mean no.
+    #[test]
+    fn only_an_explicit_yes_is_a_yes() {
+        for answer in ["y", "Y", "yes", "YES", " yes \n"] {
+            assert!(is_yes(answer), "{answer:?} was not read as yes");
+        }
+        for answer in ["", "\n", "n", "no", "ye", "yep", "sure", "1"] {
+            assert!(!is_yes(answer), "{answer:?} was read as yes");
+        }
+    }
+
+    /// `--yes` is the whole point of the flag: it answers the question so a
+    /// script never reaches the prompt.
+    #[test]
+    fn the_yes_flag_skips_the_question() {
+        assert!(matches!(Confirm::decide(true, true), Confirm::Assumed));
+        assert!(matches!(Confirm::decide(true, false), Confirm::Assumed));
+    }
+
+    /// Prompting a stdin nobody is typing at is not caution — it is a hang or
+    /// an instant no that reads as a refusal to work. Saying so, and naming the
+    /// flag, is the only useful answer.
+    #[test]
+    fn a_question_that_cannot_be_asked_is_not_answered_for_the_user() {
+        assert!(matches!(Confirm::decide(false, false), Confirm::Impossible));
+        assert!(matches!(Confirm::decide(false, true), Confirm::Ask));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -554,6 +554,87 @@ fn file_ls_separates_present_from_missing() {
     assert!(status.stdout.contains("✗ "), "{}", status.stdout);
 }
 
+/// The point of `prune`: the entries pointing at nothing go, and only those.
+#[test]
+fn file_prune_drops_the_entries_whose_files_are_gone() {
+    let sandbox = Sandbox::new();
+    let here = sandbox.home().join("here.md");
+    std::fs::write(&here, "").unwrap();
+    let gone = sandbox.home().join("gone.md");
+    std::fs::write(&gone, "").unwrap();
+
+    sandbox.run(&["file", "add", here.to_str().unwrap()]).ok();
+    sandbox.run(&["file", "add", gone.to_str().unwrap()]).ok();
+    std::fs::remove_file(&gone).unwrap();
+
+    let run = sandbox.run(&["file", "prune", "--yes"]);
+    run.ok();
+    // What went is named, not counted: "removed 1 entry" is not something a
+    // user can check afterwards.
+    assert!(run.stdout.contains("Removed"), "{}", run.stdout);
+    assert!(run.stdout.contains("gone.md"), "{}", run.stdout);
+
+    let left = sandbox.run(&["file", "ls"]);
+    left.ok();
+    assert_eq!(left.lines(), vec![here.to_str().unwrap()]);
+}
+
+/// Deleting on an assumed yes is the failure mode worth guarding: a run with
+/// nothing on stdin cannot ask, so it says so and names the flag instead of
+/// picking an answer.
+#[test]
+fn file_prune_refuses_to_assume_an_answer_it_could_not_ask_for() {
+    let sandbox = Sandbox::new();
+    let gone = sandbox.home().join("gone.md");
+    std::fs::write(&gone, "").unwrap();
+    sandbox.run(&["file", "add", gone.to_str().unwrap()]).ok();
+    std::fs::remove_file(&gone).unwrap();
+
+    // The test harness gives the child no terminal, which is exactly the case.
+    let run = sandbox.run(&["file", "prune"]);
+    run.code(1);
+    assert!(run.stderr.contains("--yes"), "{}", run.stderr);
+
+    // And the list is untouched.
+    assert_eq!(sandbox.run(&["file", "ls"]).ok().lines().len(), 1);
+}
+
+/// A list with nothing missing must not ask a question at all — a prompt with
+/// no entries under it is one the user cannot answer meaningfully.
+#[test]
+fn file_prune_says_so_when_there_is_nothing_to_do() {
+    let sandbox = Sandbox::new();
+    let here = sandbox.home().join("here.md");
+    std::fs::write(&here, "").unwrap();
+    sandbox.run(&["file", "add", here.to_str().unwrap()]).ok();
+
+    // No `--yes`, and no terminal: reaching the confirmation at all would fail.
+    let run = sandbox.run(&["file", "prune"]);
+    run.ok();
+    assert!(run.stdout.contains("Nothing to prune"), "{}", run.stdout);
+    assert_eq!(sandbox.run(&["file", "ls"]).ok().lines().len(), 1);
+}
+
+/// What is about to be dropped is printed before anything happens, so the
+/// answer to the question is an informed one.
+#[test]
+fn file_prune_shows_the_entries_before_removing_them() {
+    let sandbox = Sandbox::new();
+    let gone = sandbox.home().join("gone.md");
+    std::fs::write(&gone, "").unwrap();
+    sandbox.run(&["file", "add", gone.to_str().unwrap()]).ok();
+    std::fs::remove_file(&gone).unwrap();
+
+    let run = sandbox.run(&["file", "prune", "--yes"]);
+    run.ok();
+    let shown = run.stdout.find("✗ ").expect("no listing of what would go");
+    let removed = run
+        .stdout
+        .find("Removed")
+        .expect("nothing reported removed");
+    assert!(shown < removed, "listed the entries after removing them");
+}
+
 /// A relative path is resolved against where the user is standing, not against
 /// wherever scriv happens to run.
 #[test]


### PR DESCRIPTION
The tracked-file list accumulates entries pointing at nothing — a repository re-cloned, a note renamed, a checkout deleted. Clearing them meant reading `file ls --missing` and handing each path to `file remove` by hand.

```
$ scriv file prune
✗ /Users/joakim/dev/old-thing/notes.md
✗ /Users/joakim/scratch/todo.md
Remove 2 entries from the list? [y/N] y
Removed ~/dev/old-thing/notes.md
Removed ~/scratch/todo.md
```

### Decisions

**The entries are printed before the question.** A count is not something anyone can answer — "remove 4 entries?" is decidable only by someone who already knows which four. They use the same ✗ rows `ls --status` draws, factored into one `status_row` now that there are two callers.

**A question that cannot be asked is not answered on the user's behalf.** With no terminal on stdin and no `--yes`, `prune` refuses and names the flag. Prompting a stdin nobody is typing at is not caution: it is a hang, or an instant "no" that reads as a refusal to work. `term::Confirm` makes that a three-way decision — ask, assumed, impossible — rather than a bare boolean.

**Only an explicit `y`/`yes` counts.** A bare return is what someone answers when they were not reading, and end-of-input has said nothing at all. Both are no.

Both decisions are pure functions with tests: `files::partition_missing` takes the existence check as an argument rather than reaching for the filesystem, and `term::Confirm::decide` is the flag-and-tty rule on its own.

Scope, stated: this only edits the list. The files are already gone — that is the definition of what it removes — so nothing on disk is deleted, which is also why the confirmation is a courtesy rather than a last line of defence.

Verified in a pty as well as in `tests/cli.rs`, since the confirmation branch is unreachable without a terminal: answering `n` leaves the list untouched and prints "Nothing removed"; answering `y` writes it back without the missing entries.

### The three docs

1. **CLI help — touched.** `FileCmd::Prune` and its `--yes` flag carry doc comments. `EXAMPLES` is unchanged: it covers the entry point of each command *group*, and `file` already has its line.
2. **README — touched.** `prune` added to the `scriv file` row, which must list what `scriv file --help` does.
3. **`docs/demo.gif` — not re-recorded, and does not need it.** No picker's rows, colours or previews changed; `prune` opens no picker at all.

`make` green: 255 unit tests, 47 CLI tests, clippy clean.