### PR TITLE
Review the CLI surface: escape sequences, process groups, and four edge cases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,19 @@ in the PR body which ones you touched, or why none needed it.
 command or flag, and the `EXAMPLES` block are the only documentation most
 users read, and clap ships them straight to the terminal. A new command or
 flag is not done until it has a doc comment; a renamed or re-scoped one is not
-done until the old wording is gone. `EXAMPLES` covers the common entry point
-of each command group — add a line when you add a group, not when you add
-every flag.
+done until the old wording is gone.
+
+`EXAMPLES` is three lines and stays three lines. It once carried one per
+command group, which was thirteen lines of identical shape sitting directly
+below the list of commands that already named every one of them — a wall to
+scroll past rather than something read. What it shows now is one of each
+*kind*: what to run first, how a `sel` composes into the shell, and a verb
+acting on its own. A new command group does not earn a line; it earns one only
+by being a kind of thing none of the three already demonstrates.
+
+Aliases are declared `visible_alias`, never `alias`. clap hides the latter, and
+a name the binary accepts but the help does not mention is exactly the drift
+this section exists to prevent.
 
 **2. README.md.** It is deliberately short — a page, not a manual — and it stays
 that way. Three things in it can go stale: the command table, which must list

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,6 @@ edition = "2024"
 description = "Provides fuzzy-completion for various local and remote resources."
 license = "MIT"
 repository = "https://github.com/joakimen/scriv"
-# Artwork, the demo recording and CI config belong to the repository, not the
-# crate. Nothing under src/ reads them, so keep them out of `cargo package`
-# too — otherwise every published tarball carries the GIF and the SVGs.
 exclude = ["docs/", "demo/", ".github/", ".claude/", ".idea/"]
 
 [dependencies]
@@ -17,30 +14,20 @@ clap_complete = "4.6.7"
 dirs = "6"
 ignore = "0.4.31"
 indexmap = { version = "2.14.0", features = ["serde"] }
-# Pinned to skim's ratatui so the `SkimItem::display` types match; core
-# text/style modules only.
+# Not a TUI here: scriv implements skim's `SkimItem::display`, which *returns* a
+# `ratatui::text::Line`, so the crate is a type dependency and has to be the
+# same version skim was built against. Bump it out of step with skim and the
+# error is a `Line` that is not the `Line` the trait wants.
 ratatui = { version = "0.30", default-features = false }
