### PR TITLE
Trade 1.1MB of binary for 20s off every `make`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,9 @@ unicode-width = "0.2"
 
 [profile.release]
 strip = true
-lto = true
+# Thin rather than fat. Fat LTO is a single serial optimisation pass over the
+# whole program: measured here it costs 31s against thin's 11s on every `make`
+# — the gate CI runs too — and buys 1.1MB of binary. The cross-crate inlining
+# it adds is not measurable in a binary whose runtime is spent spawning git and
+# gh and waiting on a selection.
+lto = "thin"


### PR DESCRIPTION
`[profile.release] lto = true` is fat LTO — a single serial optimisation pass
over the whole program, and the one step in the gate that does not speed up on
a machine with cores to spare. This switches it to thin.

Measured on this crate (M-series, 8 cores):

|             | cold  | after a source edit | binary  |
| ----------- | ----- | ------------------- | ------- |
| fat (was)   | 49.8s | 31.3s               | 4.76MB  |
| thin (now)  | 29.6s | 11.4s               | 5.84MB  |

Confirmed in place after the change: the release rebuild is 11.21s and the
binary is 5,844,208 bytes.

`make` builds release before every pull request, and CI's `build` job runs
`make`, so the 20s is paid twice per change. What fat buys is cross-crate
inlining, which is not measurable in a binary whose runtime is spent spawning
`git` and `gh` and waiting on a selection.

## The trade-off, named

The shipped binary grows by 1.1MB. `release.yml` builds with this same profile,
so release artifacts get thin LTO too — that is deliberate rather than
overlooked. Keeping fat for shipped binaries would mean a `dist` profile whose
codegen local `make` never exercises, which is a worse trade than the megabyte.

## The three docs

None needed, and each was checked:

- **CLI help text** — no command, flag, alias or example changes.
- **README.md** — no new command group; the command table, the fish key-binding
  sentence and the `Install` line are all unaffected.
- **docs/demo.gif** — nothing changes what any selector draws. No re-record.

`make` green.