### PR TITLE
Split `edit` into `file` and `dir`, and widen the command descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,12 @@ done until the old wording is gone.
 `EXAMPLES` is three lines and stays three lines. It once carried one per
 command group, which was thirteen lines of identical shape sitting directly
 below the list of commands that already named every one of them — a wall to
-scroll past rather than something read. What it shows now is one of each
-*kind*: what to run first, how a `sel` composes into the shell, and a verb
-acting on its own. A new command group does not earn a line; it earns one only
-by being a kind of thing none of the three already demonstrates.
+scroll past rather than something read. What it shows now is the three
+commands worth the most: `pr checkout`, `branch switch`, `history sel`. Setup
+is deliberately not among them — `config init` is run once and the README
+already walks someone through it — and neither is anything a `--help` away. A
+new command group does not earn a line; it earns one only by displacing one of
+the three as something people reach for more often.
 
 Aliases are declared `visible_alias`, never `alias`. clap hides the latter, and
 a name the binary accepts but the help does not mention is exactly the drift
@@ -204,9 +206,17 @@ test that allocated a pty would be testing skim.
   status instead of printing a second, vaguer error line on top of git's.
 - **The top-level commands are registries; `edit` is the exception.**
   `repo`/`file`/`branch`/`pr`/`history` are each a set scriv knows about, with
-  `ls`/`sel` and a verb over that set. `edit` acts on the directory the user is
-  standing in, so it is a verb at the top level rather than one more noun — and
-  it has no `ls`. Resist filing ambient-directory work under a noun group.
+  `ls`/`sel` and a verb over that set. `edit` has subcommands too, but they are
+  not that: `file` and `dir` name what is being *looked for* in the tree the
+  user happens to be standing in, which is why neither has an `ls` — there is
+  no set to list without walking one. Resist filing ambient-directory work
+  under a noun group, and resist giving `edit` an `ls`.
+
+  `edit` with no subcommand is `edit file`, dispatched through the same arm so
+  the two spellings cannot drift apart. The cost is that a file actually named
+  `file` or `dir` needs `./file`, which is the ordinary shell answer to an
+  ambiguous first argument and is said in the help.
+
   `repo open` is the one place a registry verb reads the ambient directory, and
   only to skip a question it can already answer: in a repository it opens that
   one, `--select` asks anyway, and outside one it is the ordinary selector. The set

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ scriv config check         # confirm it all resolves
 | `scriv pr` | `ls` `sel` `checkout` `open` `merge` |
 | `scriv proc` | `ls` `sel` `kill` |
 | `scriv history` | `ls` `sel` |
-| `scriv edit` | a file below `$PWD`, opened in `$EDITOR` |
+| `scriv edit` | `file` `dir` — found below `$PWD`, opened in `$EDITOR` |
 
 `ls` prints the set, `sel` fuzzy-selects one line of it, and the other verbs
 act. Every `sel` composes: `cd (scriv repo sel)`. Each group takes a one-letter

--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -1,12 +1,16 @@
-//! `scriv edit` — fuzzy-find a file and open it in your editor.
+//! `scriv edit` — fuzzy-find a file or a directory and open it in your editor.
 //!
-//! Unlike the other commands, this one is a verb rather than a registry: it
-//! searches whatever directory you are in rather than a list scriv maintains.
-//! `--tracked` points the same selector at the known-files list instead.
+//! Unlike the other groups, this one is not a registry over a set scriv
+//! maintains: `file` and `dir` name what is being *looked for* in the tree the
+//! user is standing in, so neither has an `ls` and neither can be listed
+//! without walking. `--tracked` is the one exception, pointing `file` at the
+//! known-files list instead.
 //!
 //! Nothing here needs shell integration — a child process cannot change its
 //! parent's directory, which is why `repo sel` is wrapped in a fish function,
 //! but it can perfectly well inherit the terminal and run an editor in it.
