### PR TITLE
Add an optional bacon config that mirrors `make check`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,11 @@ searches your shell history — all through one built-in fuzzy selector (skim).
 - Keep commits logical and self-contained: each one should build and test
   green on its own.
 
+`bacon.toml` is checked in for anyone who wants the same two steps rerun on
+save in a split instead of invoked by hand. It is optional and nothing depends
+on it — `make` remains the entry point, and the jobs run the Makefile's exact
+commands so a green split cannot mean something looser than a green gate.
+
 ### What is automated, and what still is not
 
 `.claude/settings.json` is checked in, and two hooks come with it. Both are

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Provides fuzzy-completion for various local and remote resources."
 license = "MIT"
 repository = "https://github.com/joakimen/scriv"
-exclude = ["docs/", "demo/", ".github/", ".claude/", ".idea/"]
+exclude = ["docs/", "demo/", ".github/", ".claude/", ".idea/", "bacon.toml"]
 
 [dependencies]
 anyhow = "1"

--- a/bacon.toml
+++ b/bacon.toml
@@ -1,0 +1,17 @@
+#:schema https://dystroy.org/bacon/.bacon.schema.json
+
+# Optional watcher config. bacon is not needed to build, test or release scriv;
+# it reruns the `make check` steps on save so the answer is already on screen.
+# The commands are kept identical to the Makefile's — a split reporting green on
+# looser flags than the gate would be worse than not running one.
+
+default_job = "clippy"
+env.CARGO_TERM_COLOR = "always"
+
+[jobs.clippy]
+command = ["cargo", "clippy", "--all-targets", "--", "-D", "warnings"]
+need_stdout = false
+
+[jobs.test]
+command = ["cargo", "test"]
+need_stdout = true


### PR DESCRIPTION
## What

Checks in a `bacon.toml` whose jobs run the Makefile's exact commands, and a short note in `CLAUDE.md` saying it is optional.

## Why

`make check` measures ~7s after touching one file on this machine — fmt 0.1s, clippy 1.1s, test 5.2s. That time sits in the edit loop rather than in the work. bacon reruns the same steps on save in a split, so the result is on screen before it is asked for.

The config exists rather than relying on `bacon` with no config because bacon's built-in `clippy` job is `cargo clippy` with neither `--all-targets` nor `-D warnings`. A split left on defaults would report green on looser flags than the gate does. Project jobs merge over bacon's defaults, so `check`, `doc`, `nextest` and the rest still resolve; only `clippy` and `test` are pinned.

`make` is unchanged and nothing in the build, test or release path depends on the file. It is added to the `exclude` list so it does not ship in the published crate, alongside the other tooling paths.

## Considered and rejected

Three other tools were measured against the same loop before landing only this one:

- **mold** — ELF-only; its macOS port is discontinued, and this is `aarch64-apple-darwin` on Apple's rewritten `ld` (ld-1267). Codegen plus link over the frontend is ~0.6s across three binaries, so a free linker would remove under 0.3s of the 7s regardless.
- **sccache** — cannot cache incremental compilation, so adopting it means `CARGO_INCREMENTAL=0`: the 1.4s incremental rebuild is traded for a full one to win on cold builds. CI already runs `Swatinem/rust-cache`, which covers that case directly.
- **cargo-nextest** — test execution is 0.57s running the binaries directly, so the speed argument is not there. Its process-per-test isolation is a real argument given #70, but it costs a tool every contributor must install and it does not run doctests — zero today, which makes it a silent hole the first time one is added. Left open deliberately.

`[profile.dev] debug = 0` was also measured: 1.48s against 1.44s. No gain, not applied.

## Trade-off

A checked-in config for an optional tool is a file that can go stale — if `make check` gains a step or changes a flag, `bacon.toml` has to follow, and nothing in CI compares them. The alternative is every user of bacon rediscovering the flag mismatch, which is the worse direction: a stale job here is visibly running the wrong command, while no config at all is quietly running a weaker check.

## The three docs

- **CLI help text** — untouched. No command, flag, alias or example changes.
- **README.md** — deliberately not touched. bacon is a contributor's watcher, not a command group, an install requirement or a platform; the README's job ends at a working setup.
- **`docs/demo.gif`** — no re-record. Nothing changed what any selector draws, and `demo/demo.tape` is unmodified.

`make` green in the worktree.