### PR TITLE
Tell a development build apart from the release of the same name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,14 @@ jobs:
       id-token: write
       attestations: write
     steps:
+      # `fetch-depth: 0` is load-bearing, not thoroughness. `build.rs` decides
+      # whether this is a release by asking `git describe --tags
+      # --exact-match`, and the default shallow checkout fetches no tags at
+      # all — so every released binary would answer `--version` with a
+      # development string naming the commit it was built from.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
       # `rustup show` installs the pinned toolchain; the target is added
       # explicitly rather than trusted to rust-toolchain.toml's `targets`, which
       # is honoured only when the toolchain is first installed from that file.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,94 @@
+//! Decide what `scriv --version` reports.
+//!
+//! A binary built from a checkout is not the binary the release of the same
+//! name contains — it may be a commit ahead, or carry edits that were never
+//! pushed — and both used to say `0.2.1`. A bug report, or a `mise` install
+//! sitting beside a `make install`, had no way to tell them apart.
+//!
+//! So the version is the crate version only when this commit *is* a release:
+//! sitting exactly on a tag, with nothing modified. Anything else is a
+//! development build and says so, naming the commit it came from.
+//!
+//! Git is not required. A build from a packaged tarball has no repository to
+//! ask — `cargo package` excludes `.git` — and that is not a development build
+//! either, so it falls back to the crate version rather than failing.
+
+use std::process::{Command, Stdio};
+
+/// The paths whose contents decide what the binary *is*.
+///
+/// This list does two jobs, and it is the same list for both on purpose: cargo
+/// re-runs this script when one of them changes, and the dirty check asks git
+/// about exactly these. Let the two drift apart and the answer becomes a coin
+/// toss — a modified file that does not trigger a re-run leaves a stale
+/// `.dirty` behind, and one that triggers a re-run but is never asked about
+/// produces a `.dirty` that comes and goes.
+///
+/// It is deliberately not the whole worktree. An edited README does not make a
+/// different binary, and a version that changed because of one would be noise.
+const SOURCES: &[&str] = &["src", "build.rs", "Cargo.toml", "Cargo.lock"];
+
+fn main() {
+    // Without these the version freezes at whatever the first build saw: cargo
+    // does not watch `.git` on its own, so a commit changes nothing it can see.
+    // Naming any path at all also switches off the default whole-package watch,
+    // which is why the source paths are listed here too.
+    for path in SOURCES {
+        println!("cargo:rerun-if-changed={path}");
+    }
+    // A commit moves HEAD or the ref it points at, a checkout rewrites HEAD,
+    // and staging touches the index. Watching `refs` as a directory rather than
+    // resolving the current branch keeps this correct across a branch switch.
+    for path in [".git/HEAD", ".git/index", ".git/refs"] {
+        println!("cargo:rerun-if-changed={path}");
+    }
+
+    println!("cargo:rustc-env=SCRIV_VERSION={}", version());
+}
+
+fn version() -> String {
+    let crate_version = std::env::var("CARGO_PKG_VERSION").expect("cargo sets CARGO_PKG_VERSION");
+
+    // No repository to ask: a packaged or vendored build, which is the release
+    // it claims to be.
+    let Some(sha) = git(&["rev-parse", "--short=7", "HEAD"]) else {
+        return crate_version;
+    };
+
+    let mut status = vec!["status", "--porcelain", "--untracked-files=no", "--"];
+    status.extend(SOURCES);
+    let dirty = git(&status).is_some_and(|out| !out.is_empty());
+    let tagged = git(&["describe", "--tags", "--exact-match", "HEAD"]).is_some();
+
+    if tagged && !dirty {
+        return crate_version;
+    }
+
+    // Dot-separated rather than `+sha`, so the whole thing stays one token for
+    // anything splitting `scriv --version` on whitespace.
+    let mut version = format!("{crate_version}-dev.{sha}");
+    if dirty {
+        version.push_str(".dirty");
+    }
+    version
+}
+
+/// Run `git` with `args`, returning its trimmed stdout, or `None` when git is
+/// missing, this is not a repository, or the command failed.
+///
+/// `--no-optional-locks` for the same reason the preview panes use it: a plain
+/// `git status` rewrites the index, and a build should not take the
+/// repository's index lock away from whatever the user is running in it.
+fn git(args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("--no-optional-locks")
+        .args(args)
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,15 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
+/// What `scriv --version` reports.
+///
+/// The crate version when this commit is a release — sitting exactly on a tag
+/// with nothing modified — and `<version>-dev.<sha>[.dirty]` otherwise, so a
+/// binary built from a checkout is never mistaken for the release of the same
+/// name. Computed at compile time by `build.rs`, which is where the reasoning
+/// lives.
+pub const VERSION: &str = env!("SCRIV_VERSION");
+
 use config::Config;
 use logger::Logger;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ const STYLES: Styles = Styles::styled()
 #[derive(Parser)]
 #[command(
     name = "scriv",
-    version,
+    version = scriv::VERSION,
     about = "Provides fuzzy-completion for various local and remote resources.",
     after_help = EXAMPLES,
     styles = STYLES,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -176,17 +176,41 @@ fn help_lists_every_top_level_command() {
 }
 
 /// `--version` has to print the version cargo built, not a hardcoded string
-/// that stops being true at the next release.
+/// that stops being true at the next release — and it has to say when the
+/// binary is *not* the release of that name.
+///
+/// The shape is asserted rather than the exact string, because both forms are
+/// correct depending on where the build happened: exactly the crate version
+/// when the commit is a clean tag or there is no repository to ask, and
+/// `<version>-dev.<sha>[.dirty]` from any checkout that is neither. A test
+/// demanding one of them would fail in CI or on a release runner.
 #[test]
-fn version_reports_the_crate_version() {
+fn version_reports_the_crate_version_and_flags_a_development_build() {
     let sandbox = Sandbox::new();
     let run = sandbox.run(&["--version"]);
     run.ok();
+
+    let version = run
+        .stdout
+        .trim()
+        .strip_prefix("scriv ")
+        .unwrap_or_else(|| panic!("unexpected --version output: {}", run.stdout));
+    let crate_version = env!("CARGO_PKG_VERSION");
+
+    let Some(dev) = version.strip_prefix(crate_version) else {
+        panic!("`{version}` does not start with the crate version {crate_version}");
+    };
     assert!(
-        run.stdout.contains(env!("CARGO_PKG_VERSION")),
-        "{}",
-        run.stdout
+        dev.is_empty() || dev.starts_with("-dev."),
+        "`{version}` is neither the release version nor a development build",
     );
+    if let Some(rest) = dev.strip_prefix("-dev.") {
+        let sha = rest.strip_suffix(".dirty").unwrap_or(rest);
+        assert!(
+            !sha.is_empty() && sha.chars().all(|c| c.is_ascii_hexdigit()),
+            "`{version}` names no commit",
+        );
+    }
 }
 
 /// A mistyped command is a usage error, and the conventional status for one is


### PR DESCRIPTION
A binary built from a checkout said `0.2.1`, and so did the `0.2.1` on GitHub,
though they need not contain the same code — the local one may be a commit
ahead, or carry edits that were never pushed. `make install` beside a `mise`
install left no way to tell which one was running.

`scriv --version` now reports the crate version only when the commit *is* a
release: exactly on a tag, with nothing modified. Anything else is
`0.2.1-dev.<sha>`, plus `.dirty` when the sources differ from the commit.

Verified against every state, in order:

| state | `--version` |
| --- | --- |
| dirty worktree | `0.2.1-dev.3d9be47.dirty` |
| clean, untagged | `0.2.1-dev.85f7b5f` |
| clean, on a tag | `0.2.1` |
| tagged, file touched but unchanged | `0.2.1` |
| tagged, file edited | `0.2.1-dev.85f7b5f.dirty` |
| tagged, edit reverted | `0.2.1` |
| tag deleted | `0.2.1-dev.85f7b5f` |

## Two things that bit while writing this

**Cargo does not watch `.git`.** The first version of `build.rs` emitted no
`rerun-if-changed` at all, on the theory that cargo's default whole-package
watch would cover it. It does not cover `.git`, so the version froze at whatever
the first build saw — committing, tagging and untagging all reported the same
string. The git paths are named explicitly now.

**The watch set and the dirty check must be the same set.** Naming any path
switches off the default watch, so the source paths have to be listed too — and
if the list cargo watches differs from the list `git status` is asked about, the
answer becomes a coin toss: a modified file that does not trigger a re-run
leaves a stale `.dirty` behind, and one that triggers a re-run without being
asked about produces a `.dirty` that comes and goes. Both were observed. That is
what the shared `SOURCES` const is for, and why it is not the whole worktree —
an edited README does not make a different binary.

**`release.yml` now checks out with `fetch-depth: 0`.** The default shallow
checkout fetches no tags, so `git describe --exact-match` would fail and every
*released* binary would have called itself a development build. This is the one
change here that only proves itself on a real release.

## Trade-offs worth naming

- **Two `git` invocations per build-script run**, which now happens whenever
  `src/`, the manifests, or the git refs change. Measured in single-digit
  milliseconds against a build that takes 30s.
- **Dirtiness is scoped to what affects the binary.** An uncommitted README
  edit does not produce `.dirty`. That is deliberate and documented in
  `SOURCES`, but it does mean `.dirty` is not the same question `git status`
  answers.
- **A tarball with no `.git`** — what `cargo package` produces — falls back to
  the crate version rather than failing. A vendored build is not a development
  build.

## The three docs

1. **CLI help.** `--version` is clap's own flag and its output is the change;
   the existing test now asserts the *shape* of both valid forms rather than an
   exact string, since a release runner and a CI runner correctly disagree. No
   command or flag was added.
2. **README.md.** Untouched. The `## Releasing` section already says the tag is
   what releases; nothing about the install path or the platforms changed.
3. **`docs/demo.gif`.** Untouched and not re-recorded — the tape never runs
   `--version`, and no selector's output changed.

`make` green.