+//! That holds for a directory too: opening one is the editor's business, not
+//! the shell's, and `cd` is what [`crate::cmd::repo`] is for.
 
 use std::io::ErrorKind;
 use std::path::Path;
@@ -15,28 +19,50 @@ use std::process::Command;
 use anyhow::{Result, anyhow, bail};
 
 use crate::path::{display_path, expand_tilde};
-use crate::select::{Preview, SelectItem, file_preview};
+use crate::select::{Preview, SelectItem, dir_preview, file_preview};
 use crate::{Ctx, Reported, files, select, walk};
 
-/// `scriv edit [FILE]...` — open `paths`, or select interactively when empty.
+/// `scriv edit file [FILE]...` — open `paths`, or select interactively when
+/// empty.
 ///
 /// With `tracked`, selection comes from the known-files list; otherwise from
 /// the current directory tree. Multiple selections open together, which is what
 /// an editor's buffer list is for.
-pub fn run(ctx: &Ctx, paths: &[String], tracked: bool) -> Result<()> {
-    let targets = if !paths.is_empty() {
-        paths.to_vec()
-    } else {
-        let selected = if tracked {
-            select_tracked(ctx)?
+pub fn file(ctx: &Ctx, paths: &[String], tracked: bool) -> Result<()> {
+    open_or_select(ctx, paths, || {
+        if tracked {
+            select_tracked(ctx)
         } else {
-            select_from_cwd(ctx)?
-        };
-        match selected {
+            select_files(ctx)
+        }
+    })
+}
+
+/// `scriv edit dir [DIR]...` — open `paths`, or select interactively when
+/// empty.
+///
+/// Every editor worth setting `$EDITOR` to opens a directory as something: a
+/// file browser, a project root, a tree pane. Which one is the editor's
+/// business — scriv's part is finding the directory without a `cd` and a `ls`
+/// per level.
+pub fn dir(ctx: &Ctx, paths: &[String]) -> Result<()> {
+    open_or_select(ctx, paths, || select_dirs(ctx))
+}
+
+/// Open `paths`, or whatever `select` yields when there are none.
+fn open_or_select(
+    ctx: &Ctx,
+    paths: &[String],
+    select: impl FnOnce() -> Result<Option<Vec<String>>>,
+) -> Result<()> {
+    let targets = if paths.is_empty() {
+        match select()? {
             Some(targets) => targets,
             // Cancelled: a conventional silent exit, nothing to open.
             None => return Ok(()),
         }
+    } else {
+        paths.to_vec()
     };
 
     // Selecting nothing is not an error either — the selector was simply left
@@ -55,7 +81,7 @@ pub fn run(ctx: &Ctx, paths: &[String], tracked: bool) -> Result<()> {
 /// showing the first is the difference between a selector that opens instantly
 /// and one that appears to hang. An empty tree simply gives an empty selector,
 /// as it would in `fzf`.
-fn select_from_cwd(ctx: &Ctx) -> Result<Option<Vec<String>>> {
+fn select_files(ctx: &Ctx) -> Result<Option<Vec<String>>> {
     // Paths stay relative to the working directory: the editor is launched from
     // it, and relative paths are what shows up in its buffer list.
     let items =
@@ -64,6 +90,23 @@ fn select_from_cwd(ctx: &Ctx) -> Result<Option<Vec<String>>> {
     cancellable(select::select_many_streamed(
         items,
         "Edit",
+        true,
+        &ctx.config.selector,
+    ))
+}
+
+/// Choose directories from the current directory tree.
+///
+/// [`select_files`] over [`walk::dirs`], with the preview built per row rather
+/// than taken from [`Preview::File`]: `bat` on a directory is an error message,
+/// and what identifies a directory is what is inside it.
+fn select_dirs(ctx: &Ctx) -> Result<Option<Vec<String>>> {
+    let items =
+        walk::dirs(Path::new(".")).map(|dir| SelectItem::plain(&dir).preview(dir_preview(&dir)));
+
+    cancellable(select::select_many_streamed(
+        items,
+        "Edit directory",
         true,
         &ctx.config.selector,
     ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,15 +22,15 @@ use scriv::{Ctx, Reported, cmd, shell};
 
 /// Usage examples appended to the top-level help.
 ///
-/// Three, and one of each *kind* rather than one per command group: what to run
-/// first, how a `sel` composes into the shell, and a verb acting on its own.
-/// A line per group was thirteen lines of the same shape, which is a wall to
-/// scroll past rather than something read — and the list of commands is already
-/// directly above it. Anything more specific is a `--help` away.
+/// Three, and the three worth the most: what people open scriv for every day.
+/// Setup is not among them — `config init` is run once, and the README already
+/// walks someone through it — and neither is anything a `--help` away. A line
+/// per command group was thirteen lines of the same shape sitting directly
+/// below the list that already named every one of them.
 const EXAMPLES: &str = "\x1b[1;92mExamples:\x1b[0m
-  scriv config init            Write a starter configuration
-  cd (scriv repo sel)          Jump to a repository (fish)
-  scriv pr checkout            Select a GitHub pull request and check it out";
+  scriv pr checkout            Select a GitHub pull request and check it out
+  scriv branch switch          Select a branch and switch to it
+  scriv history sel            Search the commands you have already run";
 
 /// Help styling matching cargo: bright-green bold headers and usage,
 /// bright-cyan bold literals (command and flag names), cyan placeholders.
@@ -79,25 +79,31 @@ struct Cli {
 #[derive(Subcommand)]
 #[command(disable_help_subcommand = true)]
 enum Command {
-    /// List and select the Git repositories under your search paths
+    /// Manage local Git repositories
     #[command(visible_alias = "r")]
     Repo {
         #[command(subcommand)]
         command: RepoCmd,
     },
-    /// Track the files you visit regularly
+    /// Manage commonly used files
     #[command(visible_alias = "f")]
     File {
         #[command(subcommand)]
         command: FileCmd,
     },
-    /// Fuzzy-find a file and open it in your editor
+    /// Open files and directories in $EDITOR
     ///
-    /// Selection comes from the current directory tree, honouring `.gitignore`,
-    /// or from your tracked files with `--tracked`. Selecting several opens them
-    /// all. The editor is `$VISUAL`, then `$EDITOR`.
-    #[command(visible_alias = "e")]
+    /// Selection comes from the current directory tree, honouring `.gitignore`.
+    /// Selecting several opens them all. The editor is `$VISUAL`, then
+    /// `$EDITOR`.
+    ///
+    /// With no subcommand this is `edit file`, which is what it is nearly
+    /// always reached for. A file or directory actually named `file` or `dir`
+    /// needs `./file` to tell it apart from the subcommand.
+    #[command(visible_alias = "e", args_conflicts_with_subcommands = true)]
     Edit {
+        #[command(subcommand)]
+        command: Option<EditCmd>,
         /// Files to open; omit to select interactively
         #[arg(value_name = "FILE")]
         files: Vec<String>,
@@ -105,7 +111,7 @@ enum Command {
         #[arg(short, long, conflicts_with = "files")]
         tracked: bool,
     },
-    /// Switch between local and remote git branches
+    /// Manage local and remote Git branches
     ///
     /// Listings lead with the current branch, then local branches, then
     /// remote-only ones, each most recently committed to first. In a branch
@@ -116,7 +122,7 @@ enum Command {
         #[command(subcommand)]
         command: BranchCmd,
     },
-    /// Work with GitHub pull requests (via the `gh` CLI)
+    /// Manage GitHub PRs
     ///
     /// In a pull request selector, ctrl-r asks GitHub again and reloads the list
     /// in place, for when a check has finished while you were looking at it.
@@ -124,7 +130,7 @@ enum Command {
         #[command(subcommand)]
         command: PrCmd,
     },
-    /// Find a running process and signal it
+    /// Manage system processes
     ///
     /// Rows come from a single `ps` call, busiest first, and carry the whole
     /// command line — arguments included — so a process is recognisable by what
@@ -136,7 +142,7 @@ enum Command {
         #[command(subcommand)]
         command: ProcCmd,
     },
-    /// Search the commands you have already run (fish)
+    /// Manage shell history
     ///
     /// Reads fish's history file directly — newest first, with repeats of a
     /// command collapsed onto the one row and dated with when it was last run.
@@ -164,6 +170,34 @@ enum Command {
     Init {
         /// Shell to emit integration for
         shell: Shell,
+    },
+}
+
+#[derive(Subcommand)]
+enum EditCmd {
+    /// Fuzzy-find a file and open it
+    ///
+    /// What `scriv edit` does with no subcommand.
+    #[command(visible_alias = "f")]
+    File {
+        /// Files to open; omit to select interactively
+        #[arg(value_name = "FILE")]
+        files: Vec<String>,
+        /// Select from your tracked files instead of the current directory
+        #[arg(short, long, conflicts_with = "files")]
+        tracked: bool,
+    },
+    /// Fuzzy-find a directory and open it
+    ///
+    /// The preview pane is what is directly inside each one. What an editor
+    /// does with a directory is its own business — a file browser, a project
+    /// root, a tree pane; scriv's part is finding it without a `cd` and a `ls`
+    /// per level.
+    #[command(visible_alias = "d")]
+    Dir {
+        /// Directories to open; omit to select interactively
+        #[arg(value_name = "DIR")]
+        dirs: Vec<String>,
     },
 }
 
@@ -526,7 +560,16 @@ fn run(cli: Cli) -> anyhow::Result<()> {
             FileCmd::Rm { file } => cmd::file::remove(&ctx, file.as_deref()),
             FileCmd::Prune { yes } => cmd::file::prune(&ctx, yes),
         },
-        Command::Edit { files, tracked } => cmd::edit::run(&ctx, &files, tracked),
+        // No subcommand is `edit file` with whatever was given at the top
+        // level, so the two spellings cannot drift into behaving differently.
+        Command::Edit {
+            command,
+            files,
+            tracked,
+        } => match command.unwrap_or(EditCmd::File { files, tracked }) {
+            EditCmd::File { files, tracked } => cmd::edit::file(&ctx, &files, tracked),
+            EditCmd::Dir { dirs } => cmd::edit::dir(&ctx, &dirs),
+        },
         Command::Branch { command } => match command {
             BranchCmd::Ls { status, scope } => {
                 cmd::branch::ls(&ctx, scope.filter(), status, scope.fetch)

--- a/src/select.rs
+++ b/src/select.rs
@@ -74,6 +74,17 @@ pub fn file_preview(path: &str) -> Preview {
     Preview::Command(file_preview_cmd(path))
 }
 
+/// The preview for a directory: what is directly inside it.
+///
+/// `ls` rather than a recursive listing, and capped at 200 rows: the pane is
+/// re-run on every move through the list, so it has to answer in the time it
+/// takes to scroll past. `-A` shows dotfiles without `.` and `..`, `-p` marks
+/// the subdirectories — enough to recognise a directory by what it contains.
+pub fn dir_preview(path: &str) -> Preview {
+    let path = quote(path);
+    Preview::Command(format!("ls -Ap -- {path} 2>&1 | head -n 200"))
+}
+
 /// The command behind [`Preview::File`] and [`file_preview`].
 fn file_preview_cmd(path: &str) -> String {
     let path = quote(path);

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -56,6 +56,36 @@ const QUEUE_BOUND: usize = 1024;
 /// nothing to grant from in here either: Full Disk Access is given to the
 /// terminal application, not to a process that asks for it.
 pub fn files(root: &Path) -> impl Iterator<Item = String> + Send + 'static {
+    walk(root, Kind::File)
+}
+
+/// Directories under `root`, as paths relative to `root`.
+///
+/// [`files`] in every other respect — same ignore rules, same streaming, same
+/// silence about what it could not read. `root` itself is not offered: `scriv
+/// edit dir` is for going somewhere else, and the editor is already being run
+/// from here.
+pub fn dirs(root: &Path) -> impl Iterator<Item = String> + Send + 'static {
+    walk(root, Kind::Dir)
+}
+
+/// Which entries a walk yields.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    File,
+    Dir,
+}
+
+impl Kind {
+    fn matches(self, entry: &ignore::DirEntry) -> bool {
+        entry.file_type().is_some_and(|ft| match self {
+            Self::File => ft.is_file(),
+            Self::Dir => ft.is_dir(),
+        })
+    }
+}
+
+fn walk(root: &Path, kind: Kind) -> impl Iterator<Item = String> + Send + 'static {
     let root = root.to_path_buf();
     let (tx, rx) = sync_channel::<String>(QUEUE_BOUND);
 
@@ -81,11 +111,17 @@ pub fn files(root: &Path) -> impl Iterator<Item = String> + Send + 'static {
                 let Ok(entry) = entry else {
                     return WalkState::Continue;
                 };
-                if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+                if !kind.matches(&entry) {
                     return WalkState::Continue;
                 }
                 let path = entry.path();
                 let rel = path.strip_prefix(&root).unwrap_or(path);
+                // The walk starts at `root`, which strips to nothing. A blank
+                // row is not a choice, and "here" is where the editor already
+                // is.
+                if rel.as_os_str().is_empty() {
+                    return WalkState::Continue;
+                }
                 match tx.send(rel.to_string_lossy().into_owned()) {
                     Ok(()) => WalkState::Continue,
                     // The receiver is gone: the user has selected or cancelled,
@@ -136,6 +172,50 @@ mod tests {
             !got.contains(&"ignored.txt".to_string()),
             ".gitignore not honoured: {got:?}"
         );
+    }
+
+    /// `edit dir` walks the same tree under the same rules and yields only the
+    /// directories — including the ones holding no files at all, which is
+    /// exactly the case a file walk could never surface.
+    #[test]
+    fn dirs_yields_directories_under_the_same_rules() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        fs::create_dir_all(root.join("src/cmd")).unwrap();
+        fs::create_dir_all(root.join("empty")).unwrap();
+        fs::write(root.join("src/main.rs"), "").unwrap();
+        fs::create_dir_all(root.join("node_modules/pkg")).unwrap();
+        fs::write(root.join(".gitignore"), "target\n").unwrap();
+        fs::create_dir_all(root.join("target/debug")).unwrap();
+
+        let got: Vec<String> = dirs(root).collect();
+
+        assert!(got.contains(&"src".to_string()), "{got:?}");
+        assert!(got.contains(&"src/cmd".to_string()), "{got:?}");
+        assert!(got.contains(&"empty".to_string()), "{got:?}");
+        assert!(
+            !got.iter().any(|d| d.contains("node_modules")),
+            "WALKER_SKIP dir leaked: {got:?}"
+        );
+        assert!(
+            !got.iter().any(|d| d.starts_with("target")),
+            ".gitignore not honoured: {got:?}"
+        );
+        assert!(
+            !got.iter().any(|d| d.ends_with(".rs")),
+            "a file reached the directory walk: {got:?}"
+        );
+    }
+
+    /// The walk starts at the root, which strips to an empty path. A blank row
+    /// is not something anyone can select, and "here" is where the editor is
+    /// already running.
+    #[test]
+    fn the_root_itself_is_not_offered() {
+        let dir = TempDir::new().unwrap();
+        fs::create_dir_all(dir.path().join("inner")).unwrap();
+        let got: Vec<String> = dirs(dir.path()).collect();
+        assert_eq!(got, vec!["inner".to_string()]);
     }
 
     /// fd reads `.fdignore` in addition to `.gitignore`; a user who keeps one

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -262,6 +262,35 @@ fn the_documented_abbreviations_resolve() {
     }
 }
 
+/// `scriv edit` with no subcommand is `edit file`, and both spellings reach the
+/// editor with the same arguments. `$EDITOR` is `echo` here, so what it was
+/// asked to open comes back on stdout — the one way to see the wiring without
+/// a terminal or a real editor.
+///
+/// The `--` is part of the contract: a file named `-c` is a filename, and to
+/// vim `-c` is an Ex command to run.
+#[test]
+fn edit_defaults_to_the_file_subcommand() {
+    let sandbox = Sandbox::new();
+    let bare = sandbox.run_with_env(&["edit", "notes.md"], &[("EDITOR", "echo")]);
+    bare.ok();
+    let explicit = sandbox.run_with_env(&["edit", "file", "notes.md"], &[("EDITOR", "echo")]);
+    explicit.ok();
+    assert_eq!(bare.stdout, explicit.stdout, "the two spellings disagree");
+    assert_eq!(bare.stdout.trim(), "-- notes.md");
+}
+
+/// `edit dir` takes its own positionals, so a directory reaches the editor the
+/// same way a file does. Without this, `dir` would be indistinguishable from a
+/// file named `dir`.
+#[test]
+fn edit_dir_opens_the_directories_it_is_given() {
+    let sandbox = Sandbox::new();
+    let run = sandbox.run_with_env(&["edit", "dir", "src", "tests"], &[("EDITOR", "echo")]);
+    run.ok();
+    assert_eq!(run.stdout.trim(), "-- src tests");
+}
+
 /// Every registry offers `sel` under that name. The command itself needs a
 /// terminal, but whether the verb exists at all is answerable without one — and
 /// a group that missed the rename would only show up as a broken key binding.


### PR DESCRIPTION
Three changes to the CLI surface.

**`scriv edit dir`** is the half that was missing. An editor opens a directory
as a file browser, a project root or a tree pane; reaching one previously meant
a `cd` and a `ls` per level. It walks the same tree under the same ignore rules
as `edit file`, and its preview is what is directly inside each row —
`bat` on a directory is an error message, and what identifies a directory is
its contents. Bounded to 200 lines like every other preview here.

**`scriv edit` with no subcommand is `edit file`**, dispatched through the same
match arm so the two spellings cannot drift into behaving differently. A test
asserts they produce identical editor invocations.

**The top-level descriptions** described their own implementation — "Find a
running process and signal it", "Reads fish's history file directly". A line in
a command list is for telling groups apart; the detail is a `--help` away.

**The examples** are now the three commands worth the most (`pr checkout`,
`branch switch`, `history sel`) rather than one of each kind. `config init` is
run once and the README already walks someone through it, so it was spending a
third of the block on a command nobody repeats.

## Trade-off worth naming

A file or directory actually named `file` or `dir` is now shadowed by the
subcommand and needs `./file`. That is the ordinary shell answer to an ambiguous
first argument, and the help says so — but it is a real behaviour change for
anyone who had such a file.

## The three docs

1. **CLI help.** `EditCmd` has doc comments on both subcommands and both
   aliases; `edit`'s own doc comment states the `./file` ambiguity. `EXAMPLES`
   rewritten, and `CLAUDE.md` updated on both counts — what the three examples
   are chosen for, and that `edit`'s subcommands are *not* a registry (they name
   what is being looked for, which is why neither has an `ls`).
2. **README.md.** The `scriv edit` table row now lists `file` and `dir`, so it
   matches what `scriv edit --help` prints. No new section; `edit` was already
   a row.
3. **`docs/demo.gif`.** Not re-recorded. The tape types `scriv edit`, which
   still opens the same file selector with the same rows and the same preview —
   nothing on screen changed. `make demo-check` passes locally.

`make` green.