### PR TITLE
Stop the term tests reading the terminal they run in

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -183,9 +183,13 @@ pub struct HangupWatch {
 /// Bind it — `let _watch = term::watch_for_hangup()`. A bare statement drops it
 /// immediately and watches nothing.
 pub fn watch_for_hangup() -> HangupWatch {
-    let stop = Arc::new(AtomicBool::new(false));
     // stderr is what the selector draws on, so it is the terminal that matters.
-    if !std::io::stderr().is_terminal() {
+    watch_for_hangup_on(std::io::stderr().is_terminal())
+}
+
+fn watch_for_hangup_on(on_terminal: bool) -> HangupWatch {
+    let stop = Arc::new(AtomicBool::new(false));
+    if !on_terminal {
         return HangupWatch { stop, thread: None };
     }
 
@@ -300,7 +304,10 @@ pub struct ScratchRow {
 impl ScratchRow {
     /// Move to a fresh row below the cursor, giving it back when dropped.
     pub fn take() -> Self {
-        let taken = std::io::stderr().is_terminal();
+        Self::take_on(std::io::stderr().is_terminal())
+    }
+
+    fn take_on(taken: bool) -> Self {
         if taken {
             let mut err = std::io::stderr().lock();
             // An explicit carriage return: whether a bare newline returns to
@@ -367,15 +374,19 @@ pub struct Spinner {
 /// spins for nothing.
 #[must_use]
 pub fn spinner(label: &str, color: bool) -> Spinner {
+    spinner_on(label, color, std::io::stderr().is_terminal())
+}
+
+fn spinner_on(label: &str, color: bool, on_terminal: bool) -> Spinner {
     let stop = Arc::new(AtomicBool::new(false));
-    if !std::io::stderr().is_terminal() {
+    if !on_terminal {
         return Spinner {
             stop,
             thread: None,
             _row: ScratchRow::none(),
         };
     }
-    let row = ScratchRow::take();
+    let row = ScratchRow::take_on(true);
 
     let label = label.to_string();
     let flag = Arc::clone(&stop);
@@ -561,10 +572,8 @@ mod tests {
 
     #[test]
     fn no_terminal_means_nothing_is_watched() {
-        // The test harness captures stderr, so this is the redirected case.
-        let watch = watch_for_hangup();
         assert!(
-            watch.thread.is_none(),
+            watch_for_hangup_on(false).thread.is_none(),
             "watched a terminal that was not there"
         );
     }
@@ -648,14 +657,14 @@ mod tests {
 
     #[test]
     fn no_terminal_means_no_animation() {
-        // The test harness captures stderr, so this is the redirected case.
-        let spinner = spinner("fetching", true);
+        let spinner = spinner_on("fetching", true, false);
         assert!(spinner.thread.is_none(), "spun without a terminal");
+        assert!(!spinner._row.is_taken(), "took a row it could not draw on");
     }
 
     #[test]
     fn the_spinner_draws_on_a_row_of_its_own() {
-        let spinner = spinner("fetching", true);
+        let spinner = spinner_on("fetching", true, true);
         assert_eq!(
             spinner._row.is_taken(),
             spinner.thread.is_some(),
@@ -665,10 +674,7 @@ mod tests {
 
     #[test]
     fn no_terminal_means_no_row_taken() {
-        assert_eq!(
-            ScratchRow::take().is_taken(),
-            std::io::stderr().is_terminal()
-        );
+        assert!(!ScratchRow::take_on(false).is_taken());
         assert!(!ScratchRow::none().is_taken());
     }
 


### PR DESCRIPTION
`make` fails locally and passes in CI:

```
---- term::tests::no_terminal_means_nothing_is_watched stdout ----
panicked at src/term.rs:566:9: watched a terminal that was not there

---- term::tests::no_terminal_means_no_animation stdout ----
panicked at src/term.rs:653:9: spun without a terminal
```

Both tests carried the comment "The test harness captures stderr, so this is
the redirected case" and asserted no thread was spawned. libtest's capture
intercepts the `print!`/`eprint!` macros, not file descriptor 2 — so
`std::io::stderr().is_terminal()` inside a test answers for the terminal
`cargo test` was invoked from. In CI there is none and the tests passed; run
`make` from a shell and they fail. `no_terminal_means_no_row_taken` had the
same dependency and hid it by restating `is_terminal()` on the right-hand
side, which made it unfalsifiable rather than correct.

The fix is to inject the answer. `watch_for_hangup`, `spinner` and
`ScratchRow::take` keep their signatures and resolve the terminal themselves;
the decision each makes moves into a private `_on(bool)` the tests call with
the case they mean. No behaviour changes and no call site moves.

One consequence worth naming: `the_spinner_draws_on_a_row_of_its_own` now
passes `true` unconditionally, so it spawns the drawing thread even without a
terminal and one frame plus its erase lands in CI's stderr. That is the cost
of testing the drawing path at all — the alternative is a test that only
covers the branch that draws nothing, which is the branch that was already
broken.

Verified with `script -q /dev/null cargo test --lib`, which gives the suite a
real pty and reproduces the failure on `main`: 280 passed. `make` green.

### The three docs

None needed. No command, flag, help text or selector output changed — this is
a test-visibility fix behind unchanged public signatures, so the CLI help,
README and `docs/demo.gif` are all still accurate.