### PR TITLE
Read `SCRIV_NO_COLOR` rather than the shared `NO_COLOR`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,8 +230,12 @@ test that allocated a pty would be testing skim.
   the terminal on its way out. Add a fish wrapper only for what genuinely cannot
   work from a child process.
 - **Colour is decided once, on `Ctx`.** `--color auto|always|never` wins, then
-  `NO_COLOR`, then whether stdout is a terminal — so `ls` output stays pipe-safe
-  by default and `--color always` can still feed `less -R`. Printing code reads
+  `SCRIV_NO_COLOR`, then whether stdout is a terminal — so `ls` output stays
+  pipe-safe by default and `--color always` can still feed `less -R`. The
+  variable is scriv's own: the cross-tool `NO_COLOR` convention is deliberately
+  not read, because it is one switch for every tool at once and this is a switch
+  for this one, and sharing the name would leave no way to keep scriv coloured
+  in an environment that had turned everything else plain. Printing code reads
   `ctx.color()` and never asks the terminal itself; one run must not colour one
   command's output and not another's. The picker is out of scope: it is a
   terminal UI that only ever draws on a terminal.

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -154,7 +154,7 @@ enum Status {
 
 impl Status {
     /// A shape, not a colour alone — the same rule the pull request listings
-    /// follow, so a piped or `NO_COLOR` report says exactly as much.
+    /// follow, so a piped or `SCRIV_NO_COLOR` report says exactly as much.
     fn glyph(self) -> &'static str {
         match self {
             Self::Ok => "✓",
@@ -584,7 +584,7 @@ mod tests {
     }
 
     /// The report has to be readable without colour — piped, redirected, or
-    /// under `NO_COLOR` — so each status carries a distinct shape of its own.
+    /// under `SCRIV_NO_COLOR` — so each status carries a distinct shape of its own.
     #[test]
     fn every_status_is_a_distinct_shape_not_a_colour() {
         let glyphs: Vec<&str> = [Status::Ok, Status::Warn, Status::Fail]

--- a/src/cmd/pr.rs
+++ b/src/cmd/pr.rs
@@ -111,7 +111,7 @@ impl StatusColumns {
 ///
 /// The row is tinted by state and each glyph carries its own colour on top —
 /// green `✓`, red `✗`. Colour is dropped when stdout is not a terminal, and the
-/// glyphs are shapes rather than colours, so a piped or `NO_COLOR` listing
+/// glyphs are shapes rather than colours, so a piped or `SCRIV_NO_COLOR` listing
 /// still says everything a coloured one does.
 pub fn ls(ctx: &Ctx, state: &str, limit: usize, status: bool) -> Result<()> {
     let prs = collect(ctx, state, limit)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub struct Ctx {
     /// The editor `scriv edit` launches, from the environment.
     editor: Option<String>,
     /// Whether printed output carries colour, resolved once from `--color`,
-    /// `NO_COLOR` and whether stdout is a terminal.
+    /// `SCRIV_NO_COLOR` and whether stdout is a terminal.
     color: bool,
     pub config: Config,
     pub log: Logger,

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,10 +67,12 @@ struct Cli {
 
     /// When to colour printed output
     ///
-    /// `auto` colours a terminal and honours `NO_COLOR`. `always` colours a
-    /// pipe or a file too, for a pager such as `less -R`. Either explicit
-    /// value overrides `NO_COLOR`. The picker is unaffected — it only ever
-    /// draws on a terminal.
+    /// `auto` colours a terminal and honours `SCRIV_NO_COLOR`. `always` colours
+    /// a pipe or a file too, for a pager such as `less -R`. Either explicit
+    /// value overrides `SCRIV_NO_COLOR`. The picker is unaffected — it only
+    /// ever draws on a terminal.
+    ///
+    /// The variable is scriv's own; the cross-tool `NO_COLOR` is not read.
     #[arg(long, global = true, value_name = "WHEN", default_value = "auto")]
     color: ColorChoice,
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,10 +1,10 @@
 //! Terminal capability checks shared by the printing commands.
 //!
 //! Colour is decided once, at startup, by [`ColorChoice::resolve`] and carried
-//! on [`Ctx`](crate::Ctx) — `--color` if the user said, else the `NO_COLOR`
-//! convention, else whether stdout is a terminal, so `scriv … ls` stays
-//! pipe-safe by default. [`Spinner`] and [`ScratchRow`] follow the same rule
-//! from the other side: they touch the display only when there is one to touch.
+//! on [`Ctx`](crate::Ctx) — `--color` if the user said, else `SCRIV_NO_COLOR`,
+//! else whether stdout is a terminal, so `scriv … ls` stays pipe-safe by
+//! default. [`Spinner`] and [`ScratchRow`] follow the same rule from the other
+//! side: they touch the display only when there is one to touch.
 
 use std::io::{IsTerminal, Write};
 use std::sync::Arc;
@@ -19,7 +19,7 @@ use std::time::Duration;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
 #[clap(rename_all = "lower")]
 pub enum ColorChoice {
-    /// Colour when stdout is a terminal and `NO_COLOR` is unset.
+    /// Colour when stdout is a terminal and `SCRIV_NO_COLOR` is unset.
     #[default]
     Auto,
     /// Always colour, terminal or not — for a pager (`less -R`) or a recording.
@@ -34,9 +34,9 @@ impl ColorChoice {
     /// `is_tty` is passed in rather than looked up so the rule is a pure
     /// function with a test; [`ColorChoice::for_stdout`] is what callers use.
     ///
-    /// An explicit `always`/`never` outranks `NO_COLOR`: the environment states
+    /// An explicit `always`/`never` outranks `SCRIV_NO_COLOR`: the environment states
     /// a default, and a flag on the command line is the user overriding their
-    /// own default for this one run. `auto` is where `NO_COLOR` applies.
+    /// own default for this one run. `auto` is where `SCRIV_NO_COLOR` applies.
     pub fn resolve(self, is_tty: bool, no_color: bool) -> bool {
         match self {
             Self::Always => true,
@@ -51,11 +51,21 @@ impl ColorChoice {
     }
 }
 
-/// Honour the `NO_COLOR` convention: colour is disabled when the variable is
-/// present and non-empty.
+/// The variable that turns scriv's colour off: set and non-empty means no
+/// colour.
+///
+/// Deliberately scriv's own rather than the cross-tool `NO_COLOR`
+/// (<https://no-color.org>), which scriv does not read. The convention is a
+/// single switch for every tool at once, and this is a switch for this one;
+/// having them be the same name would mean scriv could not be made colourful in
+/// an environment that had turned everything else plain. `--color always` is
+/// still the per-run override in either direction.
 pub fn no_color() -> bool {
-    std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty())
+    std::env::var_os(NO_COLOR_ENV_VAR).is_some_and(|v| !v.is_empty())
 }
+
+/// The environment variable [`no_color`] reads.
+pub const NO_COLOR_ENV_VAR: &str = "SCRIV_NO_COLOR";
 
 /// Stdout for a listing, which ends quietly when the reader stops reading.
 ///
@@ -450,12 +460,15 @@ mod tests {
     use super::*;
 
     /// `auto` is the rule that was there before there was a flag: a terminal,
-    /// and `NO_COLOR` unset.
+    /// and `SCRIV_NO_COLOR` unset.
     #[test]
     fn auto_colours_only_a_terminal_without_no_color() {
         assert!(ColorChoice::Auto.resolve(true, false));
         assert!(!ColorChoice::Auto.resolve(false, false), "coloured a pipe");
-        assert!(!ColorChoice::Auto.resolve(true, true), "ignored NO_COLOR");
+        assert!(
+            !ColorChoice::Auto.resolve(true, true),
+            "ignored SCRIV_NO_COLOR"
+        );
     }
 
     /// The point of `always` is a destination that is not a terminal — a pager
@@ -468,14 +481,29 @@ mod tests {
         assert!(!ColorChoice::Never.resolve(false, false));
     }
 
-    /// `NO_COLOR` states a default for the environment; a flag on the command
+    /// scriv reads its own variable, not the cross-tool `NO_COLOR`
+    /// (<https://no-color.org>). The convention is one switch for every tool at
+    /// once; this is a switch for this one, and sharing the name would leave no
+    /// way to keep scriv coloured in an environment that had turned everything
+    /// else plain.
+    ///
+    /// Pinned here because nothing else can catch it: `no_color` reads the
+    /// environment, and whether it read the right name is invisible to a test
+    /// that cannot set one — which is every test in this crate, since mutating
+    /// the environment is unsound once another thread exists.
+    #[test]
+    fn the_variable_is_scrivs_own_and_not_the_shared_convention() {
+        assert_eq!(NO_COLOR_ENV_VAR, "SCRIV_NO_COLOR");
+    }
+
+    /// `SCRIV_NO_COLOR` states a default for the environment; a flag on the command
     /// line is the user overriding their own default for this one run, so it
     /// has to win in both directions.
     #[test]
     fn an_explicit_choice_outranks_no_color() {
         assert!(
             ColorChoice::Always.resolve(true, true),
-            "NO_COLOR beat --color always"
+            "SCRIV_NO_COLOR beat --color always"
         );
         assert!(!ColorChoice::Never.resolve(true, false));
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -102,7 +102,7 @@ impl Sandbox {
 
     /// Run `scriv` with `args`, from `cwd`.
     ///
-    /// `env_clear` is the whole point: an inherited `SCRIV_CONFIG`, `NO_COLOR`
+    /// `env_clear` is the whole point: an inherited `SCRIV_CONFIG`, `SCRIV_NO_COLOR`
     /// or `EDITOR` would quietly change what is being tested, and an inherited
     /// `HOME` would point the run at the developer's own config.
     fn run_in(&self, cwd: &Path, args: &[&str]) -> Run {
@@ -114,7 +114,7 @@ impl Sandbox {
     }
 
     /// [`Sandbox::run`] with `env` set on top — for the variables scriv is
-    /// meant to react to, such as `NO_COLOR`.
+    /// meant to react to, such as `SCRIV_NO_COLOR`.
     fn run_with_env(&self, args: &[&str], env: &[(&str, &str)]) -> Run {
         self.run_full(self.home(), args, env)
     }
@@ -700,7 +700,32 @@ fn color_always_colours_a_pipe_and_never_does_not() {
     }
 }
 
-/// `NO_COLOR` states a default for the environment; a flag on the command line
+/// `SCRIV_NO_COLOR` is what turns colour off, and it has to actually reach a
+/// run that would otherwise be coloured.
+#[test]
+fn scriv_no_color_turns_colour_off() {
+    let sandbox = Sandbox::new();
+    coloured_listing(&sandbox);
+
+    let run = sandbox.run_with_env(
+        &["--color", "auto", "file", "ls", "--status"],
+        &[("SCRIV_NO_COLOR", "1")],
+    );
+    run.ok();
+    assert!(!run.stdout.contains('\x1b'), "{:?}", run.stdout);
+
+    // Set but empty is not set: the convention every variable of this shape
+    // follows, and the difference between `set -x SCRIV_NO_COLOR ""` meaning
+    // nothing and meaning everything.
+    let empty = sandbox.run_with_env(
+        &["--color", "always", "file", "ls", "--status"],
+        &[("SCRIV_NO_COLOR", "")],
+    );
+    empty.ok();
+    assert!(empty.stdout.contains('\x1b'), "{:?}", empty.stdout);
+}
+
+/// `SCRIV_NO_COLOR` states a default for the environment; a flag on the command line
 /// is the user overriding their own default for this one run, so it wins in
 /// both directions.
 #[test]
@@ -710,12 +735,12 @@ fn an_explicit_color_choice_outranks_no_color() {
 
     let forced = sandbox.run_with_env(
         &["--color", "always", "file", "ls", "--status"],
-        &[("NO_COLOR", "1")],
+        &[("SCRIV_NO_COLOR", "1")],
     );
     forced.ok();
     assert!(
         forced.stdout.contains('\x1b'),
-        "NO_COLOR beat `--color always`: {:?}",
+        "SCRIV_NO_COLOR beat `--color always`: {:?}",
         forced.stdout
     );
 }


### PR DESCRIPTION
scriv's colour switch is now its own variable.

```
NO_COLOR=1 scriv file ls --status         # coloured
SCRIV_NO_COLOR=1 scriv file ls --status   # plain
```

### The trade-off, up front

This is a deliberate departure from <https://no-color.org>. `NO_COLOR=1` in an environment no longer silences scriv, and anyone relying on it has to set `SCRIV_NO_COLOR` too. That is a real cost and it is the point of the change: the convention is one switch for every tool at once, and sharing the name leaves no way to keep scriv coloured in an environment that has turned everything else plain.

### What does not move

The rest of the rule is unchanged, and its tests with it: `--color always|never` still outranks the variable in both directions, `auto` is still the only mode it applies in, and set-but-empty still counts as unset.

### Where it is pinned

Which name is read lives in a unit test in `term.rs`, not in `tests/cli.rs`. Telling the old behaviour from the new one from outside the process needs a run with a terminal on stdout *and* a variable set — the CLI harness pipes stdout, so `auto` is colourless either way and the two are indistinguishable there. Setting the variable from inside a test is unsound once another thread exists. So `no_color` reads a named constant and the constant is asserted.

I wrote a CLI test for this first and deleted it: it passed under both the old and the new behaviour, which makes it worse than none.

### The three docs

1. **CLI help — touched.** The `--color` doc comment names `SCRIV_NO_COLOR` and says the shared convention is not read, since that is the surprising half.
2. **README — untouched, correctly.** It names neither variable; colour is `scriv --help` territory.
3. **`docs/demo.gif` — not re-recorded, and does not need it.** The tape sets no colour variable and the picker is out of scope for `--color` regardless — it only ever draws on a terminal.

`CLAUDE.md`'s colour bullet is updated with the reasoning, since it is where the "colour is decided once" rule is written down.

No `config check` row: the variable is a preference rather than something that can be misconfigured, and an unset one is the ordinary case.

`make` green: 254 unit tests, 44 CLI tests, clippy clean.