### PR TITLE
Stop leaving a picker spinning when its terminal goes away

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,17 @@ test that allocated a pty would be testing skim.
   thing; a two-line prompt is left cut in half. Take a row, draw on that, and
   step back up on the way out so the cursor is where the shell's repaint expects
   it. Never draw on the row scriv was invoked on.
+- **The picker watches for its terminal disappearing.** skim's input loop does
+  not stop when its event stream ends: on a pty whose other end has closed,
+  `crossterm` reports end-of-stream immediately and forever and skim's `select!`
+  treats that as nothing to do, so the process pins a core until something kills
+  it — one was found here having done so for over a day. Normally `SIGHUP` ends
+  scriv first; `term::watch_for_hangup` is for when it does not, and it probes
+  with a *zero-length write* so it can neither disturb what skim has drawn nor
+  take a keystroke skim was going to act on. On macOS that is the only probe
+  that works: `poll` reports no hangup and `tcgetattr`, `TIOCGWINSZ` and
+  `tcgetpgrp` all keep answering normally on a slave whose master is gone. Take
+  the guard out only once skim's loop terminates on its own.
 - **Only `cd` needs the shell.** A child cannot change its parent's directory,
   which is why `repo pick` prints a path for a fish function to consume. Running
   an editor needs no such help: `scriv edit` spawns it directly and skim restores

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,6 +1688,7 @@ dependencies = [
  "ignore",
  "indexmap",
  "ratatui",
+ "rustix",
  "serde",
  "serde_json",
  "skim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,11 @@ indexmap = { version = "2.14.0", features = ["serde"] }
 # Pinned to skim's ratatui so the `SkimItem::display` types match; core
 # text/style modules only.
 ratatui = { version = "0.30", default-features = false }
+# A zero-length write to the terminal, to notice when it has gone away while a
+# picker is open — see `term::watch_for_hangup`. Already in the tree via tokio
+# and the `ignore` walk, so this compiles nothing new, and it is what keeps that
+# probe out of an `unsafe` block: this crate has none.
+rustix = { version = "1", default-features = false, features = ["std"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Library use only — skip the `cli`, `image`, and `listen` features and the

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -561,6 +561,11 @@ fn run_picker(feed: Feed, run: Run, cfg: &PickerConfig) -> Result<Outcome> {
         anyhow::bail!("interactive selection needs a terminal");
     }
 
+    // skim does not stop when its input ends, so a picker whose terminal has
+    // gone spins at 100% CPU for as long as the process is left alive. Held for
+    // exactly as long as the picker is open.
+    let _watch = crate::term::watch_for_hangup();
+
     let mut builder = SkimOptionsBuilder::default();
     builder
         .height(cfg.height.clone())

--- a/src/term.rs
+++ b/src/term.rs
@@ -7,6 +7,8 @@
 //! side: they touch the display only when there is one to touch.
 
 use std::io::{IsTerminal, Write};
+
+use rustix::fd::AsFd;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::JoinHandle;
@@ -181,6 +183,123 @@ impl Confirm {
     /// [`Confirm::decide`] against this process's stdin.
     pub fn resolve(yes: bool) -> Self {
         Self::decide(yes, std::io::stdin().is_terminal())
+    }
+}
+
+/// The status scriv exits with when its terminal disappears underneath it.
+///
+/// 128 + SIGHUP, which is what the shell would have reported had the signal
+/// been delivered and taken its default action. Nothing is waiting to read it —
+/// the terminal is gone — but a status that means something is still cheaper
+/// than one that does not.
+pub const EXIT_HANGUP: u8 = 129;
+
+/// How often the terminal is probed while a picker is open. Twice a second is
+/// far below anything measurable and still notices a hangup promptly.
+const HANGUP_POLL: Duration = Duration::from_millis(500);
+
+/// How many probes in a row must fail before the terminal is called gone.
+///
+/// More than one because the consequence is ending the process: a single odd
+/// answer from a terminal that is still there would take down a picker somebody
+/// was reading.
+const HANGUP_STRIKES: u32 = 2;
+
+/// Whether a failed probe means the terminal has gone, rather than that the
+/// probe itself was interrupted.
+///
+/// `EIO` is what a pty whose other end has closed answers with, and `ENXIO` is
+/// the same answer from a device that is no longer attached. `EBADF` means the
+/// descriptor is not there at all. `EINTR` and `EAGAIN` are ordinary and say
+/// nothing about the terminal.
+pub fn is_hangup(err: rustix::io::Errno) -> bool {
+    use rustix::io::Errno;
+    matches!(err, Errno::IO | Errno::NXIO | Errno::BADF | Errno::PIPE)
+}
+
+/// Ask the terminal whether it is still there, without writing to it.
+///
+/// A zero-length write runs the driver's checks and then writes no bytes, so it
+/// cannot disturb what the picker has drawn — and unlike a read, it cannot take
+/// a keystroke that skim was going to act on.
+fn still_attached(fd: rustix::fd::BorrowedFd<'_>) -> bool {
+    match rustix::io::write(fd, &[]) {
+        Ok(_) => true,
+        Err(e) => !is_hangup(e),
+    }
+}
+
+/// Ends the process if the terminal goes away while a picker is open.
+///
+/// The picker is skim, and skim's input loop does not stop when its event
+/// stream ends: on a pty whose other end has closed, `crossterm`'s
+/// `EventStream` yields end-of-stream immediately and forever, and skim's
+/// `select!` treats that as nothing to do and asks again. The result is a
+/// process pinning a core for as long as it is left alone — one was found here
+/// having done so for over a day.
+///
+/// Normally the kernel prevents this: closing the other end of a pty sends
+/// `SIGHUP` to the foreground process group and the default action ends scriv
+/// before skim can spin. This is for when that does not happen — an orphaned
+/// process group, a terminal that never hung up the group scriv was in — which
+/// is the state the spinning process had reached.
+///
+/// The real fix belongs in skim, whose loop should stop when its input ends.
+/// Until it does, scriv declines to be the process left behind.
+#[must_use]
+pub struct HangupWatch {
+    stop: Arc<AtomicBool>,
+    /// `None` when there was no terminal to watch, which makes this a no-op
+    /// rather than a check at the call site.
+    thread: Option<JoinHandle<()>>,
+}
+
+/// Watch the terminal for as long as the returned guard is held.
+///
+/// Bind it — `let _watch = term::watch_for_hangup()`. A bare statement drops it
+/// immediately and watches nothing.
+pub fn watch_for_hangup() -> HangupWatch {
+    let stop = Arc::new(AtomicBool::new(false));
+    // stderr is what the picker draws on, so it is the terminal whose loss
+    // matters. Without one there is nothing to watch and nothing to protect.
+    if !std::io::stderr().is_terminal() {
+        return HangupWatch { stop, thread: None };
+    }
+
+    let flag = Arc::clone(&stop);
+    let thread = std::thread::spawn(move || {
+        let mut strikes = 0;
+        while !flag.load(Ordering::Relaxed) {
+            std::thread::sleep(HANGUP_POLL);
+            if flag.load(Ordering::Relaxed) {
+                return;
+            }
+            if still_attached(std::io::stderr().as_fd()) {
+                strikes = 0;
+                continue;
+            }
+            strikes += 1;
+            if strikes >= HANGUP_STRIKES {
+                // Nothing to unwind: the terminal that skim's state describes is
+                // gone, and every destructor between here and `main` would be
+                // writing to it. Leaving by the shortest route is the point.
+                std::process::exit(EXIT_HANGUP as i32);
+            }
+        }
+    });
+    HangupWatch {
+        stop,
+        thread: Some(thread),
+    }
+}
+
+impl Drop for HangupWatch {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        // Not joined: the thread sleeps in half-second steps, and making every
+        // picker's exit wait for one would be paying for the watch on the path
+        // where nothing went wrong.
+        drop(self.thread.take());
     }
 }
 
@@ -479,6 +598,48 @@ mod tests {
     fn always_colours_a_pipe_too() {
         assert!(ColorChoice::Always.resolve(false, false));
         assert!(!ColorChoice::Never.resolve(false, false));
+    }
+
+    /// `EIO` is what a pty answers once the other end has closed, and it is the
+    /// answer the spinning picker was getting. `ENXIO` is a device that is no
+    /// longer attached, `EBADF` a descriptor that is not there at all.
+    #[test]
+    fn the_errors_that_mean_the_terminal_has_gone() {
+        use rustix::io::Errno;
+        for err in [Errno::IO, Errno::NXIO, Errno::BADF, Errno::PIPE] {
+            assert!(is_hangup(err), "{err:?} was not read as a hangup");
+        }
+    }
+
+    /// Ending the process is the consequence, so anything that merely means
+    /// "ask again" must not reach it. An interrupted or would-block write says
+    /// nothing at all about whether the terminal is still there.
+    #[test]
+    fn an_interrupted_probe_is_not_a_hangup() {
+        use rustix::io::Errno;
+        for err in [Errno::INTR, Errno::AGAIN, Errno::NOSPC, Errno::PERM] {
+            assert!(!is_hangup(err), "{err:?} would have killed a live picker");
+        }
+    }
+
+    /// Without a terminal there is nothing to watch and nothing that could go
+    /// wrong, so no thread is started — and nothing can call `exit` on a run
+    /// that was only ever a pipe.
+    #[test]
+    fn no_terminal_means_nothing_is_watched() {
+        // The test harness captures stderr, so this is the redirected case.
+        let watch = watch_for_hangup();
+        assert!(
+            watch.thread.is_none(),
+            "watched a terminal that was not there"
+        );
+    }
+
+    /// 128 + SIGHUP: the status the shell would have reported had the signal
+    /// been delivered and taken its default action.
+    #[test]
+    fn the_hangup_exit_status_is_the_one_a_signal_would_have_given() {
+        assert_eq!(EXIT_HANGUP, 128 + 1);
     }
 
     /// scriv reads its own variable, not the cross-tool `NO_COLOR`


### PR DESCRIPTION
A `scriv history pick` was found on this machine pinning a core, and had been doing so for **over a day**. It is not specific to `history` — any picker reaches the same state.

### Root cause: skim's input loop

`src/tui/backend.rs`, identical in skim 5.5.0 (what we pin) and 5.6.1 (latest, so there is nothing to upgrade to):

```rust
loop {
    let crossterm_event = reader.next().fuse();
    tokio::select! {
        maybe_event = crossterm_event => {
          match maybe_event {
            ...
            Some(Err(e)) => { _ = event_tx_clone.try_send(Event::Error(e.to_string())); }
            None | Some(Ok(_)) => {},          // <- end-of-stream: do nothing, ask again
          }
        },
        ...
    }
}
```

On a pty whose other end has closed, `crossterm`'s `EventStream` yields `None` immediately and forever. The loop has no delay, so it runs flat out until something kills the process. A persistent `Some(Err(_))` does the same.

Normally the kernel gets there first: closing the other end of a pty sends `SIGHUP` to the foreground process group and the default action ends scriv before skim can spin. The process found here had survived that — which is exactly the case this covers.

### Measured

Picker on a pty, `SIGHUP` ignored in the child to model whatever kept the original alive, then the master closed:

```
BEFORE, terminal killed         peak CPU 100.1% | STILL RUNNING after 8s | had to be SIGKILLed
AFTER,  terminal killed         peak CPU   0.0% | exited after ~1s       | exit 129
AFTER,  terminal alive 8s       peak CPU   0.7% | untouched              | exit 0, returned its selection
```

The third line is the regression that would matter — a guard that kills live pickers — and it does not happen across sixteen probe intervals.

### The guard

`term::watch_for_hangup` probes twice a second and ends the process after two consecutive `EIO`s.

**Why a zero-length write.** It must not disturb what skim has drawn, so it writes nothing; and it must not take a keystroke skim was going to act on, which rules out a read. A zero-length write runs the driver's checks and writes no bytes: `Ok(0)` while the terminal is there, `EIO` once it is not.

**Why not something more obvious.** On macOS nothing else notices. Measured on a slave whose master had closed: `poll` with an empty mask reports no hangup at all, and `tcgetattr`, `TIOCGWINSZ` and `tcgetpgrp` all keep answering normally, indefinitely. Only a read (EOF) or a write (`EIO`) tells the truth. That list is in the CLAUDE.md note so nobody re-derives it.

**Two strikes, not one,** because the consequence is ending the process.

**No `unsafe`.** The probe goes through `rustix`, which keeps this crate's count of unsafe blocks at zero.

### Trade-offs, named

- **This is a guard, not a repair.** The bug is skim's and the fix belongs there. This should come out when skim's loop terminates on its own; the CLAUDE.md note says so.
- **`rustix` becomes a direct dependency.** Already in the tree via tokio and the `ignore` walk, so it compiles nothing new and adds nothing to the supply chain. I did not run `repo-surface-sync`: no install path, supported platform, public API or badge follows from a transitive dep becoming direct. Say if you would rather it ran.
- **The Linux path is unverified.** Everything above was measured on macOS. Linux *does* report `POLLHUP` where macOS does not, so the guard is likely redundant there and at worst a no-op — but I have not measured it, and CI has no pty to measure it in.
- **No `tests/cli.rs` case.** Reaching this needs a pty and a terminal that dies mid-run. The pure parts are unit-tested — which errno means a hangup, that anything meaning "ask again" does not, that no thread starts without a terminal, and the exit status — and the end-to-end behaviour was verified with a harness rather than committed as a test.

### The three docs

1. **CLI help — untouched, correctly.** No command, flag or example changed; the guard has no surface.
2. **README — untouched, correctly.** It names no exit statuses and describes no failure modes.
3. **`docs/demo.gif` — not re-recorded, and does not need it.** No picker's rows, colours or previews changed.

`make` green: 263 unit tests, 48 CLI tests, clippy clean.