### PR TITLE
Add prek git hooks and pin prek in mise.toml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,8 +29,19 @@ here rather than one that seemed possible:
   direction costs a reset and a force-push over a branch others may have
   pulled.
 
-Nothing checks that each commit is green on its own, and nothing checks the
-three docs below. Both are still read by hand, and both have gone wrong here.
+`prek.toml` adds a third guard, for git rather than for the agent, and unlike
+the two above it is opt-in: `make hooks` installs the shims, once per clone,
+since the hooks directory lives in the common `.git` and every worktree shares
+it. Its pre-commit stage is file hygiene, `make fmt-check`, and the same
+refusal to commit on `main` that
+`hooks/no-commit-on-main.sh` gives the agent; its pre-push stage runs `make
+check`. prek is pinned in `mise.toml`, which is the whole of that file — the
+compiler comes from `rust-toolchain.toml`.
+
+Even with the hooks installed, nothing checks that each commit is green on its
+own — the pre-push hook sees the tip, and a green tip says nothing about the
+three commits below it. Nothing checks the three docs below either. Both are
+still read by hand, and both have gone wrong here.
 
 ### The three docs that go stale silently
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 description = "Provides fuzzy-completion for various local and remote resources."
 license = "MIT"
 repository = "https://github.com/joakimen/scriv"
-exclude = ["docs/", "demo/", ".github/", ".claude/"]
+exclude = ["docs/", "demo/", ".github/", ".claude/", "prek.toml", "mise.toml"]
 
 [dependencies]
 anyhow = "1"

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,12 @@ fmt-check:
 install:
 	cargo install --path . --force
 
+# Install the git hooks in prek.toml. Opt-in, and once per clone — the hooks
+# directory lives in the common `.git`, so every worktree shares it.
+.PHONY: hooks
+hooks:
+	prek install --hook-type pre-commit --hook-type pre-push
+
 # Re-record docs/demo.gif. Local only — the render depends on installed fonts.
 # Requires vhs (brew install vhs).
 .PHONY: demo

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ repository, a tracked file and a pull request.
 
 ```sh
 make                # fmt check, clippy, tests, release build
+make hooks          # install the git hooks in prek.toml
 make demo           # re-record docs/demo.gif
 make demo-fixture   # build the demo sandbox and poke at it by hand
 ```

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,9 @@
+#:schema https://mise.jdx.dev/schema/mise.json
+# The one development tool nothing else here installs. Rust is absent because
+# rust-toolchain.toml pins it and rustup reads that file directly, and vhs is
+# absent because mise has no macOS build of the ttyd it shells out to — half a
+# recorder pinned in a second place is worse than the `brew install vhs` that
+# CLAUDE.md already names.
+
+[tools]
+prek = "0.4.11"

--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,55 @@
+#:schema https://www.schemastore.org/prek.json
+# Git hooks for prek (https://prek.j178.dev). Nothing runs until `make hooks`
+# installs the shims, and the hooks are a backstop rather than a second gate:
+# `make` stays the entry point, and every hook below either calls one of its
+# targets or checks something no target does.
+
+[[repos]]
+repo = "builtin"
+hooks = [
+    # The GIF is the one tracked file that is not text; both fixers rewrite
+    # bytes and would corrupt it.
+    { id = "trailing-whitespace", stages = ["pre-commit"], exclude = "\\.gif$" },
+    { id = "end-of-file-fixer", stages = ["pre-commit"], exclude = "\\.gif$" },
+    { id = "check-merge-conflict", stages = ["pre-commit"] },
+    { id = "check-added-large-files", stages = ["pre-commit"] },
+    { id = "check-toml", stages = ["pre-commit"] },
+    { id = "check-yaml", stages = ["pre-commit"] },
+]
+
+[[repos]]
+repo = "local"
+
+# CLAUDE.md forbids committing to main, and `.claude/hooks/no-commit-on-main.sh`
+# only refuses the agent. This refuses git.
+[[repos.hooks]]
+id = "no-commit-on-main"
+name = "commits go on a branch, not main"
+entry = "sh -c 'test \"$(git branch --show-current)\" != main || { echo \"On main. Branch first: git switch -c <name>\" >&2; exit 1; }'"
+language = "system"
+stages = ["pre-commit"]
+always_run = true
+pass_filenames = false
+
+# The first thing `make` runs, and the cheapest: a fraction of a second against
+# the full gate it would otherwise fail at the top of.
+[[repos.hooks]]
+id = "fmt-check"
+name = "make fmt-check"
+entry = "make fmt-check"
+language = "system"
+stages = ["pre-commit"]
+types = ["rust"]
+pass_filenames = false
+
+# Clippy and the tests cost ten seconds, which is worth paying once per push
+# rather than once per commit. It checks the tip only — that each commit is
+# green on its own is still nobody's job but the author's.
+[[repos.hooks]]
+id = "check"
+name = "make check"
+entry = "make check"
+language = "system"
+stages = ["pre-push"]
+always_run = true
+pass_filenames = false


### PR DESCRIPTION
Two files that were not here: `prek.toml`, and a `mise.toml` pinning the tool that runs it. Both are opt-in — nothing runs until `make hooks` installs the shims.

## What the hooks are, and what they are not

Not a second gate. `bacon.toml` was deleted last week for being a second spelling of `make check` that had to be kept in step by hand, and this does not repeat it: every hook either calls a Makefile target or checks something no target does.

The split is by cost:

- **pre-commit** — file hygiene (trailing whitespace, end of file, merge-conflict markers, large files, TOML and YAML parse), `make fmt-check`, and a refusal to commit on `main`. All of it well under a second.
- **pre-push** — `make check`. Clippy and the tests are ~10s here, worth paying once per push rather than once per commit.

The `main` guard is the one that earns its place: CLAUDE.md says never commit straight to `main`, and `.claude/hooks/no-commit-on-main.sh` only refuses the agent. This refuses git.

Both fixers exclude `*.gif` — they rewrite bytes, and `docs/demo.gif` is the one tracked file that is not text.

Named trade-off: the pre-push hook checks the tip, not each commit. Per-commit greenness is still nobody but the author’s job, and CLAUDE.md now says so in those words rather than the old "nothing checks".

## What `mise.toml` deliberately does not pin

prek only.

- **Rust** — `rust-toolchain.toml` pins it and rustup reads that file directly. A second pin could disagree with it.
- **vhs** — mise has no macOS arm64 build of `ttyd`, which vhs shells out to (`mise install` errors on it). vhs alone would pin half a recorder while duplicating the version `ci.yml` already carries.
- **shellcheck** — the four shell scripts here are clean but for one SC1007 on `CDPATH= cd --` in `demo/record.sh`, a deliberate idiom. Adding the tool means adding a disable comment to buy nothing.

## The three docs

- **CLI help (`src/main.rs`)** — untouched. No command, flag or alias changes; this is build tooling.
- **README** — one line in `Development`: `make hooks`. Nothing else; `prek.toml` is not a user-facing dependency, so the `Install` line is unchanged.
- **`docs/demo.gif`** — no re-record. Nothing changes what any selector draws.

`CLAUDE.md` gains a paragraph under "What is automated, and what still is not", and both new files join `exclude` in `Cargo.toml` as `bacon.toml` did.

## Verification

`make` green. `prek run --all-files` green on both stages, and this branch’s commit and push went through the installed hooks.