### PR TITLE
Add a fast `make check`, and check in the Claude Code config

### DIFF
--- a/.claude/hooks/no-commit-on-main.sh
+++ b/.claude/hooks/no-commit-on-main.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Refuse a commit that would land directly on `main`.
+#
+# CLAUDE.md says never to commit straight to main, and until now nothing
+# enforced it. The failure is not expensive to fix but it is expensive to fix
+# *well*: undoing it means a reset and a force-push over a branch other people
+# may already have pulled, which is exactly the kind of history rewrite the
+# same document says to stop and ask about.
+#
+# Reads the PreToolUse payload on stdin. Exit 2 blocks the command and hands
+# this script's stderr back as the reason; every other path exits 0, so a
+# missing `jq` or a directory that is not a repository never blocks work.
+set -uo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat)
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
+[ -n "${command:-}" ] || exit 0
+
+# Only a command that actually *runs* `git commit`. Matching the bare substring
+# would block `rg 'git commit' CLAUDE.md` and any pull request body that quotes
+# the command — so the match is anchored to a command position: the start of a
+# line, or just after a separator.
+#
+# `-C <path>` and `-c <name>=<value>` take a value, so they are matched together
+# with it; without that, `git -C . commit` reads as `git`, the flag `-C`, and
+# then `.` where `commit` was expected, and slips through. Any other global
+# option is a single token.
+#
+# It errs toward blocking. A `gh pr create --body` whose text happens to begin a
+# line with `git commit` is refused, which costs a reword; the other direction
+# costs a reset and a force-push over a branch other people may have pulled.
+printf '%s' "$command" |
+	grep -Eq '(^|[;&|(]|&&|\|\|)[[:space:]]*git([[:space:]]+(-[Cc][[:space:]]+[^[:space:]]+|-[^[:space:]]+))*[[:space:]]+commit([[:space:]]|$)' ||
+	exit 0
+
+# The branch that matters is the one in the directory the command will run in,
+# not the project root: a commit made inside a worktree is on that worktree's
+# branch.
+cwd=$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null)
+[ -n "${cwd:-}" ] || cwd="${CLAUDE_PROJECT_DIR:-$PWD}"
+
+branch=$(git -C "$cwd" rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+[ "$branch" = "main" ] || exit 0
+
+cat >&2 <<'EOF'
+Refusing: HEAD is `main`, and this commit would land on it directly.
+
+CLAUDE.md: "Never commit straight to `main`. The pull request is what leaves a
+reviewable record of work nobody watched happen."
+
+Put the work on a branch first. Anything larger than a one-line fix gets its
+own worktree:
+
+    git worktree add .claude/worktrees/<name> -b <name>
+
+If this really has to go on main, run the commit outside Claude Code.
+EOF
+exit 2

--- a/.claude/hooks/rustfmt.sh
+++ b/.claude/hooks/rustfmt.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Format a Rust file the moment it is written, so `make` never fails on
+# whitespace.
+#
+# `fmt-check` is the first thing `make` runs, so an unformatted edit costs a
+# full gate — clippy, tests and a release build never start — to be told about
+# indentation. Running `cargo fmt` here removes that failure mode entirely
+# rather than making it faster to hit.
+#
+# Reads the PostToolUse payload on stdin. Never fails the tool call: a missing
+# `jq`, a path outside a cargo project, or a `cargo fmt` that cannot parse
+# half-written code all exit 0 and leave the edit alone.
+set -uo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+path=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty' 2>/dev/null) || exit 0
+[ -n "${path:-}" ] || exit 0
+
+case "$path" in
+*.rs) ;;
+*) exit 0 ;;
+esac
+
+# Format from the edited file's own directory rather than the project root.
+# Feature work here happens in git worktrees under `.claude/worktrees/`, each a
+# separate checkout with its own `Cargo.toml`; `cargo fmt` walks up from the
+# working directory, so this reaches the right one instead of formatting the
+# main checkout on every edit made in a worktree.
+dir=$(dirname "$path")
+[ -d "$dir" ] || exit 0
+cd "$dir" || exit 0
+
+cargo fmt >/dev/null 2>&1 || true
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(cargo build:*)",
+      "Bash(cargo check:*)",
+      "Bash(cargo clippy:*)",
+      "Bash(cargo fmt:*)",
+      "Bash(cargo test:*)",
+      "Bash(cargo tree:*)",
+      "Bash(make:*)",
+      "Bash(rg:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git ls-files:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git describe:*)",
+      "Bash(git worktree list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh repo view:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run view:*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/rustfmt.sh",
+            "timeout": 30,
+            "statusMessage": "cargo fmt"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/no-commit-on-main.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,11 @@ jobs:
       - name: Install toolchain (pinned by rust-toolchain.toml)
         run: rustup show
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - run: cargo fmt --check
-      - run: cargo clippy --all-targets -- -D warnings
-      - run: cargo test
-      - run: cargo build --release
+      # The same target run locally, rather than the four commands it happens
+      # to expand to today. Spelling them out here meant CI could keep passing
+      # a gate the Makefile no longer described — the two agreed only as long
+      # as somebody remembered to edit both.
+      - run: make
 
   # The demo is re-recorded by hand (`make demo`), because the render depends on
   # the fonts installed on the machine. CI only plays the tape, to catch one

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
 /target
 .idea