-# A zero-length write to the terminal, to notice when it has gone away while a
-# selector is open — see `term::watch_for_hangup`. Already in the tree via tokio
-# and the `ignore` walk, so this compiles nothing new, and it is what keeps that
-# probe out of an `unsafe` block: this crate has none.
 rustix = { version = "1", default-features = false, features = ["std"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-# Library use only — skip the `cli`, `image`, and `listen` features and the
-# heavy deps (image stack, IPC server, duplicate clap) they pull in.
 skim = { version = "5", default-features = false }
-# Turning `history`'s stored Unix seconds into a local date. Already in the
-# tree via ratatui, so this compiles nothing new; `local-offset` is the one
-# feature added, and only `Ctx` uses it — see the note there about why the
-# offset is read before anything spawns a thread.
 time = { version = "0.3", features = ["local-offset"] }
 toml = { version = "1.1.3", features = ["preserve_order"] }
 
 [dev-dependencies]
 tempfile = "3"
-# Tests only: proves the status glyphs really are the two columns wide that the
-# aligned pull request listings assume. Already in the tree via skim.
 unicode-width = "0.2"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -55,3 +55,18 @@ make                # fmt check, clippy, tests, release build
 make demo           # re-record docs/demo.gif
 make demo-fixture   # build the demo sandbox and poke at it by hand
 ```
+
+## Releasing
+
+Bump `version` in `Cargo.toml`, refresh `Cargo.lock` (`cargo check`), and merge
+that as its own pull request. Then tag the merge commit on `main`:
+
+```sh
+git checkout main && git pull
+git tag v0.3.0 && git push origin v0.3.0
+```
+
+The tag is what releases: `.github/workflows/release.yml` builds macOS and Linux
+on x86_64 and arm64, attaches four tarballs with checksums and build
+provenance, and writes the notes from the commits. Releases are immutable, so a
+tag pushed at the wrong commit needs a new version rather than a fix.

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -116,6 +116,13 @@ fn open(ctx: &Ctx, targets: &[String]) -> Result<()> {
 
     let status = Command::new(program)
         .args(args)
+        // `--` first, because a filename is not a flag however it is spelled.
+        // The walk yields paths relative to the working directory, so a file
+        // named `-c` arrives as exactly that — and to vim, `-c` is an Ex command
+        // to run rather than a file to open. clap catches this on the argument
+        // path and cannot on the selector path, which does not go through clap
+        // at all. Every editor worth setting `$EDITOR` to understands `--`.
+        .arg("--")
         .args(targets)
         .status()
         .map_err(|e| match e.kind() {

--- a/src/cmd/file.rs
+++ b/src/cmd/file.rs
@@ -141,6 +141,23 @@ pub fn add(ctx: &Ctx, file: Option<&str>) -> Result<()> {
         },
     };
 
+    // The list is one path per line, so a path containing a newline is not
+    // something it can hold: written, it comes back as two entries, neither of
+    // which is the file, and `file rm` can then never match the path it was
+    // given. Refused on the way in — the alternative is a list only a text
+    // editor can repair.
+    if let Some(control) = file.chars().find(|c| c.is_control()) {
+        bail!(
+            "the known-files list is one path per line, so it cannot hold a path \
+             containing {}",
+            match control {
+                '\n' => "a newline".to_string(),
+                '\t' => "a tab".to_string(),
+                c => format!("the control character U+{:04X}", c as u32),
+            }
+        );
+    }
+
     let sanitized = sanitize_file_path(&file, ctx.home_str(), ctx.pwd_str());
     let expanded = expand_tilde(&sanitized, ctx.home_str());
     if !Path::new(&expanded).exists() {
@@ -158,7 +175,7 @@ pub fn add(ctx: &Ctx, file: Option<&str>) -> Result<()> {
     Ok(())
 }
 
-/// `scriv file remove [path]` — remove a file, by argument or interactively.
+/// `scriv file rm [path]` — remove a file, by argument or interactively.
 pub fn remove(ctx: &Ctx, file: Option<&str>) -> Result<()> {
     ctx.ensure_files_migrated()?;
     match file {

--- a/src/cmd/proc.rs
+++ b/src/cmd/proc.rs
@@ -9,12 +9,16 @@ use crate::proc::{self, Process, Signal};
 use crate::select::{Preview, SelectItem};
 use crate::{Ctx, Reported, select, term};
 
-/// The process table, minus what must never be offered.
+/// The whole process table, as `ps` reported it.
 ///
 /// One `ps` call serves the listing, the selector rows and every preview pane —
 /// see [`proc::preview`] for why the previews are built from it rather than
 /// asking again per row.
-fn processes() -> Result<Vec<Process>> {
+///
+/// Unfiltered, because the entries that must never be *offered* are exactly the
+/// ones [`proc::refuse`] has to recognise when a pid is named on the command
+/// line: filter here and the parent chain is no longer there to check against.
+fn table() -> Result<Vec<Process>> {
     let output = Command::new("ps")
         .args(proc::PS_ARGS)
         .stdin(Stdio::null())
@@ -29,13 +33,18 @@ fn processes() -> Result<Vec<Process>> {
             stderr.to_string()
         });
     }
-    let text = String::from_utf8_lossy(&output.stdout);
-    // `id()` is this process; everything above it in the parent chain runs up
-    // through the shell to the terminal, and none of it is killable material.
-    Ok(proc::selectable(
-        &proc::parse(&text),
-        std::process::id() as i32,
-    ))
+    Ok(proc::parse(&String::from_utf8_lossy(&output.stdout)))
+}
+
+/// This process, which is the root of the chain that must never be signalled.
+fn self_pid() -> i32 {
+    std::process::id() as i32
+}
+
+/// The process table, minus what must never be offered: scriv itself and
+/// everything above it in the parent chain.
+fn processes() -> Result<Vec<Process>> {
+    Ok(proc::selectable(&table()?, self_pid()))
 }
 
 fn spawn_error(err: std::io::Error) -> anyhow::Error {
@@ -81,13 +90,22 @@ pub fn sel(ctx: &Ctx) -> Result<()> {
 /// exited between the listing and the keystroke — is reported against the row
 /// it belongs to and does not hide the others that worked.
 pub fn kill(ctx: &Ctx, pids: &[i32], signal: Signal) -> Result<()> {
-    let procs = processes()?;
+    let table = table()?;
+    let procs = proc::selectable(&table, self_pid());
+
     let targets = if pids.is_empty() {
         match choose(ctx, &procs, signal)? {
             Some(targets) => targets,
             None => return Ok(()),
         }
     } else {
+        // Nothing filtered these, so they are checked instead — refusing the
+        // whole run rather than skipping the bad ones, since a list that was
+        // partly signalled and partly not is the hardest outcome to act on.
+        let refused = proc::refuse(&table, self_pid(), pids);
+        if let Some((pid, refusal)) = refused.first() {
+            bail!("refusing to signal {pid}: {}", refusal.reason());
+        }
         pids.to_vec()
     };
     if targets.is_empty() {

--- a/src/cmd/repo.rs
+++ b/src/cmd/repo.rs
@@ -473,6 +473,7 @@ pub fn clone(ctx: &Ctx, target: Option<&str>, limit: usize) -> Result<()> {
 
     // `owner/repo` names a repository outright; there is nothing to choose.
     if let Some(slug) = target.filter(|t| t.contains('/')) {
+        check_slug(slug)?;
         return finish(ctx, &root, vec![slug.to_string()]);
     }
 
@@ -480,6 +481,10 @@ pub fn clone(ctx: &Ctx, target: Option<&str>, limit: usize) -> Result<()> {
         Some(owner) => owner.to_string(),
         None => select_owner(ctx, &root)?,
     };
+    // The owner selector accepts anything typed, precisely so an owner scriv has
+    // never seen can still be cloned from — which means it is exactly as
+    // unchecked as an argument, and gets the same check.
+    check_slug(&owner)?;
 
     let repos = gh::list_repos(&owner, limit)?;
     ctx.log
@@ -502,6 +507,24 @@ pub fn clone(ctx: &Ctx, target: Option<&str>, limit: usize) -> Result<()> {
         return Ok(());
     }
     finish(ctx, &root, chosen)
+}
+
+/// Reject a name that is not one GitHub could have issued.
+///
+/// A slug is two things at once: a positional argument to `gh`, and the
+/// `<owner>/<repo>` that [`destination`] joins onto the root. One beginning with
+/// `-` is read as a flag rather than a name, and one carrying `..` or a third
+/// path component walks out of the root through that join. `gh` refuses both
+/// today; that is its rule to change, and this is the one place scriv can state
+/// its own.
+fn check_slug(slug: &str) -> Result<()> {
+    if gh::valid_slug(slug) {
+        return Ok(());
+    }
+    bail!(
+        "`{slug}` is not a GitHub owner or owner/repo name — those are letters, \
+         digits, `-`, `_` and `.`, and do not begin with `-`"
+    )
 }
 
 /// Skip what is already on disk, clone the rest, and exit non-zero if any

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -17,6 +17,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use serde::Deserialize;
 
 use crate::Reported;
+use crate::term;
 
 /// JSON fields requested from `gh pr list`.
 ///
@@ -496,7 +497,26 @@ pub fn parse_prs(data: &str) -> Result<Vec<PullRequest>> {
     if data.trim().is_empty() {
         return Ok(Vec::new());
     }
-    serde_json::from_str(data).context("parsing `gh pr list` output")
+    let mut prs: Vec<PullRequest> =
+        serde_json::from_str(data).context("parsing `gh pr list` output")?;
+    // Titles, branch names and descriptions are written by whoever opened the
+    // pull request — on a public repository, by anyone at all — and every one of
+    // them ends up drawn on a terminal. Made safe here, once, so no listing or
+    // selector row downstream has to remember to.
+    for pr in &mut prs {
+        pr.title = term::one_row(&pr.title);
+        pr.head_ref_name = term::one_row(&pr.head_ref_name);
+        pr.body = term::block(&pr.body);
+        if let Some(author) = &mut pr.author {
+            author.login = term::one_row(&author.login);
+        }
+        for check in &mut pr.status_check_rollup {
+            check.name = term::one_row(&check.name);
+            check.context = term::one_row(&check.context);
+            check.workflow_name = term::one_row(&check.workflow_name);
+        }
+    }
+    Ok(prs)
 }
 
 /// Pull requests for the repository the working directory belongs to.
@@ -653,7 +673,42 @@ pub fn parse_repos(data: &str) -> Result<Vec<Repo>> {
     if data.trim().is_empty() {
         return Ok(Vec::new());
     }
-    serde_json::from_str(data).context("parsing `gh repo list` output")
+    let mut repos: Vec<Repo> =
+        serde_json::from_str(data).context("parsing `gh repo list` output")?;
+    // As in [`parse_prs`]: a description is whatever its owner typed. Left out
+    // of this is `name_with_owner`, which is not display text — it is the slug
+    // handed to `gh repo clone` and the directory it lands in, and quietly
+    // rewriting either would clone something other than what was asked for.
+    // [`valid_slug`] is what guards that one.
+    for repo in &mut repos {
+        repo.description = term::one_row(&repo.description);
+        if let Some(language) = &mut repo.primary_language {
+            language.name = term::one_row(&language.name);
+        }
+    }
+    Ok(repos)
+}
+
+/// Whether `slug` is a GitHub `owner` or `owner/repo` scriv will act on.
+///
+/// A slug is not display text: it is a positional argument to `gh` and a
+/// component of the path a clone is written to. One starting with `-` is read
+/// by `gh` as a flag rather than a name, and one containing `..` or an extra
+/// `/` escapes `<root>/<owner>/<repo>` through the `Path::join` that builds it.
+/// GitHub itself allows neither in a real name, so refusing them costs nothing
+/// and does not depend on `gh` continuing to reject them first.
+pub fn valid_slug(slug: &str) -> bool {
+    let parts: Vec<&str> = slug.split('/').collect();
+    (1..=2).contains(&parts.len())
+        && parts.iter().all(|part| {
+            !part.is_empty()
+                && !part.starts_with('-')
+                && part
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+                && *part != ".."
+                && *part != "."
+        })
 }
 
 /// Every repository belonging to `owner`.
@@ -810,6 +865,73 @@ mod tests {
         {"number":9,"title":"WIP","author":null,"headRefName":"wip",
          "isDraft":true,"state":"OPEN","updatedAt":"2026-07-20T11:00:00Z"}
     ]"#;
+
+    /// A pull request title is written by whoever opened it — on a public
+    /// repository, by anyone — and `pr ls` writes it straight to a terminal,
+    /// which acts on escape sequences rather than showing them. Unfiltered,
+    /// `\x1b[32m` would let a title paint its own row green, so a pull request
+    /// with failing checks could be made to look like one that passed.
+    #[test]
+    fn a_pull_request_cannot_carry_an_escape_into_a_listing() {
+        let prs = parse_prs(
+            r#"[{"number":1,"title":"fix\u001b[2K\u001b[32m all checks pass",
+                 "author":{"login":"a\u001b[31mb"},"headRefName":"x\u001b[0m",
+                 "body":"para\u001b[2Kone\n\npara two","state":"OPEN",
+                 "statusCheckRollup":[{"name":"bu\u001b[2Kild","status":"COMPLETED",
+                 "conclusion":"FAILURE"}]}]"#,
+        )
+        .unwrap();
+        let pr = &prs[0];
+        for text in [&pr.title, &pr.body, &pr.head_ref_name] {
+            assert!(!text.contains('\x1b'), "{text:?}");
+        }
+        assert!(!pr.author_login().contains('\x1b'));
+        assert!(!pr.status_check_rollup[0].name.contains('\x1b'));
+        // The verdict is unchanged: sanitising is about what is drawn, not
+        // about what the checks said.
+        assert_eq!(pr.checks().failed, 1);
+    }
+
+    /// A description is the same kind of foreign text, and the clone selector
+    /// draws it beside every row.
+    #[test]
+    fn a_repository_description_cannot_carry_an_escape_either() {
+        let repos = parse_repos(
+            r#"[{"nameWithOwner":"acme/api","description":"a\u001b[2Kb",
+                 "primaryLanguage":{"name":"R\u001b[31must"}}]"#,
+        )
+        .unwrap();
+        assert_eq!(repos[0].description, "a[2Kb");
+        assert_eq!(repos[0].language(), "R[31must");
+        // The slug is not display text and is left exactly as it arrived —
+        // rewriting it would clone something other than what was named.
+        assert_eq!(repos[0].name_with_owner, "acme/api");
+    }
+
+    /// A slug is a positional argument to `gh` and a component of the path a
+    /// clone lands in. A leading `-` is read as a flag; `..` and an extra `/`
+    /// walk out of `<root>/<owner>/<repo>`.
+    #[test]
+    fn only_names_github_could_have_issued_are_valid_slugs() {
+        for good in ["joakimen", "acme/api", "a-b_c.d", "acme/my.repo"] {
+            assert!(valid_slug(good), "{good} rejected");
+        }
+        for bad in [
+            "-L",              // read by gh as a flag
+            "--json",          //
+            "..",              // walks out of the root
+            "../../etc",       //
+            "acme/../../etc",  //
+            "a/b/c",           // a third component the layout has no place for
+            "",                //
+            "acme/",           // an empty component
+            "/api",            //
+            "acme/api;whoami", // shell metacharacters, if one ever reaches a shell
+            "acme api",
+        ] {
+            assert!(!valid_slug(bad), "{bad} accepted");
+        }
+    }
 
     #[test]
     fn parses_gh_output() {

--- a/src/history.rs
+++ b/src/history.rs
@@ -14,12 +14,10 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use crate::path::expand_home_dir;
+use crate::term;
 
 /// Base directory for fish's data files, per the XDG spec.
 pub const XDG_DATA_ENV_VAR: &str = "XDG_DATA_HOME";
-
-/// Stands in for a line break when a multi-line command is drawn on one row.
-const NEWLINE_GLYPH: &str = "⏎";
 
 /// One command as fish recorded it.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -142,20 +140,12 @@ pub fn recent_first(entries: Vec<Entry>) -> Vec<Entry> {
 /// A row is one line by construction, so a multi-line command has to be folded
 /// into one — and the folding has to be visible, since `git commit -m 'first`
 /// run together with `second'` is not the command it would then appear to be.
-/// Tabs become spaces and other control characters are dropped, so a stray
-/// escape sequence in an old entry cannot repaint the terminal from a row
-/// nobody has even selected.
+///
+/// [`term::one_row`] is the whole of it: a shell history is foreign text like
+/// any other listing's, and the rule for drawing foreign text on a row belongs
+/// in one place rather than once per source.
 pub fn one_line(cmd: &str) -> String {
-    let joiner = format!(" {NEWLINE_GLYPH} ");
-    cmd.lines()
-        .map(|line| {
-            line.chars()
-                .map(|c| if c == '\t' { ' ' } else { c })
-                .filter(|c| !c.is_control())
-                .collect::<String>()
-        })
-        .collect::<Vec<_>>()
-        .join(&joiner)
+    term::one_row(cmd)
 }
 
 /// Width of a [`stamp`], so an entry fish recorded without a `when:` can hold
@@ -361,7 +351,7 @@ mod tests {
     /// never ran, and selecting it still yields the real multi-line text.
     #[test]
     fn folding_a_command_leaves_a_visible_mark() {
-        assert!(one_line("a\nb").contains(NEWLINE_GLYPH));
+        assert!(one_line("a\nb").contains(term::NEWLINE_GLYPH));
     }
 
     /// An escape sequence pasted into a shell years ago is still sitting in the

--- a/src/main.rs
+++ b/src/main.rs
@@ -443,7 +443,13 @@ enum HistoryCmd {
     /// Fuzzy-select a past command and print it
     Sel {
         /// Text to open the search box with
-        #[arg(short, long, value_name = "TEXT")]
+        ///
+        /// Takes a value beginning with `-` — the fish integration passes
+        /// whatever is on the command line, and a half-typed `--version` is
+        /// text to search for, not a flag. Without this, ctrl-r would fail
+        /// before opening, silently, since a key binding has nowhere to
+        /// report an error.
+        #[arg(short, long, value_name = "TEXT", allow_hyphen_values = true)]
         query: Option<String>,
         /// End the printed command with a NUL rather than a newline
         ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,20 +21,16 @@ use scriv::term::ColorChoice;
 use scriv::{Ctx, Reported, cmd, shell};
 
 /// Usage examples appended to the top-level help.
+///
+/// Three, and one of each *kind* rather than one per command group: what to run
+/// first, how a `sel` composes into the shell, and a verb acting on its own.
+/// A line per group was thirteen lines of the same shape, which is a wall to
+/// scroll past rather than something read — and the list of commands is already
+/// directly above it. Anything more specific is a `--help` away.
 const EXAMPLES: &str = "\x1b[1;92mExamples:\x1b[0m
   scriv config init            Write a starter configuration
-  scriv config check           Check your setup and report what is wrong
-  scriv repo sel               Fuzzy-select a repository, print its path
   cd (scriv repo sel)          Jump to a repository (fish)
-  scriv repo clone             Select an owner, then repositories to clone
-  scriv file add <path>        Track a file you visit often
-  scriv edit                   Select a file under the current directory, edit it
-  scriv edit --tracked         Select one of your tracked files and edit it
-  scriv branch checkout        Select a local or remote branch and switch to it
-  scriv pr checkout            Select a GitHub pull request and check it out
-  scriv proc kill              Select running processes and signal them
-  scriv history sel            Fuzzy-search your fish history for a command
-  scriv init fish | source     Load shell integration + completions";
+  scriv pr checkout            Select a GitHub pull request and check it out";
 
 /// Help styling matching cargo: bright-green bold headers and usage,
 /// bright-cyan bold literals (command and flag names), cyan placeholders.
@@ -84,13 +80,13 @@ struct Cli {
 #[command(disable_help_subcommand = true)]
 enum Command {
     /// List and select the Git repositories under your search paths
-    #[command(alias = "r")]
+    #[command(visible_alias = "r")]
     Repo {
         #[command(subcommand)]
         command: RepoCmd,
     },
     /// Track the files you visit regularly
-    #[command(alias = "f")]
+    #[command(visible_alias = "f")]
     File {
         #[command(subcommand)]
         command: FileCmd,
@@ -100,7 +96,7 @@ enum Command {
     /// Selection comes from the current directory tree, honouring `.gitignore`,
     /// or from your tracked files with `--tracked`. Selecting several opens them
     /// all. The editor is `$VISUAL`, then `$EDITOR`.
-    #[command(alias = "e")]
+    #[command(visible_alias = "e")]
     Edit {
         /// Files to open; omit to select interactively
         #[arg(value_name = "FILE")]
@@ -115,7 +111,7 @@ enum Command {
     /// remote-only ones, each most recently committed to first. In a branch
     /// selector, ctrl-r fetches from every remote and reloads the list without
     /// closing the selector.
-    #[command(alias = "b")]
+    #[command(visible_alias = "b")]
     Branch {
         #[command(subcommand)]
         command: BranchCmd,
@@ -135,7 +131,7 @@ enum Command {
     /// it was started with rather than by its name alone. scriv's own process
     /// and everything that spawned it are never listed: killing the shell or
     /// the terminal is not a thing to be one keystroke away from.
-    #[command(alias = "pc")]
+    #[command(visible_alias = "pc")]
     Proc {
         #[command(subcommand)]
         command: ProcCmd,
@@ -150,13 +146,13 @@ enum Command {
     ///
     /// The date is shown but never searched: it is digits at the front of every
     /// row, and matching it would rank timestamps above commands.
-    #[command(alias = "h")]
+    #[command(visible_alias = "h")]
     History {
         #[command(subcommand)]
         command: HistoryCmd,
     },
     /// Manage the configuration
-    #[command(alias = "c")]
+    #[command(visible_alias = "c")]
     Config {
         #[command(subcommand)]
         command: ConfigCmd,
@@ -174,7 +170,7 @@ enum Command {
 #[derive(Subcommand)]
 enum RepoCmd {
     /// List every repository found under your search paths
-    #[command(alias = "list")]
+    #[command(visible_alias = "list")]
     Ls {
         /// Return absolute file paths
         #[arg(short = 'A', long)]
@@ -216,7 +212,7 @@ enum RepoCmd {
 #[derive(Subcommand)]
 enum FileCmd {
     /// List known files
-    #[command(alias = "list")]
+    #[command(visible_alias = "list")]
     Ls {
         /// Show file existence indicators
         #[arg(long)]
@@ -276,7 +272,7 @@ impl BranchScope {
 #[derive(Subcommand)]
 enum BranchCmd {
     /// List local and remote branches
-    #[command(alias = "list")]
+    #[command(visible_alias = "list")]
     Ls {
         /// Show the current-branch marker, local/both/remote tag, and last commit
         #[arg(long)]
@@ -293,7 +289,7 @@ enum BranchCmd {
     ///
     /// Checking out a remote-only branch creates the matching local branch and
     /// sets its upstream.
-    #[command(aliases = ["co", "switch"])]
+    #[command(visible_aliases = ["co", "switch"])]
     Checkout {
         /// Branch to check out, e.g. `main` or `origin/feature`
         branch: Option<String>,
@@ -344,7 +340,7 @@ impl MergeMethodArg {
 #[derive(Subcommand)]
 enum PrCmd {
     /// List pull requests
-    #[command(alias = "list")]
+    #[command(visible_alias = "list")]
     Ls {
         /// Also show the state tag, source branch, and last-updated date
         ///
@@ -360,7 +356,7 @@ enum PrCmd {
         scope: PrScope,
     },
     /// Check out a pull request's branch; omit the number to select one
-    #[command(alias = "co")]
+    #[command(visible_alias = "co")]
     Checkout {
         /// Pull request number
         number: Option<u64>,
@@ -399,7 +395,7 @@ enum PrCmd {
 #[derive(Subcommand)]
 enum ProcCmd {
     /// List running processes, busiest first
-    #[command(alias = "list")]
+    #[command(visible_alias = "list")]
     Ls {
         /// Also show the owner, CPU share and how long it has been running
         ///
@@ -432,7 +428,7 @@ enum ProcCmd {
 #[derive(Subcommand)]
 enum HistoryCmd {
     /// List past commands, most recent first
-    #[command(alias = "list")]
+    #[command(visible_alias = "list")]
     Ls {
         /// Prefix each command with the local date and time it was last run
         ///

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -10,6 +10,8 @@ use std::collections::HashSet;
 
 use anyhow::{Result, bail};
 
+use crate::term;
+
 /// The `ps` field list scriv reads, in the order [`parse`] expects.
 ///
 /// The trailing `=` on each field suppresses its header, so every line is a
@@ -50,6 +52,11 @@ impl Process {
 /// Unparseable lines are skipped rather than failing the listing: `ps` prints a
 /// process whose command it cannot read as a blank or truncated line, and one
 /// of those must not take the whole selector down with it.
+///
+/// A command line is the least trustworthy text scriv handles: every process on
+/// the machine chooses its own argv, and `proc ls` writes it to a terminal. It
+/// is made safe here rather than at each of the three places that draw it — see
+/// [`term::one_row`].
 pub fn parse(text: &str) -> Vec<Process> {
     text.lines().filter_map(parse_line).collect()
 }
@@ -67,13 +74,13 @@ fn parse_line(line: &str) -> Option<Process> {
         return None;
     }
     Some(Process {
-        user: fields[0].to_string(),
+        user: term::one_row(fields[0]),
         pid: fields[1].parse().ok()?,
         ppid: fields[2].parse().ok()?,
         cpu: fields[3].parse().ok()?,
         mem: fields[4].parse().ok()?,
-        elapsed: fields[5].to_string(),
-        command: command.to_string(),
+        elapsed: term::one_row(fields[5]),
+        command: term::one_row(command),
     })
 }
 
@@ -94,6 +101,59 @@ pub fn ancestry(processes: &[Process], pid: i32) -> HashSet<i32> {
         current = parent.ppid;
     }
     chain
+}
+
+/// Why a pid given on the command line will not be signalled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Refusal {
+    /// `0` or negative. To `kill(2)` these are not processes at all: `0` is the
+    /// caller's own process group, `-1` is every process the user may signal,
+    /// and any other negative number is the process group of its absolute
+    /// value. `scriv proc kill -- -1` would end the login session — from a
+    /// command whose entire premise is that the shell is not reachable by one
+    /// keystroke.
+    NotAProcess,
+    /// scriv itself, or something that spawned it — the chain that runs up
+    /// through the shell to the terminal emulator. The selector has never
+    /// offered these; naming one explicitly must not be the way around that.
+    OwnAncestry,
+}
+
+impl Refusal {
+    pub fn reason(self) -> &'static str {
+        match self {
+            Self::NotAProcess => {
+                "not a process id — `0` means this process group and a negative \
+                 number means a whole process group; use `kill` directly if that \
+                 is what you meant"
+            }
+            Self::OwnAncestry => "scriv itself or a process that spawned it",
+        }
+    }
+}
+
+/// Check pids given as arguments against the rules the selector enforces by
+/// simply never offering the rows.
+///
+/// The interactive path filters its list through [`selectable`], so a pid that
+/// reaches [`crate::cmd::proc::kill`] from the selector is already known to be
+/// safe. A pid typed on the command line has been through none of that, and
+/// `kill` reads `0` and negatives as process *groups* — so the one path with no
+/// list to filter is also the one that can take out the session. Same rules,
+/// applied to the arguments.
+pub fn refuse(processes: &[Process], self_pid: i32, pids: &[i32]) -> Vec<(i32, Refusal)> {
+    let own = ancestry(processes, self_pid);
+    pids.iter()
+        .filter_map(|&pid| {
+            if pid <= 0 {
+                Some((pid, Refusal::NotAProcess))
+            } else if own.contains(&pid) {
+                Some((pid, Refusal::OwnAncestry))
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 /// The processes worth offering, busiest first.
@@ -331,6 +391,17 @@ joakim          70123 70100    0.0  0.4       01:20 -fish
         assert_eq!(procs[2].name(), "-fish");
     }
 
+    /// Every process on the machine chooses its own argv, and `proc ls` writes
+    /// it to a terminal. An escape that reached it could erase the rows around
+    /// it, so a listing could be made to hide the very process being hunted.
+    #[test]
+    fn a_command_line_cannot_carry_an_escape_out_of_ps() {
+        let procs = parse("joakim 501 1 0.0 0.1 01:00 /bin/evil \x1b[2K\x1b[1;32mhidden\n");
+        assert_eq!(procs.len(), 1);
+        assert!(!procs[0].command.contains('\x1b'), "{:?}", procs[0].command);
+        assert_eq!(procs[0].command, "/bin/evil [2K[1;32mhidden");
+    }
+
     /// The chain scriv must never offer: itself, the shell that ran it, and on
     /// up to the terminal. `-9` on any of it ends the session.
     #[test]
@@ -342,6 +413,46 @@ joakim          70123 70100    0.0  0.4       01:20 -fish
             chain.contains(&70100),
             "its parent, even though ps did not list it"
         );
+    }
+
+    /// `kill` reads `0` and negatives as process *groups*, not processes: `0`
+    /// is the caller's own group and `-1` is every process the user may signal.
+    /// `scriv proc kill -- -1` would end the login session, from the one command
+    /// that goes out of its way never to offer the shell.
+    #[test]
+    fn a_pid_that_is_really_a_process_group_is_refused() {
+        let procs = sample();
+        for pid in [0, -1, -70123] {
+            let refused = refuse(&procs, 501, &[pid]);
+            assert_eq!(
+                refused,
+                vec![(pid, Refusal::NotAProcess)],
+                "{pid} reached kill"
+            );
+        }
+    }
+
+    /// The selector never offers scriv's own chain, and naming a pid on the
+    /// command line must not be the way around that — it is the path with no
+    /// list to have filtered.
+    #[test]
+    fn an_ancestor_named_as_an_argument_is_refused_too() {
+        let procs = sample();
+        // 70123 is `-fish`, whose parent 70100 stands in for the terminal.
+        assert_eq!(
+            refuse(&procs, 70123, &[70123]),
+            vec![(70123, Refusal::OwnAncestry)]
+        );
+        assert_eq!(
+            refuse(&procs, 70123, &[70100]),
+            vec![(70100, Refusal::OwnAncestry)]
+        );
+    }
+
+    /// An ordinary pid is not refused, or the command would do nothing at all.
+    #[test]
+    fn an_unrelated_pid_passes() {
+        assert!(refuse(&sample(), 70123, &[501, 1]).is_empty());
     }
 
     /// A table read while processes are exiting can contain a ppid loop. The

--- a/src/term.rs
+++ b/src/term.rs
@@ -303,6 +303,57 @@ impl Drop for HangupWatch {
     }
 }
 
+/// Stands in for a line break in text folded onto one row.
+pub const NEWLINE_GLYPH: &str = "⏎";
+
+/// Text from outside scriv, made safe to draw on one row of a terminal.
+///
+/// Everything scriv lists comes from somewhere it does not control — a pull
+/// request title written by whoever opened it, the argv of any process on the
+/// machine, a command typed into a shell years ago — and a listing writes it
+/// straight to a terminal, which *acts on* what it is sent rather than showing
+/// it. `\x1b[2K` erases the row it was drawn on, `\x1b[32m` paints a failing
+/// check green: unfiltered, a listing can be made to say the opposite of what
+/// scriv found. Control characters are therefore dropped rather than passed on,
+/// which is also why scriv's own colour is applied *after* this, never before.
+///
+/// Newlines fold to [`NEWLINE_GLYPH`] rather than wrapping. One row per entry
+/// is what makes `wc -l` and `grep` mean what they look like they mean, and a
+/// title carrying a newline could otherwise forge an entire extra row.
+///
+/// Tabs become a single space: a tab is not a control the terminal acts on
+/// dangerously, but it is one whose width depends on where in the row it lands,
+/// which is enough to knock every column after it out of line.
+pub fn one_row(text: &str) -> String {
+    let joiner = format!(" {NEWLINE_GLYPH} ");
+    text.lines()
+        .map(drop_controls)
+        .collect::<Vec<_>>()
+        .join(&joiner)
+}
+
+/// [`one_row`] for text that is allowed to keep its line breaks — a preview
+/// pane, which is a block rather than a row.
+pub fn block(text: &str) -> String {
+    text.lines()
+        .map(drop_controls)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// One line of foreign text with its control characters removed.
+///
+/// `char::is_control` is the Unicode `Cc` category, so this covers the C1
+/// controls (`U+0080`–`U+009F`) as well as the ASCII ones — on a terminal in a
+/// UTF-8 locale those are inert, but on one that is not, `U+009B` *is* a
+/// control sequence introducer.
+fn drop_controls(line: &str) -> String {
+    line.chars()
+        .map(|c| if c == '\t' { ' ' } else { c })
+        .filter(|c| !c.is_control())
+        .collect()
+}
+
 /// Wrap `text` in an ANSI 256-colour sequence when `on`, so the same colour
 /// indices the selector uses also drive plain listings.
 pub fn paint(text: &str, color: u8, on: bool) -> String {
@@ -499,6 +550,59 @@ impl Drop for Spinner {
 
 #[cfg(test)]
 mod tests {
+    use super::{NEWLINE_GLYPH, block, one_row};
+
+    /// The whole point: an escape sequence in foreign text must not reach the
+    /// terminal, which acts on what it is sent. `\x1b[2K` erases the row the
+    /// text was drawn on — enough to make a listing show fewer entries than it
+    /// found.
+    #[test]
+    fn control_characters_never_survive_a_row() {
+        let row = one_row("ok\x1b[2K\x1b[1;31mFAKE\x07\x7f");
+        assert!(!row.contains('\x1b'), "{row:?}");
+        assert_eq!(row, "ok[2K[1;31mFAKE");
+    }
+
+    /// The C1 controls too: on a terminal that is not in a UTF-8 locale,
+    /// `U+009B` *is* a control sequence introducer.
+    #[test]
+    fn c1_controls_are_dropped_as_well() {
+        assert_eq!(one_row("a\u{9b}31mb"), "a31mb");
+    }
+
+    /// A row is one line by construction, so a newline has to become visible
+    /// rather than wrap: unfolded, a pull request title carrying one would forge
+    /// an entire extra row in `pr ls`.
+    #[test]
+    fn a_newline_folds_into_one_visible_row() {
+        let row = one_row("first\nsecond");
+        assert!(!row.contains('\n'), "{row:?}");
+        assert_eq!(row, format!("first {NEWLINE_GLYPH} second"));
+    }
+
+    /// A tab's width depends on where in the row it lands, which is enough to
+    /// knock every column after it out of line.
+    #[test]
+    fn a_tab_becomes_one_space() {
+        assert_eq!(one_row("a\tb"), "a b");
+    }
+
+    /// Ordinary text is left exactly as it was — including the non-ASCII that
+    /// makes up most repository descriptions.
+    #[test]
+    fn text_with_nothing_wrong_with_it_is_unchanged() {
+        for text in ["plain", "æøå — ünïcode", "✓ passed", ""] {
+            assert_eq!(one_row(text), text);
+        }
+    }
+
+    /// A preview pane is a block, not a row: its line breaks are the layout.
+    /// Everything else is still dropped.
+    #[test]
+    fn a_block_keeps_its_line_breaks_and_nothing_else() {
+        assert_eq!(block("a\n\x1b[2Kb"), "a\n[2Kb");
+    }
+
     /// A writer that takes `ok` complete lines and then fails with `kind`,
     /// standing in for a `head` that has read its rows and gone.
     ///

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -231,6 +231,54 @@ fn every_registry_exposes_sel() {
     }
 }
 
+/// The fish integration hands `--query` whatever is on the command line, so the
+/// value can perfectly well start with a `-`. Rejected as a flag, ctrl-r would
+/// fail before the selector opened — and a key binding has nowhere to report an
+/// error, so it would simply appear to do nothing.
+///
+/// The run gets no terminal, so it fails at the selector rather than at parsing:
+/// "needs a terminal" is the proof the argument was accepted.
+#[test]
+fn a_history_query_may_begin_with_a_dash() {
+    let sandbox = Sandbox::new();
+    let history = sandbox.home().join(".local/share/fish/fish_history");
+    std::fs::create_dir_all(history.parent().unwrap()).unwrap();
+    std::fs::write(&history, "- cmd: git status\n  when: 1700000000\n").unwrap();
+
+    let run = sandbox.run(&["history", "sel", "--query", "--version"]);
+    assert!(
+        !run.stderr.contains("a value is required"),
+        "the query was read as a flag: {}",
+        run.stderr
+    );
+    assert!(
+        run.stderr.contains("needs a terminal"),
+        "expected to get as far as the selector: {}",
+        run.stderr
+    );
+}
+
+/// A slug is a positional argument to `gh` and a component of the path a clone
+/// is written to, so one beginning with `-` is read as a flag and one carrying
+/// `..` walks out of the configured root.
+#[test]
+fn repo_clone_refuses_a_slug_github_could_not_have_issued() {
+    let sandbox = Sandbox::new();
+    sandbox.write_config(&format!(
+        "[repo]\nroot = {:?}\n",
+        sandbox.home().join("dev").to_str().unwrap()
+    ));
+    for slug in ["../../etc/passwd", "acme/../../etc"] {
+        let run = sandbox.run(&["repo", "clone", slug]);
+        run.code(1);
+        assert!(
+            run.stderr.contains("not a GitHub owner"),
+            "{slug} was accepted: {}",
+            run.stderr
+        );
+    }
+}
+
 // --- config -----------------------------------------------------------------
 
 /// The starter config is what a new user gets, and the very next thing they do
@@ -517,6 +565,18 @@ fn file_add_ls_and_remove_round_trip() {
     let ls = sandbox.run(&["file", "ls"]);
     ls.ok();
     assert_eq!(ls.lines(), vec![note.to_str().unwrap()]);
+
+    // A path containing a newline is not something a one-path-per-line file can
+    // hold: written, it comes back as two entries and neither is the file, so
+    // `file rm` could never match the path it was given again.
+    let bad = sandbox.run(&["file", "add", "one\ntwo.md"]);
+    bad.code(1);
+    assert!(bad.stderr.contains("one path per line"), "{}", bad.stderr);
+    assert_eq!(
+        sandbox.run(&["file", "ls"]).ok().lines(),
+        vec![note.to_str().unwrap()],
+        "the rejected path reached the list anyway"
+    );
 
     let removed = sandbox.run(&["file", "rm", note.to_str().unwrap()]);
     removed.ok();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -200,6 +200,48 @@ fn an_unknown_command_is_a_usage_error() {
     assert!(run.stdout.is_empty(), "usage errors belong on stderr");
 }
 
+/// An alias the binary accepts and the help does not mention is a name only
+/// its author knows about. clap hides `alias` and shows `visible_alias`, and
+/// the two are one keyword apart, so nothing but reading the rendered help
+/// proves which one was written.
+#[test]
+fn help_names_the_aliases_the_binary_accepts() {
+    let sandbox = Sandbox::new();
+    let top = sandbox.run(&["--help"]);
+    top.ok();
+    for alias in ["r", "f", "e", "b", "pc", "h", "c"] {
+        assert!(
+            top.stdout.contains(&format!("[aliases: {alias}]")),
+            "`{alias}` is accepted but unmentioned:\n{}",
+            top.stdout
+        );
+    }
+
+    let branch = sandbox.run(&["branch", "--help"]);
+    branch.ok();
+    assert!(
+        branch.stdout.contains("[aliases: co, switch]"),
+        "{}",
+        branch.stdout
+    );
+}
+
+/// The examples are a fixed three, one of each kind rather than one per command
+/// group — the group list is directly above them and already names every one.
+#[test]
+fn the_help_examples_stay_at_three() {
+    let sandbox = Sandbox::new();
+    let run = sandbox.run(&["--help"]);
+    run.ok();
+    let examples = run
+        .stdout
+        .split_once("Examples:")
+        .expect("no examples block")
+        .1;
+    let lines = examples.lines().filter(|l| !l.trim().is_empty()).count();
+    assert_eq!(lines, 3, "the examples block has grown:{examples}");
+}
+
 /// Abbreviations are part of the surface people actually type. They are aliases
 /// in clap, so nothing but a run of the binary proves they resolve.
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -848,6 +848,45 @@ fn proc_kill_refuses_an_unknown_signal_before_selecting() {
     assert!(run.stderr.contains("known signals are"), "{}", run.stderr);
 }
 
+/// To `kill`, `0` and a negative number are process *groups*, not processes:
+/// `0` is the caller's own group and `-1` is every process the user may signal.
+/// clap takes them happily as `i32`, so nothing but this stands between
+/// `scriv proc kill -- -1` and the end of the login session — from the one
+/// command that deliberately never offers the shell in its selector.
+///
+/// Run for real, with a signal that would work: the point is that the refusal
+/// happens, and a test that could only pass because the signal was invalid
+/// would prove nothing about the guard.
+#[test]
+fn proc_kill_refuses_a_pid_that_is_really_a_process_group() {
+    let sandbox = Sandbox::new();
+    for pid in ["0", "-1"] {
+        let run = sandbox.run(&["proc", "kill", "--signal", "CONT", "--", pid]);
+        run.code(1);
+        assert!(
+            run.stderr.contains("refusing to signal"),
+            "{pid} was not refused: {}",
+            run.stderr
+        );
+        assert!(run.stdout.is_empty(), "{pid} was signalled: {}", run.stdout);
+    }
+}
+
+/// An ordinary pid is not caught by that guard — a check that refused
+/// everything would pass the test above and leave the command useless.
+#[test]
+fn proc_kill_still_accepts_an_ordinary_pid() {
+    let sandbox = Sandbox::new();
+    // Almost certainly not a live process, so `kill` reports it as gone; what
+    // matters is that scriv got as far as asking.
+    let run = sandbox.run(&["proc", "kill", "--signal", "CONT", "2147483646"]);
+    assert!(
+        !run.stderr.contains("refusing to signal"),
+        "an ordinary pid was refused: {}",
+        run.stderr
+    );
+}
+
 /// `--force` *is* a signal choice, so offering it alongside `--signal` would be
 /// asking which of two answers to the same question wins.
 #[test]


### PR DESCRIPTION
A technical and security review of the CLI surface, plus the fixes. Every
finding below was reproduced against the built binary before it was fixed, and
each has a regression test.

## What was wrong

**1. Foreign text reached the terminal with its control characters intact.**
Everything scriv lists comes from somewhere it does not control, and a listing
writes it straight to a terminal — which *acts on* what it is sent. `\e[2K`
erases the row it was drawn on; `\e[32m` paints a failing check green. So
`scriv pr ls` could be made to show fewer pull requests than it found, or show
a red ✗ as a green ✓.

Reproduced against `proc ls`, where any local process controls its own argv:

```
$ perl -e 'sleep 30' -- $'X\e[2K\e[1;31mFAKE\e[0m' &
$ scriv proc ls | grep FAKE | od -c
0000020   X   ^   [   [   2   K   ^   [   [   1   ;   3   1   m   F   A   K   E
```

The same `term::Listing` path carries GitHub PR titles, authors, branch names
and repository descriptions. `history` was already safe — it folds control
characters out when it renders a row — and that rule is now the shared one.

**2. `scriv proc kill <pid>` skipped every guard the selector applies.** The
selector deliberately never offers scriv, the shell that ran it, or the
terminal above that. An explicit pid went through none of that filtering — and
`kill` reads `0` and negative numbers as process *groups*, so
`scriv proc kill -- -1` signalled every process the user could signal. clap
took it as an ordinary `i32`; verified by running it with an invalid signal, so
the parse was proved without signalling anything.

**3. `scriv edit` gave the editor no `--`.** A file named `-c` in the walked
tree arrives as a bare `-c`, and to vim that is an Ex command to run. clap
blocks this on the argument path; the selector path does not go through clap.

**4. `history sel --query` rejected values starting with `-`**, so ctrl-r did
nothing at all whenever the command line began with a dash — silently, since a
key binding has nowhere to report an error.

**5. A path containing a newline corrupted the known-files list** into two
entries, after which `file rm` could never match it again. Only a text editor
could repair it.

**6. `repo clone` passed its slug to `gh` unvalidated** and joined it onto the
configured root, so a leading `-` read as a flag and `..` escaped the root.
Latent — `gh` rejects the malformed slug today — but that is `gh`'s rule to
change, not scriv's guarantee.

## Where the fix went

Sanitisation is at the boundaries foreign text enters through — `gh`'s JSON and
`ps`'s output — rather than at each of the places that draw it, so no listing,
selector row or preview downstream has to remember to. A repository slug is
deliberately *not* sanitised: it is not display text but the name a clone is
made from, and quietly rewriting it would clone something other than what was
asked for. `gh::valid_slug` guards that one instead.

## Also in here

- The help examples are three, one of each *kind*, rather than one per command
  group — thirteen lines of identical shape sat directly below the list of
  commands that already named every one of them.
- Aliases were declared with clap's `alias`, which never appears in `--help`, so
  every abbreviation the binary accepted was one only its author knew about.
  They are `visible_alias` now, and a test reads them back out of the rendered
  help.
- Cargo.toml: all fifteen dependencies checked against the source, all in use.
  ratatui is the one that looks wrong in a program that is not a TUI — scriv
  implements skim's `SkimItem::display`, which *returns* a `ratatui::text::Line`,
  so it is a type dependency that must match the version skim was built against.
  That is the one comment kept; the rest said what the manifest already said.
- A short `## Releasing` section in the README. The steps were only in the git
  history.

## Trade-offs worth naming

- **`scriv edit` now passes `--`.** An editor that does not understand it would
  break. Every editor worth setting `$EDITOR` to does.
- **`proc kill` refuses the whole run** when any pid is bad, rather than
  skipping the bad ones — a list that was partly signalled and partly not is the
  hardest outcome to act on.
- **`valid_slug` is stricter than GitHub.** It allows letters, digits, `-`, `_`
  and `.`. If GitHub ever issues a name outside that, scriv refuses a name that
  works.

## The three docs

1. **CLI help.** `EXAMPLES` rewritten; `--query` documented as taking a leading
   dash and why; aliases now rendered. `CLAUDE.md` records both new rules — that
   the examples stay at three, and that aliases are declared `visible_alias`.
2. **README.md.** One new section, `## Releasing`. The command table and the
   key-binding sentence are unchanged; no command group was added or removed.
3. **`docs/demo.gif`.** Not re-recorded and does not need to be. The tape types
   `scriv branch checkout`, `scriv edit` and `scriv pr ls --status`; no row
   layout, colour or preview content changed, and the fixture's data contains no
   control characters for the new sanitising to alter. `make demo-check` passes
   locally.

`make` green, and each of the four commits builds and tests green on its own.