-.claude
+
+# Claude Code's per-project directory holds three different things:
+# `settings.json` and `hooks/` are the repository's own configuration and are
+# checked in; `settings.local.json` is personal, and `worktrees/` is where
+# feature branches are checked out. Ignore the directory and name the
+# exceptions, so a new kind of local state defaults to being ignored.
+.claude/*
+!.claude/settings.json
+!.claude/hooks/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,31 @@ searches your shell history — all through one built-in fuzzy selector (skim).
 
 ## Before opening a pull request
 
-- `make` — fmt check, clippy (`-D warnings`), tests, release build. All four
-  must pass; CI runs the same set.
+- `make check` while working — fmt check, clippy (`-D warnings`), tests. A few
+  seconds, and it is what to run between edits.
+- `make` before the pull request — the same three plus the release build. CI
+  runs `make`, the same target, not a copy of what it expands to.
 - Keep commits logical and self-contained: each one should build and test
   green on its own.
+
+### What is automated, and what still is not
+
+`.claude/settings.json` is checked in, and two hooks come with it. Both are
+guards, not conveniences — each one removes a mistake that was actually made
+here rather than one that seemed possible:
+
+- **`hooks/rustfmt.sh`** runs `cargo fmt` on every Rust file as it is written.
+  `fmt-check` is the *first* thing `make` runs, so an unformatted edit used to
+  cost a full gate — clippy, tests and a release build never starting — to be
+  told about indentation.
+- **`hooks/no-commit-on-main.sh`** refuses a `git commit` whose HEAD is `main`.
+  It errs toward blocking: a command that merely quotes `git commit` at the
+  start of a line is refused too, which costs a reword, where the other
+  direction costs a reset and a force-push over a branch others may have
+  pulled.
+
+Nothing checks that each commit is green on its own, and nothing checks the
+three docs below. Both are still read by hand, and both have gone wrong here.
 
 ### The three docs that go stale silently
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,18 @@
 .DEFAULT_GOAL := build
 
+# Everything that can fail on correctness, and nothing that cannot.
+#
+# The inner loop: a handful of seconds, against `build`'s minute, almost all of
+# which is the release build. That build is worth running before a pull request
+# — release settings turn on optimisations and `lto`, and a crate can compile in
+# debug and fail there — but it is not worth running between two edits to a
+# test, and waiting out a minute for that answer is how a fast loop becomes a
+# slow one.
+.PHONY: check
+check: fmt-check lint test
+
 .PHONY: build
-build: fmt-check lint test
+build: check
 	cargo build --release
 
 .PHONY: test


### PR DESCRIPTION
Tooling, from what actually cost time across the last four pull requests rather
than from general best practice.

## `make check`

fmt-check, clippy and tests — everything that can fail on correctness, and
nothing that cannot. Measured in this worktree, after touching `src/lib.rs`:

| | |
| --- | --- |
| `make check` | **6s** |
| `make` | **37s** |

Almost all of the difference is the release build. That build is worth running
before a pull request — release settings turn on optimisations and `lto`, and a
crate can compile in debug and fail there — but it is not worth running between
two edits to a test, and waiting a minute for that answer is how a fast loop
becomes a slow one. `make` is unchanged in what it checks.

## CI runs `make`

It ran the four commands the Makefile happens to expand to. That meant CI could
keep passing a gate the Makefile no longer described, and the two agreed only as
long as somebody remembered to edit both. It calls the target now.

## `.claude/` is no longer ignored wholesale

The directory was fully gitignored, so nothing about how this repository is
worked on could be shared. It is now ignored with two named exceptions —
`settings.json` and `hooks/` — so a new kind of local state still defaults to
being ignored. `settings.local.json` and `worktrees/` stay out; verified with
`git add -An` against a directory seeded with both.

Two hooks, both guards rather than conveniences. Each removes a mistake that was
actually made here:

- **`rustfmt.sh`** — `cargo fmt` on a Rust file as it is written. `fmt-check` is
  the *first* thing `make` runs, so an unformatted edit cost a whole gate to be
  told about indentation. It formats from the edited file's own directory, not
  the project root, because feature work here happens in worktrees under
  `.claude/worktrees/` and each is a separate checkout.
- **`no-commit-on-main.sh`** — refuses a `git commit` whose HEAD is `main`,
  which CLAUDE.md has always forbidden and nothing has ever enforced.

Neither can fail a tool call by accident: a missing `jq`, a path outside a cargo
project, or a directory that is not a repository all exit 0.

Verified against ten cases before wiring it up — blocked: `git commit`,
`git add -A && git commit`, `git -C . commit`, `git -c user.name=x commit`,
`git --no-pager commit`. Allowed: `rg "git commit" CLAUDE.md`,
`git log --grep commit`, `echo run git commit later`, `cargo test`,
`gh pr merge`. The `-C`/`-c` cases needed the flag matched together with its
value; without that, `git -C . commit` read as `git`, a flag, then `.` where
`commit` was expected, and slipped through.

## Trade-offs worth naming

- **The commit guard errs toward blocking.** A command whose text begins a line
  with `git commit` — a `gh pr create --body` quoting it, say — is refused. That
  costs a reword; the other direction costs a reset and a force-push over a
  branch others may have pulled. The block message says how to proceed.
- **`cargo fmt` runs on every Rust edit**, including intermediate ones. It is
  ~50ms and idempotent, but it does mean a file can be reformatted between an
  edit and reading it back.
- **The allowlist is a judgement call about what is safe to run unattended.** It
  is builds, tests, searches, and the `git`/`gh` subcommands that only report —
  nothing that writes, pushes, merges or deletes. Reasonable people could draw
  it tighter.
- **Two things are still unautomated and have both gone wrong here**: that each
  commit is green on its own, and the three-docs walk. `CLAUDE.md` now says so
  explicitly rather than leaving the absence implied.

## The three docs

1. **CLI help.** Untouched — no command, flag or example changed.
2. **README.md.** Untouched. Its `## Development` block lists `make`, `make
   demo` and `make demo-fixture`; `make check` is a contributor's inner loop
   rather than something the README's job requires, and that section already
   hands off to `CLAUDE.md`. Said here rather than left unmentioned.
3. **`docs/demo.gif`.** Untouched and not re-recorded — nothing in this pull
   request runs, builds or draws anything the tape records.

`make` green.